### PR TITLE
Improve bot model and risk logic

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -148,8 +148,8 @@ class DataHandler:
                 market['type'] == 'future'
             ):
                 orderbook = await self.fetch_orderbook(symbol)
-                bid_volume = sum([bid[1] for bid in orderbook.get('bids', [])[:5]]) if orderbook.get('bids') else False
-                ask_volume = sum([ask[1] for ask in orderbook.get('asks', [])[:5]]) if orderbook.get('asks') else False
+                bid_volume = sum([bid[1] for bid in orderbook.get('bids', [])[:5]]) if orderbook.get('bids') else 0
+                ask_volume = sum([ask[1] for ask in orderbook.get('asks', [])[:5]]) if orderbook.get('asks') else 0
                 if min(bid_volume, ask_volume) > 10000:
                     liquid_pairs.append(symbol)
         return liquid_pairs

--- a/utils.py
+++ b/utils.py
@@ -39,10 +39,10 @@ class TelegramLogger(logging.Handler):
         self.message_interval = 1800
         self.message_lock = asyncio.Lock()
 
-    async def send_telegram_message(self, message):
+    async def send_telegram_message(self, message, urgent: bool = False):
         async with self.message_lock:
             try:
-                if time.time() - self.last_message_time >= self.message_interval:
+                if urgent or time.time() - self.last_message_time >= self.message_interval:
                     await self.bot.send_message(chat_id=self.chat_id, text=message[:4096])
                     self.last_message_time = time.time()
                 else:


### PR DESCRIPTION
## Summary
- fix volume calculation in `select_liquid_pairs`
- add urgent message option to `TelegramLogger`
- enrich LSTM features and add attention+early stopping
- compute dynamic trade risk based on returns and volatility
- send urgent Telegram notifications for open/close events

## Testing
- `python -m py_compile data_handler.py model_builder.py trade_manager.py trading_bot.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_685410c15d48832da4e323a58178a007