### PR TITLE
Enhance bot resource controls and adaptive thresholds

### DIFF
--- a/config.json
+++ b/config.json
@@ -47,5 +47,9 @@
     "pullback_period": 3600,
     "pullback_volatility_coeff": 1.0,
     "retrain_interval": 86400,
-    "min_liquidity": 1000000
+    "min_liquidity": 1000000,
+    "ws_queue_size": 10000,
+    "disk_buffer_size": 10000,
+    "prediction_history_size": 100,
+    "optuna_trials": 20
 }

--- a/optimizer.py
+++ b/optimizer.py
@@ -18,6 +18,7 @@ class ParameterOptimizer:
         self.last_atr_update = {symbol: 0 for symbol in data_handler.usdt_pairs}
         self.atr_update_interval = 5  # Обновление ATR каждые 5 свечей
         self.last_volatility = {symbol: 0.0 for symbol in data_handler.usdt_pairs}  # Для отслеживания изменений волатильности
+        self.max_trials = config.get('optuna_trials', 20)
 
     async def optimize(self, symbol):
         # Оптимизация гиперпараметров для символа
@@ -37,7 +38,7 @@ class ParameterOptimizer:
                 return self.best_params_by_symbol[symbol] or self.config
             # Использование TPESampler с multivariate=True для учета корреляций
             study = optuna.create_study(direction='maximize', sampler=TPESampler(n_startup_trials=10, multivariate=True))
-            study.optimize(lambda trial: self.objective(trial, symbol, df), n_trials=50)  # Уменьшено число испытаний для скорости
+            study.optimize(lambda trial: self.objective(trial, symbol, df), n_trials=self.max_trials)
             best_params = study.best_params
             if not self.validate_params(best_params):
                 logger.warning(f"Некорректные параметры для {symbol}, использование предыдущих")

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -268,7 +268,7 @@ class TradeManager:
             model.eval()
             with torch.no_grad():
                 prediction = model(X_tensor).squeeze().cpu().numpy()
-            long_threshold, short_threshold = await self.model_builder.adjust_thresholds(symbol)
+            long_threshold, short_threshold = await self.model_builder.adjust_thresholds(symbol, prediction)
             if position['side'] == 'buy' and prediction < short_threshold:
                 logger.info(f"Сигнал CNN-LSTM для выхода из лонга для {symbol}: предсказание={prediction:.4f}, порог={short_threshold:.2f}")
                 await self.close_position(symbol, current_price, "CNN-LSTM Exit Signal")
@@ -391,7 +391,7 @@ class TradeManager:
             model.eval()
             with torch.no_grad():
                 prediction = model(X_tensor).squeeze().cpu().numpy()
-            long_threshold, short_threshold = await self.model_builder.adjust_thresholds(symbol)
+            long_threshold, short_threshold = await self.model_builder.adjust_thresholds(symbol, prediction)
             signal = None
             if prediction > long_threshold:
                 signal = 'buy'

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -32,7 +32,8 @@ CONFIG_SCHEMA = {
         'atr_period_default', 'model_save_path', 'cache_dir', 'log_dir',
         'ray_num_cpus', 'max_recovery_attempts', 'n_splits', 'optimization_interval',
         'shap_cache_duration', 'retrain_interval', 'volatility_threshold',
-        'ema_crossover_lookback', 'pullback_period', 'pullback_volatility_coeff'
+        'ema_crossover_lookback', 'pullback_period', 'pullback_volatility_coeff',
+        'ws_queue_size', 'disk_buffer_size', 'prediction_history_size', 'optuna_trials'
     ],
     "properties": {
         "exchange": {"type": "string"},
@@ -77,7 +78,11 @@ CONFIG_SCHEMA = {
         "volatility_threshold": {"type": "number", "minimum": 0},
         "ema_crossover_lookback": {"type": "integer", "minimum": 1},
         "pullback_period": {"type": "integer", "minimum": 1},
-        "pullback_volatility_coeff": {"type": "number", "minimum": 0}
+        "pullback_volatility_coeff": {"type": "number", "minimum": 0},
+        "ws_queue_size": {"type": "integer", "minimum": 1},
+        "disk_buffer_size": {"type": "integer", "minimum": 1},
+        "prediction_history_size": {"type": "integer", "minimum": 1},
+        "optuna_trials": {"type": "integer", "minimum": 1}
     }
 }
 
@@ -189,8 +194,8 @@ async def main():
         await check_library_versions(telegram_bot, chat_id)
 
         exchange_config = {
-            'apiKey': os.getenv('API_KEY'),
-            'secret': os.getenv('API_SECRET'),
+            'apiKey': os.getenv('BYBIT_API_KEY'),
+            'secret': os.getenv('BYBIT_API_SECRET'),
             'enableRateLimit': True,
             'asyncio_loop': asyncio.get_event_loop()
         }


### PR DESCRIPTION
## Summary
- use BYBIT environment variables for credentials
- tune data queues via config
- compute volume profile using NumPy
- add adaptive CNN-LSTM thresholds
- reduce Optuna trial count
- expose new config options for memory and optimizer control

## Testing
- `python -m py_compile trading_bot.py data_handler.py model_builder.py trade_manager.py optimizer.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68544d4a7c74832d95c310de02904915