### PR TITLE
Enhance dynamic thresholds and processing

### DIFF
--- a/config.json
+++ b/config.json
@@ -49,6 +49,7 @@
     "retrain_interval": 86400,
     "min_liquidity": 1000000,
     "ws_queue_size": 10000,
+    "ws_min_process_rate": 30,
     "disk_buffer_size": 10000,
     "prediction_history_size": 100,
     "optuna_trials": 20

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -33,7 +33,7 @@ CONFIG_SCHEMA = {
         'ray_num_cpus', 'max_recovery_attempts', 'n_splits', 'optimization_interval',
         'shap_cache_duration', 'retrain_interval', 'volatility_threshold',
         'ema_crossover_lookback', 'pullback_period', 'pullback_volatility_coeff',
-        'ws_queue_size', 'disk_buffer_size', 'prediction_history_size', 'optuna_trials'
+        'ws_queue_size', 'ws_min_process_rate', 'disk_buffer_size', 'prediction_history_size', 'optuna_trials'
     ],
     "properties": {
         "exchange": {"type": "string"},
@@ -80,6 +80,7 @@ CONFIG_SCHEMA = {
         "pullback_period": {"type": "integer", "minimum": 1},
         "pullback_volatility_coeff": {"type": "number", "minimum": 0},
         "ws_queue_size": {"type": "integer", "minimum": 1},
+        "ws_min_process_rate": {"type": "integer", "minimum": 1},
         "disk_buffer_size": {"type": "integer", "minimum": 1},
         "prediction_history_size": {"type": "integer", "minimum": 1},
         "optuna_trials": {"type": "integer", "minimum": 1}


### PR DESCRIPTION
## Summary
- expand ModelBuilder with GPU training via Ray
- calibrate CNN-LSTM predictions with Platt scaling
- adapt dynamic probability thresholds using Sharpe ratio and volatility
- measure WebSocket processing rate and adjust subscriptions
- compute indicators on CPU via Ray
- add ws_min_process_rate config option

## Testing
- `python -m py_compile trading_bot.py data_handler.py trade_manager.py model_builder.py optimizer.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68545697bf90832da8f2f8fb0ca3107d