### PR TITLE
Fix CNNLSTM input size when loading models

### DIFF
--- a/model_builder.py
+++ b/model_builder.py
@@ -142,7 +142,9 @@ class ModelBuilder:
                     state = joblib.load(f)
                 self.scalers = state.get('scalers', {})
                 for symbol, sd in state.get('lstm_models', {}).items():
-                    model = CNNLSTM(self.config['lstm_timesteps'], 64, 2, 0.2)
+                    scaler = self.scalers.get(symbol)
+                    input_size = len(scaler.mean_) if scaler else self.config['lstm_timesteps']
+                    model = CNNLSTM(input_size, 64, 2, 0.2)
                     model.load_state_dict(sd)
                     model.to(self.device)
                     self.lstm_models[symbol] = model


### PR DESCRIPTION
## Summary
- derive input size from saved scaler when loading CNNLSTM

## Testing
- `python -m py_compile model_builder.py trading_bot.py data_handler.py optimizer.py trade_manager.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68547fa8e438832d91f4d0823d8f0a67