### PR TITLE
Fix orderbook cleanup with empty dataframe

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -281,7 +281,10 @@ class DataHandler:
                             threshold = current_time - pd.Timedelta(seconds=self.config['forget_window'])
                             self.ohlcv_2h = self.ohlcv_2h[self.ohlcv_2h.index.get_level_values('timestamp') >= threshold]
                     async with self.orderbook_lock:
-                        self.orderbook = self.orderbook[self.orderbook['timestamp'] >= time.time() - self.config['forget_window']]
+                        if not self.orderbook.empty and 'timestamp' in self.orderbook.columns:
+                            self.orderbook = self.orderbook[
+                                self.orderbook['timestamp'] >= time.time() - self.config['forget_window']
+                            ]
                     async with self.ohlcv_lock:
                         for symbol in list(self.processed_timestamps.keys()):
                             if symbol not in self.usdt_pairs:


### PR DESCRIPTION
## Summary
- avoid KeyError when the orderbook dataframe has no `timestamp`

## Testing
- `python - <<'EOF'
import pandas as pd, time
orderbook = pd.DataFrame()
try:
    orderbook = orderbook[orderbook['timestamp'] >= time.time() - 10]
except Exception as e:
    print('before fix error:', e)
orderbook = pd.DataFrame()
if not orderbook.empty and 'timestamp' in orderbook.columns:
    orderbook = orderbook[orderbook['timestamp'] >= time.time() - 10]
print('after fix executed successfully')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68547f9c2b9c832d89e12fa82b4fca28