### PR TITLE
Fix index checks before get_level_values

### DIFF
--- a/optimizer.py
+++ b/optimizer.py
@@ -23,7 +23,11 @@ class ParameterOptimizer:
     async def optimize(self, symbol):
         # Оптимизация гиперпараметров для символа
         try:
-            df = self.data_handler.ohlcv.xs(symbol, level='symbol', drop_level=False) if symbol in self.data_handler.ohlcv.index.get_level_values('symbol') else None
+            ohlcv = self.data_handler.ohlcv
+            if 'symbol' in ohlcv.index.names and symbol in ohlcv.index.get_level_values('symbol'):
+                df = ohlcv.xs(symbol, level='symbol', drop_level=False)
+            else:
+                df = None
             if check_dataframe_empty(df, f"optimize {symbol}"):
                 logger.warning(f"Нет данных для оптимизации {symbol}")
                 return self.best_params_by_symbol[symbol] or self.config


### PR DESCRIPTION
## Summary
- guard access to `get_level_values('symbol')` with index name check
- apply same pattern across modules

## Testing
- `python -m py_compile model_builder.py optimizer.py trade_manager.py`
- `flake8 model_builder.py optimizer.py trade_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_68547faf3ee0832dad868b626d8ac155