### PR TITLE
Enhance ML trading bot

### DIFF
--- a/config.json
+++ b/config.json
@@ -64,4 +64,8 @@
     "disk_buffer_size": 10000,
     "prediction_history_size": 100,
     "optuna_trials": 20
+    ,"return_threshold": 0.001
+    ,"skip_adx_threshold": 20
+    ,"loss_streak_threshold": 2
+    ,"backtest_interval": 604800
 }


### PR DESCRIPTION
## Summary
- add dropout and sequential split to LSTM training
- compute training labels using return threshold and backtest after training
- maintain loss streak and skip trades after consecutive losses with low ADX
- schedule periodic backtests to check strategy performance
- extend config and schema with new parameters

## Testing
- `python -m py_compile trading_bot.py data_handler.py model_builder.py optimizer.py trade_manager.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6855a533991c832db8fff8367a30c6e7