### PR TITLE
Fix pair selection logic

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -147,11 +147,7 @@ class DataHandler:
     async def select_liquid_pairs(self, markets: Dict) -> List[str]:
         pair_volumes = []
         for symbol, market in markets.items():
-            if (
-                market['active']
-                and symbol.endswith('USDT')
-                and market['type'] == 'future'
-            ):
+            if market.get('active') and symbol.endswith('USDT'):
                 try:
                     ticker = await self.exchange.fetch_ticker(symbol)
                     volume = float(ticker.get('quoteVolume') or 0)


### PR DESCRIPTION
## Summary
- simplify pair selection logic when loading markets so pairs aren't filtered out by `market['type']`

## Testing
- `python3 -m py_compile data_handler.py trading_bot.py optimizer.py model_builder.py trade_manager.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6855b57b991c832d87ff51388b714a54