### PR TITLE
Fix z-score filter for small datasets

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -204,7 +204,8 @@ class DataHandler:
             df = df.set_index("timestamp")
             for col in ["open", "high", "low", "close", "volume"]:
                 df[col] = df[col].astype(np.float32)
-            df = filter_outliers_zscore(df, "close")
+            if len(df) >= 3:
+                df = filter_outliers_zscore(df, "close")
             if df["close"].isna().sum() / len(df) > 0.05:
                 logger.warning(
                     f"Слишком много пропусков в данных для {symbol} ({timeframe}) (>5%), использование forward-fill"
@@ -768,7 +769,8 @@ class DataHandler:
                                 }
                             ]
                         )
-                        df = filter_outliers_zscore(df, "close")
+                        if len(df) >= 3:
+                            df = filter_outliers_zscore(df, "close")
                         if df.empty:
                             logger.warning(f"Данные для {symbol} ({timeframe}) отфильтрованы как аномалии")
                             continue


### PR DESCRIPTION
## Summary
- skip outlier filtering if dataset has fewer than 3 records

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_6857239c8694832db5d5e0cb9f0a438d