### PR TITLE
Fix SHAP calculation for LSTM

### DIFF
--- a/model_builder.py
+++ b/model_builder.py
@@ -287,8 +287,12 @@ class ModelBuilder:
             if time.time() - last_time < self.shap_cache_duration:
                 return
             sample = torch.tensor(X[:50], dtype=torch.float32, device=self.device)
+            was_training = model.training
+            model.train()
             explainer = shap.DeepExplainer(model, sample)
             values = explainer.shap_values(sample)
+            if not was_training:
+                model.eval()
             joblib.dump(values, cache_file)
             mean_abs = np.mean(np.abs(values[0]), axis=(0, 1))
             feature_names = [


### PR DESCRIPTION
## Summary
- force training mode when computing SHAP values so CuDNN allows backward through LSTM

## Testing
- `python -m py_compile model_builder.py`


------
https://chatgpt.com/codex/tasks/task_e_6857d3c14d14832dae3ce4d428abc95e