### PR TITLE
Make Ray LSTM training GPU optional

### DIFF
--- a/model_builder.py
+++ b/model_builder.py
@@ -58,7 +58,7 @@ class CNNLSTM(nn.Module):
         return self.l2_lambda * sum(p.pow(2.0).sum() for p in self.parameters())
 
 
-@ray.remote(num_gpus=1)
+@ray.remote(num_gpus=1 if torch.cuda.is_available() else 0)
 def _train_lstm_remote(X, y, batch_size):
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
     X_tensor = torch.tensor(X, dtype=torch.float32)


### PR DESCRIPTION
## Summary
- request GPU for Ray remote training only if one is available
- install dependencies for local testing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857f91b8dec832d8eb96f255fd7ff65