### PR TITLE
Use device_type for autocast

### DIFF
--- a/trade_manager.py
+++ b/trade_manager.py
@@ -4,6 +4,9 @@ import numpy as np
 from tenacity import retry, wait_exponential, stop_after_attempt
 from utils import logger, check_dataframe_empty, TelegramLogger
 import torch
+
+# Determine computation device once
+device_type = 'cuda' if torch.cuda.is_available() else 'cpu'
 import joblib
 import os
 import time
@@ -310,7 +313,7 @@ class TradeManager:
             X = np.array([features[-self.config['lstm_timesteps']:]])
             X_tensor = torch.tensor(X, dtype=torch.float32, device=self.model_builder.device)
             model.eval()
-            with torch.no_grad(), torch.amp.autocast('cuda'):
+            with torch.no_grad(), torch.amp.autocast(device_type):
                 prediction = model(X_tensor).squeeze().float().cpu().numpy()
             calibrator = self.model_builder.calibrators.get(symbol)
             if calibrator is not None:
@@ -462,7 +465,7 @@ class TradeManager:
             X = np.array([features[-self.config['lstm_timesteps']:]])
             X_tensor = torch.tensor(X, dtype=torch.float32, device=self.model_builder.device)
             model.eval()
-            with torch.no_grad(), torch.amp.autocast('cuda'):
+            with torch.no_grad(), torch.amp.autocast(device_type):
                 prediction = model(X_tensor).squeeze().float().cpu().numpy()
             calibrator = self.model_builder.calibrators.get(symbol)
             if calibrator is not None:


### PR DESCRIPTION
## Summary
- set a single `device_type` variable based on CUDA availability
- use that variable for `torch.amp.autocast` when predicting

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6857fb5f1bac832d95d819d38bf5fed5