### PR TITLE
Add instructions for running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,14 @@ python trading_bot.py
 ```bash
 0 3 * * * cd /path/to/bot && /usr/bin/python trading_bot.py
 ```
+
+## Запуск тестов
+
+Для выполнения тестов необходимо установить все зависимости из `requirements.txt`:
+
+```bash
+pip install -r requirements.txt
+pytest
+```
+
+Некоторые тесты используют опциональные пакеты вроде `stable_baselines3`. В среде без GPU их можно не устанавливать или подменить заглушками, отключив тем самым требование GPU.


### PR DESCRIPTION
## Summary
- explain how to install requirements and run tests in README
- note GPU-heavy optional packages such as `stable_baselines3`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6857fd744478832daad8d7aa67c0e25a