### PR TITLE
Integrate MLflow tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,18 @@ python trading_bot.py
 0 3 * * * cd /path/to/bot && /usr/bin/python trading_bot.py
 ```
 
+## MLflow
+
+Если установить пакет `mlflow` и включить флаг `mlflow_enabled` в `config.json`,
+бот будет сохранять параметры и метрики обучения в указанное хранилище.
+По умолчанию используется локальная папка `mlruns`.
+
+Пример запуска с отслеживанием экспериментов:
+
+```bash
+MLFLOW_TRACKING_URI=mlruns python trading_bot.py
+```
+
 ## Запуск тестов
 
 Для выполнения тестов необходимо установить все зависимости из `requirements.txt`:

--- a/config.json
+++ b/config.json
@@ -71,5 +71,7 @@
     "target_change_threshold": 0.001,
     "backtest_interval": 604800,
     "rl_model": "PPO",
-    "rl_timesteps": 10000
+    "rl_timesteps": 10000,
+    "mlflow_tracking_uri": "mlruns",
+    "mlflow_enabled": false
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,5 +23,6 @@ plotly>=5.22.0
 numba>=0.60.0
 ray>=2.34.0
 stable-baselines3>=2.3.2
+mlflow>=2.12.1
 --extra-index-url https://download.pytorch.org/whl/cu128
 pytest>=8.1.1


### PR DESCRIPTION
## Summary
- add MLflow dependency
- expose MLflow settings in `config.json`
- log training runs through MLflow in `ModelBuilder`
- log optimizer trials with MLflow callback
- document MLflow usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68580548b1d4832db72c74c7881b7dde