### PR TITLE
Add GPU-accelerated EMA/ATR with tests

### DIFF
--- a/tests/test_indicators_gpu.py
+++ b/tests/test_indicators_gpu.py
@@ -1,0 +1,54 @@
+import os, sys; sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import numpy as np
+import pandas as pd
+import ta
+import types
+
+ccxt_mod = types.ModuleType('ccxt')
+ccxt_mod.async_support = types.ModuleType('async_support')
+ccxt_mod.async_support.bybit = object
+sys.modules.setdefault('ccxt', ccxt_mod)
+sys.modules.setdefault('ccxt.async_support', ccxt_mod.async_support)
+sys.modules.setdefault('websockets', types.ModuleType('websockets'))
+ray_mod = types.ModuleType('ray')
+ray_mod.remote = lambda *a, **k: (lambda f: f)
+sys.modules.setdefault('ray', ray_mod)
+tenacity_mod = types.ModuleType('tenacity')
+tenacity_mod.retry = lambda *a, **k: (lambda f: f)
+tenacity_mod.wait_exponential = lambda *a, **k: None
+sys.modules['tenacity'] = tenacity_mod
+psutil_mod = types.ModuleType('psutil')
+psutil_mod.cpu_percent = lambda interval=1: 0
+psutil_mod.virtual_memory = lambda: type('mem', (), {'percent': 0})
+sys.modules.setdefault('psutil', psutil_mod)
+scipy_mod = types.ModuleType('scipy')
+stats_mod = types.ModuleType('scipy.stats')
+stats_mod.zscore = lambda a, axis=0: (a - np.mean(a, axis=axis)) / np.std(a, axis=axis)
+scipy_mod.__version__ = "1.0"
+scipy_mod.stats = stats_mod
+sys.modules.setdefault('scipy', scipy_mod)
+sys.modules.setdefault('scipy.stats', stats_mod)
+sys.modules.setdefault('httpx', types.ModuleType('httpx'))
+telegram_error_mod = types.ModuleType('telegram.error')
+telegram_error_mod.RetryAfter = Exception
+sys.modules.setdefault('telegram', types.ModuleType('telegram'))
+sys.modules.setdefault('telegram.error', telegram_error_mod)
+
+from data_handler import ema_fast, atr_fast
+
+
+def test_ema_fast_matches_ta():
+    values = np.linspace(1, 50, 50)
+    result_fast = ema_fast(values, 10)
+    expected = ta.trend.ema_indicator(pd.Series(values), window=10, fillna=True).to_numpy()
+    assert np.allclose(result_fast, expected, atol=1e-6)
+
+
+def test_atr_fast_matches_ta():
+    rng = np.random.default_rng(0)
+    high = pd.Series(rng.random(60) + 10)
+    low = high - rng.random(60)
+    close = high - rng.random(60)
+    result_fast = atr_fast(high.to_numpy(), low.to_numpy(), close.to_numpy(), 14)
+    expected = ta.volatility.average_true_range(high, low, close, window=14, fillna=True).to_numpy()
+    assert np.allclose(result_fast, expected, atol=1e-6)

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -13,6 +13,28 @@ import types
 mlflow_mod = types.ModuleType('optuna.integration.mlflow')
 mlflow_mod.MLflowCallback = object
 sys.modules['optuna.integration.mlflow'] = mlflow_mod
+optuna_mod = types.ModuleType('optuna')
+optuna_samplers = types.ModuleType('optuna.samplers')
+optuna_samplers.TPESampler = object
+optuna_mod.samplers = optuna_samplers
+sys.modules.setdefault('optuna', optuna_mod)
+sys.modules.setdefault('optuna.samplers', optuna_samplers)
+scipy_mod = types.ModuleType('scipy')
+stats_mod = types.ModuleType('scipy.stats')
+stats_mod.zscore = lambda a, axis=0: (a - a.mean()) / a.std()
+scipy_mod.__version__ = "1.0"
+scipy_mod.stats = stats_mod
+sys.modules.setdefault('scipy', scipy_mod)
+sys.modules.setdefault('scipy.stats', stats_mod)
+sys.modules.setdefault('httpx', types.ModuleType('httpx'))
+telegram_error_mod = types.ModuleType('telegram.error')
+telegram_error_mod.RetryAfter = Exception
+sys.modules.setdefault('telegram', types.ModuleType('telegram'))
+sys.modules.setdefault('telegram.error', telegram_error_mod)
+psutil_mod = types.ModuleType('psutil')
+psutil_mod.cpu_percent = lambda interval=1: 0
+psutil_mod.virtual_memory = lambda: type('mem', (), {'percent': 0})
+sys.modules.setdefault('psutil', psutil_mod)
 
 from optimizer import ParameterOptimizer
 

--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -22,6 +22,32 @@ async def _cde(*a, **kw):
 utils.check_dataframe_empty = _cde
 sys.modules['utils'] = utils
 
+tenacity_mod = types.ModuleType('tenacity')
+tenacity_mod.retry = lambda *a, **k: (lambda f: f)
+tenacity_mod.wait_exponential = lambda *a, **k: None
+tenacity_mod.stop_after_attempt = lambda *a, **k: None
+sys.modules['tenacity'] = tenacity_mod
+scipy_mod = types.ModuleType('scipy')
+stats_mod = types.ModuleType('scipy.stats')
+stats_mod.zscore = lambda a, axis=0: (a - a.mean()) / a.std()
+scipy_mod.__version__ = "1.0"
+scipy_mod.stats = stats_mod
+sys.modules.setdefault('scipy', scipy_mod)
+sys.modules.setdefault('scipy.stats', stats_mod)
+sys.modules.setdefault('httpx', types.ModuleType('httpx'))
+telegram_error_mod = types.ModuleType('telegram.error')
+telegram_error_mod.RetryAfter = Exception
+sys.modules.setdefault('telegram', types.ModuleType('telegram'))
+sys.modules.setdefault('telegram.error', telegram_error_mod)
+psutil_mod = types.ModuleType('psutil')
+psutil_mod.cpu_percent = lambda interval=1: 0
+psutil_mod.virtual_memory = lambda: type('mem', (), {'percent': 0})
+sys.modules.setdefault('psutil', psutil_mod)
+joblib_mod = types.ModuleType('joblib')
+joblib_mod.dump = lambda *a, **k: None
+joblib_mod.load = lambda *a, **k: {}
+sys.modules.setdefault('joblib', joblib_mod)
+
 import utils
 import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))


### PR DESCRIPTION
## Summary
- add `ema_fast` and `atr_fast` with optional CUDA acceleration
- integrate new functions in `IndicatorsCache`
- add unit tests for accelerated indicators

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68581351c790832dab0ff45454b0c7df