### PR TITLE
Enable remote optimization with Ray

### DIFF
--- a/tests/test_indicators_gpu.py
+++ b/tests/test_indicators_gpu.py
@@ -4,6 +4,13 @@ import pandas as pd
 import ta
 import types
 
+numba_mod = types.ModuleType('numba')
+numba_mod.cuda = types.SimpleNamespace(is_available=lambda: False)
+numba_mod.jit = lambda *a, **k: (lambda f: f)
+numba_mod.prange = range
+sys.modules.setdefault('numba', numba_mod)
+sys.modules.setdefault('numba.cuda', numba_mod.cuda)
+
 ccxt_mod = types.ModuleType('ccxt')
 ccxt_mod.async_support = types.ModuleType('async_support')
 ccxt_mod.async_support.bybit = object

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -2,6 +2,13 @@ import os, sys; sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import pytest
 import types, sys, logging
 
+if 'torch' not in sys.modules:
+    torch = types.ModuleType('torch')
+    torch.cuda = types.SimpleNamespace(is_available=lambda: False)
+    import importlib.machinery
+    torch.__spec__ = importlib.machinery.ModuleSpec('torch', None)
+    sys.modules['torch'] = torch
+
 utils = types.ModuleType('utils')
 utils.logger = logging.getLogger('test')
 async def _cde(*a, **kw):

--- a/tests/test_optimizer_ray.py
+++ b/tests/test_optimizer_ray.py
@@ -1,0 +1,93 @@
+import os, sys
+import importlib
+import types
+import asyncio
+import numpy as np
+import pandas as pd
+import pytest
+
+if 'torch' not in sys.modules:
+    torch = types.ModuleType('torch')
+    torch.cuda = types.SimpleNamespace(is_available=lambda: False)
+    import importlib.machinery
+    torch.__spec__ = importlib.machinery.ModuleSpec('torch', None)
+    sys.modules['torch'] = torch
+
+numba_mod = types.ModuleType('numba')
+numba_mod.cuda = types.SimpleNamespace(is_available=lambda: False)
+numba_mod.jit = lambda *a, **k: (lambda f: f)
+numba_mod.prange = range
+sys.modules.setdefault('numba', numba_mod)
+sys.modules.setdefault('numba.cuda', numba_mod.cuda)
+
+# ensure real optuna
+if 'optuna' in sys.modules and not hasattr(sys.modules['optuna'], 'create_study'):
+    del sys.modules['optuna']
+    sys.modules.pop('optuna.samplers', None)
+    sys.modules.pop('optuna.integration.mlflow', None)
+import optuna  # noqa: F401
+mlflow_mod = types.ModuleType('optuna.integration.mlflow')
+mlflow_mod.MLflowCallback = object
+sys.modules.setdefault('optuna.integration.mlflow', mlflow_mod)
+
+# stub ray
+ray_mod = types.ModuleType('ray')
+
+def _remote(*args, **kwargs):
+    def decorator(func):
+        def call(*a, **k):
+            return func(*a, **k)
+        return types.SimpleNamespace(remote=call, _function=func)
+    return decorator
+
+ray_mod.remote = _remote
+ray_mod.get = lambda x: x
+sys.modules['ray'] = ray_mod
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from optimizer import ParameterOptimizer
+
+
+class DummyDataHandler:
+    def __init__(self, df):
+        self.ohlcv = df
+        self.usdt_pairs = ['BTCUSDT']
+        self.indicators_cache = {}
+
+def make_df():
+    idx = pd.date_range('2020-01-01', periods=30, freq='min')
+    df = pd.DataFrame({
+        'close': np.linspace(1, 2, len(idx)),
+        'open': np.linspace(1, 2, len(idx)),
+        'high': np.linspace(1, 2, len(idx)) + 0.1,
+        'low': np.linspace(1, 2, len(idx)) - 0.1,
+        'volume': np.ones(len(idx)),
+    }, index=idx)
+    df['symbol'] = 'BTCUSDT'
+    return df.set_index(['symbol', df.index])
+
+
+@pytest.mark.asyncio
+async def test_optimize_returns_params():
+    df = make_df()
+    config = {
+        'timeframe': '1m',
+        'optuna_trials': 1,
+        'optimization_interval': 1,
+        'volatility_threshold': 0.02,
+        'ema30_period': 30,
+        'ema100_period': 100,
+        'ema200_period': 200,
+        'atr_period_default': 14,
+        'tp_multiplier': 2.0,
+        'sl_multiplier': 1.0,
+        'base_probability_threshold': 0.5,
+        'loss_streak_threshold': 2,
+        'win_streak_threshold': 2,
+        'threshold_adjustment': 0.05,
+        'mlflow_enabled': False,
+    }
+    opt = ParameterOptimizer(config, DummyDataHandler(df))
+    params = await opt.optimize('BTCUSDT')
+    assert isinstance(params, dict)
+    assert 'ema30_period' in params


### PR DESCRIPTION
## Summary
- add Ray remote objective helper using GPU when available
- refactor optimizer to dispatch trials with ray
- handle new ray helpers in tests and stub heavy deps
- add regression test for optimizer parameter output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858163c68f4832db0ff2579ef472af0