### PR TITLE
Add optional Ray RLlib backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@
 python trading_bot.py
 ```
 
+### RL agents
+
+Модуль `RLAgent` может обучать модели как с помощью `stable-baselines3`, так и через `Ray RLlib`.
+Выберите подходящий движок параметром `rl_framework` в `config.json` (`stable_baselines3` или `rllib`).
+Алгоритм указывается опцией `rl_model` (`PPO` или `DQN`), продолжительность обучения — `rl_timesteps`.
+
 Периодическое переобучение задаётся параметром `retrain_interval` в
 `config.json`. Можно запускать бота по расписанию (например, через `cron`) для
 регулярного обновления моделей:

--- a/config.json
+++ b/config.json
@@ -71,6 +71,7 @@
     "target_change_threshold": 0.001,
     "backtest_interval": 604800,
     "rl_model": "PPO",
+    "rl_framework": "stable_baselines3",
     "rl_timesteps": 10000,
     "mlflow_tracking_uri": "mlruns",
     "mlflow_enabled": false

--- a/tests/test_indicators_gpu.py
+++ b/tests/test_indicators_gpu.py
@@ -4,37 +4,47 @@ import pandas as pd
 import ta
 import types
 
-numba_mod = types.ModuleType('numba')
-numba_mod.cuda = types.SimpleNamespace(is_available=lambda: False)
-numba_mod.jit = lambda *a, **k: (lambda f: f)
-numba_mod.prange = range
-sys.modules.setdefault('numba', numba_mod)
-sys.modules.setdefault('numba.cuda', numba_mod.cuda)
+import importlib.util
+if importlib.util.find_spec('numba') is None:
+    numba_mod = types.ModuleType('numba')
+    numba_mod.cuda = types.SimpleNamespace(is_available=lambda: False)
+    numba_mod.jit = lambda *a, **k: (lambda f: f)
+    numba_mod.prange = range
+    sys.modules.setdefault('numba', numba_mod)
+    sys.modules.setdefault('numba.cuda', numba_mod.cuda)
 
 ccxt_mod = types.ModuleType('ccxt')
 ccxt_mod.async_support = types.ModuleType('async_support')
 ccxt_mod.async_support.bybit = object
+ccxt_mod.pro = types.ModuleType('pro')
+ccxt_mod.pro.bybit = object
 sys.modules.setdefault('ccxt', ccxt_mod)
 sys.modules.setdefault('ccxt.async_support', ccxt_mod.async_support)
+sys.modules.setdefault('ccxt.pro', ccxt_mod.pro)
 sys.modules.setdefault('websockets', types.ModuleType('websockets'))
 ray_mod = types.ModuleType('ray')
 ray_mod.remote = lambda *a, **k: (lambda f: f)
 sys.modules.setdefault('ray', ray_mod)
-tenacity_mod = types.ModuleType('tenacity')
-tenacity_mod.retry = lambda *a, **k: (lambda f: f)
-tenacity_mod.wait_exponential = lambda *a, **k: None
-sys.modules['tenacity'] = tenacity_mod
+import importlib.util
+if importlib.util.find_spec('tenacity') is None:
+    tenacity_mod = types.ModuleType('tenacity')
+    tenacity_mod.retry = lambda *a, **k: (lambda f: f)
+    tenacity_mod.wait_exponential = lambda *a, **k: None
+    tenacity_mod.stop_after_attempt = lambda *a, **k: (lambda f: f)
+    sys.modules['tenacity'] = tenacity_mod
 psutil_mod = types.ModuleType('psutil')
 psutil_mod.cpu_percent = lambda interval=1: 0
 psutil_mod.virtual_memory = lambda: type('mem', (), {'percent': 0})
 sys.modules.setdefault('psutil', psutil_mod)
-scipy_mod = types.ModuleType('scipy')
-stats_mod = types.ModuleType('scipy.stats')
-stats_mod.zscore = lambda a, axis=0: (a - np.mean(a, axis=axis)) / np.std(a, axis=axis)
-scipy_mod.__version__ = "1.0"
-scipy_mod.stats = stats_mod
-sys.modules.setdefault('scipy', scipy_mod)
-sys.modules.setdefault('scipy.stats', stats_mod)
+import importlib.util
+if importlib.util.find_spec('scipy') is None:
+    scipy_mod = types.ModuleType('scipy')
+    stats_mod = types.ModuleType('scipy.stats')
+    stats_mod.zscore = lambda a, axis=0: (a - np.mean(a, axis=axis)) / np.std(a, axis=axis)
+    scipy_mod.__version__ = "1.0"
+    scipy_mod.stats = stats_mod
+    sys.modules.setdefault('scipy', scipy_mod)
+    sys.modules.setdefault('scipy.stats', stats_mod)
 sys.modules.setdefault('httpx', types.ModuleType('httpx'))
 telegram_error_mod = types.ModuleType('telegram.error')
 telegram_error_mod.RetryAfter = Exception


### PR DESCRIPTION
## Summary
- add `rl_framework` setting to choose between stable-baselines3 and RLlib
- train and predict with RLlib when selected
- document RL framework option in README
- adjust tests stubs for optional dependencies

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: requests.exceptions.JSONDecodeError and others)*

------
https://chatgpt.com/codex/tasks/task_e_68582023a6d4832d914f58f33efb2be2