### PR TITLE
Add configurable MLP model

### DIFF
--- a/config.json
+++ b/config.json
@@ -36,6 +36,7 @@
     "min_data_length": 1000,
     "lstm_timesteps": 60,
     "lstm_batch_size": 32,
+    "model_type": "cnn_lstm",
     "ema30_period": 30,
     "ema100_period": 100,
     "ema200_period": 200,

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -24,7 +24,7 @@ if "stable_baselines3" not in sys.modules:
     sys.modules["stable_baselines3.common.vec_env"] = vec_env
 
 import model_builder
-from model_builder import ModelBuilder, _train_lstm_remote
+from model_builder import ModelBuilder, _train_model_remote
 
 class DummyIndicators:
     def __init__(self, length):
@@ -53,6 +53,7 @@ def create_model_builder(df):
         "min_data_length": len(df),
         "lstm_timesteps": 2,
         "lstm_batch_size": 2,
+        "model_type": "cnn_lstm",
     }
     data_handler = DummyDataHandler(df)
     trade_manager = DummyTradeManager()
@@ -80,11 +81,13 @@ def test_prepare_lstm_features_shape():
     assert isinstance(features, np.ndarray)
     assert features.shape == (len(df), 14)
 
-@pytest.mark.asyncio
-def test_train_lstm_remote_returns_state_and_predictions():
+@pytest.mark.parametrize("model_type", ["cnn_lstm", "mlp"])
+def test_train_model_remote_returns_state_and_predictions(model_type):
     X = np.random.rand(20, 3, 2).astype(np.float32)
     y = (np.random.rand(20) > 0.5).astype(np.float32)
-    state, preds, labels = _train_lstm_remote._function(X, y, batch_size=2)
+    state, preds, labels = _train_model_remote._function(
+        X, y, batch_size=2, model_type=model_type
+    )
     assert isinstance(state, dict)
     assert len(preds) == len(labels)
     assert isinstance(preds, list)


### PR DESCRIPTION
## Summary
- add `Net` MLP and GRU support
- train selected architecture via `_train_model_remote`
- load models based on `model_type`
- update config with `model_type` option
- extend tests for new architecture

## Testing
- `pytest tests/test_model_builder.py::test_train_model_remote_returns_state_and_predictions -q`
- `pytest -q` *(fails: JSONDecodeError and AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_685826395984832d9ddf23530e06b9c4