### PR TITLE
Fix catalyst requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ stable-baselines3>=2.3.2
 mlflow>=2.12.1
 pytorch-lightning>=2.2.1
 tensorflow>=2.16.1
-catalyst>=24.3
+catalyst>=22.4
 --extra-index-url https://download.pytorch.org/whl/cu128
 pytest>=8.1.1
 flask>=3.0.2


### PR DESCRIPTION
## Summary
- update `catalyst` requirement to a valid version

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement catalyst>=22.4)*
- `pytest -q` *(fails to import numpy/pandas etc)*

------
https://chatgpt.com/codex/tasks/task_e_68583a309bb0832da5f734d965b3a61e