### PR TITLE
Fix runtime env handling and async worker

### DIFF
--- a/model_builder.py
+++ b/model_builder.py
@@ -215,8 +215,7 @@ def _train_model_lightning(X, y, batch_size, model_type):
     return net.state_dict(), preds, labels
 
 
-@ray.remote(num_gpus=1 if torch.cuda.is_available() else 0)
-def _train_model_remote(X, y, batch_size, model_type="cnn_lstm", framework="pytorch"):
+def _train_model_remote_func(X, y, batch_size, model_type="cnn_lstm", framework="pytorch"):
     if framework in {"keras", "tensorflow"}:
         return _train_model_keras(X, y, batch_size, model_type)
     if framework == "lightning":
@@ -279,6 +278,10 @@ def _train_model_remote(X, y, batch_size, model_type="cnn_lstm", framework="pyto
             if epochs_no_improve >= patience:
                 break
     return model.state_dict(), preds, labels
+
+
+_train_model_remote = ray.remote(num_gpus=1 if torch.cuda.is_available() else 0)(_train_model_remote_func)
+_train_model_remote._function = _train_model_remote_func
 
 
 class ModelBuilder:

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -2,36 +2,49 @@ import os
 import time
 import requests
 
-DATA_HANDLER_URL = os.getenv('DATA_HANDLER_URL', 'http://data_handler:8000')
-MODEL_BUILDER_URL = os.getenv('MODEL_BUILDER_URL', 'http://model_builder:8001')
-TRADE_MANAGER_URL = os.getenv('TRADE_MANAGER_URL', 'http://trade_manager:8002')
-SYMBOL = os.getenv('SYMBOL', 'TEST')
-INTERVAL = float(os.getenv('INTERVAL', '5'))
+DEFAULT_DATA_HANDLER_URL = 'http://data_handler:8000'
+DEFAULT_MODEL_BUILDER_URL = 'http://model_builder:8001'
+DEFAULT_TRADE_MANAGER_URL = 'http://trade_manager:8002'
+DEFAULT_SYMBOL = 'TEST'
+DEFAULT_INTERVAL = 5.0
+
+
+def _load_env():
+    """Return runtime configuration from environment variables."""
+    return {
+        'data_handler_url': os.getenv('DATA_HANDLER_URL', DEFAULT_DATA_HANDLER_URL),
+        'model_builder_url': os.getenv('MODEL_BUILDER_URL', DEFAULT_MODEL_BUILDER_URL),
+        'trade_manager_url': os.getenv('TRADE_MANAGER_URL', DEFAULT_TRADE_MANAGER_URL),
+        'symbol': os.getenv('SYMBOL', DEFAULT_SYMBOL),
+        'interval': float(os.getenv('INTERVAL', str(DEFAULT_INTERVAL))),
+    }
 
 
 def run_once():
-    price_resp = requests.get(f"{DATA_HANDLER_URL}/price/{SYMBOL}", timeout=5)
+    env = _load_env()
+    price_resp = requests.get(f"{env['data_handler_url']}/price/{env['symbol']}", timeout=5)
     price = price_resp.json().get('price', 0)
 
     model_resp = requests.post(
-        f"{MODEL_BUILDER_URL}/predict",
-        json={'symbol': SYMBOL, 'price': price},
+        f"{env['model_builder_url']}/predict",
+        json={'symbol': env['symbol'], 'price': price},
         timeout=5,
     )
     signal = model_resp.json().get('signal')
 
     if signal:
         requests.post(
-            f"{TRADE_MANAGER_URL}/open_position",
-            json={'symbol': SYMBOL, 'side': signal, 'price': price},
+            f"{env['trade_manager_url']}/open_position",
+            json={'symbol': env['symbol'], 'side': signal, 'price': price},
             timeout=5,
         )
 
 
 def main():
     while True:
+        env = _load_env()
         run_once()
-        time.sleep(INTERVAL)
+        time.sleep(env['interval'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- load environment vars on every `run_once`
- defer `TelegramLogger` worker startup until an event loop is running
- expose `_function` on `_train_model_remote` to support tests

## Testing
- `python -m py_compile trading_bot.py model_builder.py utils.py`
- `pytest -q` *(fails: ModuleNotFoundError for numpy, pandas, requests)*

------
https://chatgpt.com/codex/tasks/task_e_68584e736670832d9d88e5a49f71ff73