### PR TITLE
Fix Docker build by pinning pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN python3.12 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # Устанавливаем зависимости
-RUN pip install --no-cache-dir --upgrade pip setuptools wheel && \
+RUN pip install --no-cache-dir pip==24.0 setuptools wheel && \
     pip install --no-cache-dir -r requirements.txt && \
     find /app/venv -type d -name '__pycache__' -exec rm -rf {} + && \
     find /app/venv -type f -name '*.pyc' -delete


### PR DESCRIPTION
## Summary
- avoid latest pip which rejects Catalyst metadata
- pin pip to 24.0 during image build

## Testing
- `pip install -r requirements.txt` *(fails: heavy downloads)*

------
https://chatgpt.com/codex/tasks/task_e_685863f7568c832d8731223722232858