### PR TITLE
Improve error handling for trading bot HTTP calls

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -1,6 +1,7 @@
 import os
 import time
 import requests
+from utils import logger
 
 DATA_HANDLER_URL = os.getenv('DATA_HANDLER_URL', 'http://data_handler:8000')
 MODEL_BUILDER_URL = os.getenv('MODEL_BUILDER_URL', 'http://model_builder:8001')
@@ -10,22 +11,49 @@ INTERVAL = float(os.getenv('INTERVAL', '5'))
 
 
 def run_once():
-    price_resp = requests.get(f"{DATA_HANDLER_URL}/price/{SYMBOL}", timeout=5)
-    price = price_resp.json().get('price', 0)
+    try:
+        price_resp = requests.get(
+            f"{DATA_HANDLER_URL}/price/{SYMBOL}", timeout=5
+        )
+        if price_resp.status_code != 200:
+            logger.error(
+                f"Failed to fetch price: HTTP {price_resp.status_code}"
+            )
+            return
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Price request error: {e}")
+        return
+    price = price_resp.json().get("price", 0)
 
-    model_resp = requests.post(
-        f"{MODEL_BUILDER_URL}/predict",
-        json={'symbol': SYMBOL, 'price': price},
-        timeout=5,
-    )
-    signal = model_resp.json().get('signal')
-
-    if signal:
-        requests.post(
-            f"{TRADE_MANAGER_URL}/open_position",
-            json={'symbol': SYMBOL, 'side': signal, 'price': price},
+    try:
+        model_resp = requests.post(
+            f"{MODEL_BUILDER_URL}/predict",
+            json={"symbol": SYMBOL, "price": price},
             timeout=5,
         )
+        if model_resp.status_code != 200:
+            logger.error(
+                f"Model prediction failed: HTTP {model_resp.status_code}"
+            )
+            return
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Model request error: {e}")
+        return
+    signal = model_resp.json().get("signal")
+
+    if signal:
+        try:
+            trade_resp = requests.post(
+                f"{TRADE_MANAGER_URL}/open_position",
+                json={"symbol": SYMBOL, "side": signal, "price": price},
+                timeout=5,
+            )
+            if trade_resp.status_code != 200:
+                logger.error(
+                    f"Trade manager error: HTTP {trade_resp.status_code}"
+                )
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Trade manager request error: {e}")
 
 
 def main():


### PR DESCRIPTION
## Summary
- add logger import in `trading_bot.py`
- handle `requests` errors in `run_once` and log failures

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy, requests, pandas)*
- `pip install -q -r requirements.txt` *(fails: could not find dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685866a5f688832d86c8dc52c3293e11