### PR TITLE
Improve ML API and ATR handling

### DIFF
--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -83,6 +83,10 @@ class DummyDataHandler:
         self.ohlcv = pd.DataFrame({'close': [100]}, index=idx)
         self.indicators = {'BTCUSDT': DummyIndicators()}
 
+    async def get_atr(self, symbol: str) -> float:
+        ind = self.indicators.get(symbol)
+        return float(ind.atr.iloc[-1]) if ind else 0.0
+
 def make_config():
     return {
         'cache_dir': '/tmp',

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -271,11 +271,12 @@ class TradeManager:
                 ):
                     logger.warning(f"Позиция для {symbol} уже открыта")
                     return
-                indicators = self.data_handler.indicators.get(symbol)
-                if not indicators or not indicators.atr.iloc[-1]:
-                    logger.warning(f"Нет данных ATR для {symbol}")
+                atr = await self.data_handler.get_atr(symbol)
+                if atr <= 0:
+                    logger.warning(
+                        f"Нет данных ATR для {symbol}, повторная попытка загрузки"
+                    )
                     return
-                atr = indicators.atr.iloc[-1]
                 sl_mult = params.get("sl_multiplier", self.config["sl_multiplier"])
                 tp_mult = params.get("tp_multiplier", self.config["tp_multiplier"])
                 size = await self.calculate_position_size(symbol, price, atr, sl_mult)
@@ -392,11 +393,12 @@ class TradeManager:
                     logger.warning(f"Позиция для {symbol} не найдена")
                     return
                 position = position.iloc[0]
-                indicators = self.data_handler.indicators.get(symbol)
-                if not indicators or not indicators.atr.iloc[-1]:
-                    logger.warning(f"Нет данных ATR для {symbol}")
+                atr = await self.data_handler.get_atr(symbol)
+                if atr <= 0:
+                    logger.warning(
+                        f"Нет данных ATR для {symbol}, повторная попытка загрузки"
+                    )
                     return
-                atr = indicators.atr.iloc[-1]
                 trailing_stop_distance = atr * self.config.get(
                     "trailing_stop_multiplier", 1.0
                 )


### PR DESCRIPTION
## Summary
- add minimal ML-based predictor API instead of static rule
- provide `DataHandler.get_atr` to recalc ATR when missing
- use ATR helper in TradeManager
- update trade manager tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68590672f298832d9c126c8de23a476c