### PR TITLE
Refactor trading_bot env handling

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -3,19 +3,16 @@ import time
 import requests
 from utils import logger
 
-DATA_HANDLER_URL = os.getenv('DATA_HANDLER_URL', 'http://data_handler:8000')
-MODEL_BUILDER_URL = os.getenv('MODEL_BUILDER_URL', 'http://model_builder:8001')
-TRADE_MANAGER_URL = os.getenv('TRADE_MANAGER_URL', 'http://trade_manager:8002')
-SYMBOL = os.getenv('SYMBOL', 'TEST')
-INTERVAL = float(os.getenv('INTERVAL', '5'))
+SYMBOL = os.getenv("SYMBOL", "TEST")
+INTERVAL = float(os.getenv("INTERVAL", "5"))
 
 
 def _load_env() -> dict:
     """Load service URLs from environment variables."""
     return {
-        'data_handler_url': os.getenv('DATA_HANDLER_URL', 'http://data_handler:8000'),
-        'model_builder_url': os.getenv('MODEL_BUILDER_URL', 'http://model_builder:8001'),
-        'trade_manager_url': os.getenv('TRADE_MANAGER_URL', 'http://trade_manager:8002'),
+        "data_handler_url": os.getenv("DATA_HANDLER_URL", "http://data_handler:8000"),
+        "model_builder_url": os.getenv("MODEL_BUILDER_URL", "http://model_builder:8001"),
+        "trade_manager_url": os.getenv("TRADE_MANAGER_URL", "http://trade_manager:8002"),
     }
 
 
@@ -23,67 +20,74 @@ def check_services() -> bool:
     """Return True if all dependent services respond to /ping."""
     env = _load_env()
     services = {
-        'data_handler': env['data_handler_url'],
-        'model_builder': env['model_builder_url'],
-        'trade_manager': env['trade_manager_url'],
+        "data_handler": env["data_handler_url"],
+        "model_builder": env["model_builder_url"],
+        "trade_manager": env["trade_manager_url"],
     }
     for name, url in services.items():
         try:
             resp = requests.get(f"{url}/ping", timeout=5)
             if resp.status_code != 200:
-                print(f"Service {name} at {url} returned {resp.status_code}")
+                logger.error("Service %s at %s returned %s", name, url, resp.status_code)
                 return False
-        except requests.RequestException as e:
-            print(f"Service {name} at {url} unavailable: {e}")
+        except requests.RequestException as exc:
+            logger.error("Service %s at %s unavailable: %s", name, url, exc)
             return False
     return True
 
 
-def run_once():
-    env = _load_env()
+def fetch_price(symbol: str, env: dict) -> float | None:
+    """Return current price or None if request failed."""
     try:
-        price_resp = requests.get(
-            f"{env['data_handler_url']}/price/{SYMBOL}", timeout=5
-        )
-        if price_resp.status_code != 200:
-            logger.error(
-                f"Failed to fetch price: HTTP {price_resp.status_code}"
-            )
-            return
-    except requests.exceptions.RequestException as e:
-        logger.error(f"Price request error: {e}")
-        return
-    price = price_resp.json().get("price", 0)
+        resp = requests.get(f"{env['data_handler_url']}/price/{symbol}", timeout=5)
+        if resp.status_code != 200:
+            logger.error("Failed to fetch price: HTTP %s", resp.status_code)
+            return None
+        return resp.json().get("price", 0)
+    except requests.RequestException as exc:
+        logger.error("Price request error: %s", exc)
+        return None
 
+
+def get_prediction(symbol: str, price: float, env: dict) -> str | None:
+    """Return model signal if available."""
     try:
-        model_resp = requests.post(
+        resp = requests.post(
             f"{env['model_builder_url']}/predict",
-            json={"symbol": SYMBOL, "price": price},
+            json={"symbol": symbol, "price": price},
             timeout=5,
         )
-        if model_resp.status_code != 200:
-            logger.error(
-                f"Model prediction failed: HTTP {model_resp.status_code}"
-            )
-            return
-    except requests.exceptions.RequestException as e:
-        logger.error(f"Model request error: {e}")
-        return
-    signal = model_resp.json().get("signal")
+        if resp.status_code != 200:
+            logger.error("Model prediction failed: HTTP %s", resp.status_code)
+            return None
+        return resp.json().get("signal")
+    except requests.RequestException as exc:
+        logger.error("Model request error: %s", exc)
+        return None
 
+
+def send_trade(symbol: str, side: str, price: float, env: dict) -> None:
+    """Send trade request to trade manager."""
+    try:
+        resp = requests.post(
+            f"{env['trade_manager_url']}/open_position",
+            json={"symbol": symbol, "side": side, "price": price},
+            timeout=5,
+        )
+        if resp.status_code != 200:
+            logger.error("Trade manager error: HTTP %s", resp.status_code)
+    except requests.RequestException as exc:
+        logger.error("Trade manager request error: %s", exc)
+
+
+def run_once() -> None:
+    env = _load_env()
+    price = fetch_price(SYMBOL, env)
+    if price is None:
+        return
+    signal = get_prediction(SYMBOL, price, env)
     if signal:
-        try:
-            trade_resp = requests.post(
-                f"{env['trade_manager_url']}/open_position",
-                json={"symbol": SYMBOL, "side": signal, "price": price},
-                timeout=5,
-            )
-            if trade_resp.status_code != 200:
-                logger.error(
-                    f"Trade manager error: HTTP {trade_resp.status_code}"
-                )
-        except requests.exceptions.RequestException as e:
-            logger.error(f"Trade manager request error: {e}")
+        send_trade(SYMBOL, signal, price, env)
 
 
 def main():


### PR DESCRIPTION
## Summary
- load service URLs in `trading_bot` dynamically instead of at import
- keep environment key style consistent
- keep English logging from earlier work

## Testing
- `python -m py_compile trading_bot.py trade_manager.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68591296d7bc832da853880d8c71aa28