### PR TITLE
Add pytest-asyncio to enable async test execution

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,5 +30,6 @@ tensorflow>=2.16.1
 catalyst==21.4
 --extra-index-url https://download.pytorch.org/whl/cu128
 pytest>=8.1.1
+pytest-asyncio>=1.0.0
 flask>=3.0.2
 requests>=2.31.0


### PR DESCRIPTION
## Summary
- add `pytest-asyncio` dependency

## Testing
- `pytest tests/test_optimizer_ray.py::test_optimize_returns_params -vv`

------
https://chatgpt.com/codex/tasks/task_e_6859272e58c0832d9d49c970129d8176