### PR TITLE
Remove asyncio decorator

### DIFF
--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -72,7 +72,6 @@ def make_df(length=5):
     df = df.set_index(["symbol", df.index])
     return df
 
-@pytest.mark.asyncio
 def test_prepare_lstm_features_shape():
     df = make_df()
     mb = create_model_builder(df)


### PR DESCRIPTION
## Summary
- delete unnecessary `@pytest.mark.asyncio` from `test_prepare_lstm_features_shape`

## Testing
- `pytest -q tests/test_model_builder.py::test_prepare_lstm_features_shape -vv`

------
https://chatgpt.com/codex/tasks/task_e_68592ba9e1cc832dbea8499784be9d04