### PR TITLE
Fix import order for ruff

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -22,6 +22,7 @@ from queue import Queue
 import pickle
 import psutil
 import ray
+from flask import Flask, jsonify
 
 try:
     from numba import cuda  # type: ignore
@@ -1002,7 +1003,6 @@ class DataHandler:
 # ----------------------------------------------------------------------
 # REST API for minimal integration testing
 # ----------------------------------------------------------------------
-from flask import Flask, jsonify
 
 api_app = Flask(__name__)
 PRICES = {"TEST": 100.0}

--- a/model_builder.py
+++ b/model_builder.py
@@ -18,6 +18,7 @@ from collections import deque
 import ray
 import gym
 from gym import spaces
+from flask import Flask, request, jsonify
 from stable_baselines3 import PPO, DQN
 from stable_baselines3.common.vec_env import DummyVecEnv
 
@@ -813,7 +814,6 @@ class RLAgent:
 # ----------------------------------------------------------------------
 # REST API for minimal integration testing
 # ----------------------------------------------------------------------
-from flask import Flask, request, jsonify
 
 api_app = Flask(__name__)
 

--- a/tests/test_indicators_gpu.py
+++ b/tests/test_indicators_gpu.py
@@ -1,10 +1,14 @@
-import os, sys; sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import numpy as np
 import pandas as pd
 import ta
 import types
 
 import importlib.util
+from data_handler import ema_fast, atr_fast
 if importlib.util.find_spec('numba') is None:
     numba_mod = types.ModuleType('numba')
     numba_mod.cuda = types.SimpleNamespace(is_available=lambda: False)
@@ -25,7 +29,6 @@ sys.modules.setdefault('websockets', types.ModuleType('websockets'))
 ray_mod = types.ModuleType('ray')
 ray_mod.remote = lambda *a, **k: (lambda f: f)
 sys.modules.setdefault('ray', ray_mod)
-import importlib.util
 if importlib.util.find_spec('tenacity') is None:
     tenacity_mod = types.ModuleType('tenacity')
     tenacity_mod.retry = lambda *a, **k: (lambda f: f)
@@ -36,7 +39,6 @@ psutil_mod = types.ModuleType('psutil')
 psutil_mod.cpu_percent = lambda interval=1: 0
 psutil_mod.virtual_memory = lambda: type('mem', (), {'percent': 0})
 sys.modules.setdefault('psutil', psutil_mod)
-import importlib.util
 if importlib.util.find_spec('scipy') is None:
     scipy_mod = types.ModuleType('scipy')
     stats_mod = types.ModuleType('scipy.stats')
@@ -50,8 +52,6 @@ telegram_error_mod = types.ModuleType('telegram.error')
 telegram_error_mod.RetryAfter = Exception
 sys.modules.setdefault('telegram', types.ModuleType('telegram'))
 sys.modules.setdefault('telegram.error', telegram_error_mod)
-
-from data_handler import ema_fast, atr_fast
 
 
 def test_ema_fast_matches_ta():

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -1,4 +1,7 @@
-import os, sys; sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import numpy as np
 import pandas as pd
@@ -23,7 +26,6 @@ if "stable_baselines3" not in sys.modules:
     sys.modules["stable_baselines3.common"] = common
     sys.modules["stable_baselines3.common.vec_env"] = vec_env
 
-import model_builder
 from model_builder import ModelBuilder, _train_model_remote
 
 class DummyIndicators:

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1,6 +1,12 @@
-import os, sys; sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import os
+import sys
+
 import pytest
-import types, sys, logging
+import types
+import logging
+from optimizer import ParameterOptimizer
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 if 'torch' not in sys.modules:
     torch = types.ModuleType('torch')
@@ -15,8 +21,6 @@ async def _cde(*a, **kw):
     return False
 utils.check_dataframe_empty = _cde
 sys.modules['utils'] = utils
-
-import types
 mlflow_mod = types.ModuleType('optuna.integration.mlflow')
 mlflow_mod.MLflowCallback = object
 sys.modules['optuna.integration.mlflow'] = mlflow_mod
@@ -42,8 +46,6 @@ psutil_mod = types.ModuleType('psutil')
 psutil_mod.cpu_percent = lambda interval=1: 0
 psutil_mod.virtual_memory = lambda: type('mem', (), {'percent': 0})
 sys.modules.setdefault('psutil', psutil_mod)
-
-from optimizer import ParameterOptimizer
 
 class DummyDataHandler:
     def __init__(self):

--- a/tests/test_optimizer_ray.py
+++ b/tests/test_optimizer_ray.py
@@ -1,10 +1,12 @@
-import os, sys
+import os
+import sys
 import importlib
 import types
-import asyncio
 import numpy as np
 import pandas as pd
 import pytest
+import optuna  # noqa: F401
+from optimizer import ParameterOptimizer
 
 if 'torch' not in sys.modules:
     torch = types.ModuleType('torch')
@@ -25,7 +27,6 @@ if 'optuna' in sys.modules and not hasattr(sys.modules['optuna'], 'create_study'
     del sys.modules['optuna']
     sys.modules.pop('optuna.samplers', None)
     sys.modules.pop('optuna.integration.mlflow', None)
-import optuna  # noqa: F401
 mlflow_mod = types.ModuleType('optuna.integration.mlflow')
 mlflow_mod.MLflowCallback = object
 sys.modules.setdefault('optuna.integration.mlflow', mlflow_mod)
@@ -45,7 +46,6 @@ ray_mod.get = lambda x: x
 sys.modules['ray'] = ray_mod
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-from optimizer import ParameterOptimizer
 
 
 class DummyDataHandler:

--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -1,6 +1,10 @@
 import pandas as pd
 import pytest
-import sys, types
+import sys
+import types
+import logging
+import os
+from trade_manager import TradeManager
 
 if 'torch' not in sys.modules:
     torch = types.ModuleType('torch')
@@ -15,7 +19,6 @@ class DummyTelegramLogger:
 
 utils = types.ModuleType('utils')
 utils.TelegramLogger = DummyTelegramLogger
-import logging
 utils.logger = logging.getLogger('test')
 async def _cde(*a, **kw):
     return False
@@ -48,11 +51,7 @@ joblib_mod.dump = lambda *a, **k: None
 joblib_mod.load = lambda *a, **k: {}
 sys.modules.setdefault('joblib', joblib_mod)
 
-import utils
-import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
-from trade_manager import TradeManager
 
 class DummyExchange:
     def __init__(self):

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -9,14 +9,17 @@ from utils import (
 )
 import inspect
 import torch
-
-# Determine computation device once
-device_type = "cuda" if torch.cuda.is_available() else "cpu"
 import joblib
 import os
 import time
 from typing import Dict, Optional
 import shutil
+from flask import Flask, request, jsonify
+import json
+import threading
+
+# Determine computation device once
+device_type = "cuda" if torch.cuda.is_available() else "cpu"
 
 
 async def _check_df_async(df, context: str = "") -> bool:
@@ -888,9 +891,6 @@ class TradeManager:
 # ----------------------------------------------------------------------
 # REST API for minimal integration testing
 # ----------------------------------------------------------------------
-from flask import Flask, request, jsonify
-import json
-import threading
 
 api_app = Flask(__name__)
 


### PR DESCRIPTION
## Summary
- move stray imports to the top of the modules
- split combined import statements in tests
- ensure ruff passes without E401/E402/E702

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68592d32bdd0832d984aebcb7f8480f6