### PR TITLE
Remove SL/TP multiplier suggestions

### DIFF
--- a/optimizer.py
+++ b/optimizer.py
@@ -296,8 +296,8 @@ class ParameterOptimizer:
             ema_periods.sort()
             ema30_period, ema100_period, ema200_period = ema_periods
             atr_period_default = trial.suggest_int("atr_period_default", 5, 20)
-            trial.suggest_float("sl_multiplier", 0.5, 2.0)
-            trial.suggest_float("tp_multiplier", 0.5, 3.0)
+            # Stop loss and take profit multipliers are now taken
+            # directly from the configuration and are not optimized.
             return _objective_remote.remote(
                 df,
                 symbol,


### PR DESCRIPTION
## Summary
- stop optimizing `sl_multiplier` and `tp_multiplier`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685947dcac78832db94d0d59082f866a