### PR TITLE
Enable tests without heavy runtime packages

### DIFF
--- a/tests/test_indicators_gpu.py
+++ b/tests/test_indicators_gpu.py
@@ -8,15 +8,8 @@ import ta
 import types
 
 import importlib.util
-from data_handler import ema_fast, atr_fast
-if importlib.util.find_spec('numba') is None:
-    numba_mod = types.ModuleType('numba')
-    numba_mod.cuda = types.SimpleNamespace(is_available=lambda: False)
-    numba_mod.jit = lambda *a, **k: (lambda f: f)
-    numba_mod.prange = range
-    sys.modules.setdefault('numba', numba_mod)
-    sys.modules.setdefault('numba.cuda', numba_mod.cuda)
 
+# Stub heavy dependencies before importing data_handler
 ccxt_mod = types.ModuleType('ccxt')
 ccxt_mod.async_support = types.ModuleType('async_support')
 ccxt_mod.async_support.bybit = object
@@ -29,29 +22,29 @@ sys.modules.setdefault('websockets', types.ModuleType('websockets'))
 ray_mod = types.ModuleType('ray')
 ray_mod.remote = lambda *a, **k: (lambda f: f)
 sys.modules.setdefault('ray', ray_mod)
-if importlib.util.find_spec('tenacity') is None:
-    tenacity_mod = types.ModuleType('tenacity')
-    tenacity_mod.retry = lambda *a, **k: (lambda f: f)
-    tenacity_mod.wait_exponential = lambda *a, **k: None
-    tenacity_mod.stop_after_attempt = lambda *a, **k: (lambda f: f)
-    sys.modules['tenacity'] = tenacity_mod
+tenacity_mod = types.ModuleType('tenacity')
+tenacity_mod.retry = lambda *a, **k: (lambda f: f)
+tenacity_mod.wait_exponential = lambda *a, **k: None
+tenacity_mod.stop_after_attempt = lambda *a, **k: (lambda f: f)
+sys.modules.setdefault('tenacity', tenacity_mod)
 psutil_mod = types.ModuleType('psutil')
 psutil_mod.cpu_percent = lambda interval=1: 0
 psutil_mod.virtual_memory = lambda: type('mem', (), {'percent': 0})
 sys.modules.setdefault('psutil', psutil_mod)
-if importlib.util.find_spec('scipy') is None:
-    scipy_mod = types.ModuleType('scipy')
-    stats_mod = types.ModuleType('scipy.stats')
-    stats_mod.zscore = lambda a, axis=0: (a - np.mean(a, axis=axis)) / np.std(a, axis=axis)
-    scipy_mod.__version__ = "1.0"
-    scipy_mod.stats = stats_mod
-    sys.modules.setdefault('scipy', scipy_mod)
-    sys.modules.setdefault('scipy.stats', stats_mod)
 sys.modules.setdefault('httpx', types.ModuleType('httpx'))
 telegram_error_mod = types.ModuleType('telegram.error')
 telegram_error_mod.RetryAfter = Exception
 sys.modules.setdefault('telegram', types.ModuleType('telegram'))
 sys.modules.setdefault('telegram.error', telegram_error_mod)
+if importlib.util.find_spec('numba') is None:
+    numba_mod = types.ModuleType('numba')
+    numba_mod.cuda = types.SimpleNamespace(is_available=lambda: False)
+    numba_mod.jit = lambda *a, **k: (lambda f: f)
+    numba_mod.prange = range
+    sys.modules.setdefault('numba', numba_mod)
+    sys.modules.setdefault('numba.cuda', numba_mod.cuda)
+
+from data_handler import ema_fast, atr_fast  # noqa: E402
 
 
 def test_ema_fast_matches_ta():

--- a/tests/test_integration_services.py
+++ b/tests/test_integration_services.py
@@ -3,7 +3,23 @@ import time
 import requests
 import multiprocessing
 from flask import Flask, request, jsonify
-import trading_bot
+import sys
+import types
+
+# Stub heavy dependencies before importing trading_bot
+numba_mod = types.ModuleType('numba')
+numba_mod.cuda = types.SimpleNamespace(is_available=lambda: False)
+numba_mod.jit = lambda *a, **k: (lambda f: f)
+numba_mod.prange = range
+sys.modules.setdefault('numba', numba_mod)
+sys.modules.setdefault('numba.cuda', numba_mod.cuda)
+sys.modules.setdefault('httpx', types.ModuleType('httpx'))
+telegram_error_mod = types.ModuleType('telegram.error')
+telegram_error_mod.RetryAfter = Exception
+sys.modules.setdefault('telegram', types.ModuleType('telegram'))
+sys.modules.setdefault('telegram.error', telegram_error_mod)
+
+import trading_bot  # noqa: E402
 
 
 # Minimal stubs for services to avoid heavy dependencies

--- a/tests/test_optimizer_ray.py
+++ b/tests/test_optimizer_ray.py
@@ -6,14 +6,50 @@ import numpy as np
 import pandas as pd
 import pytest
 import optuna  # noqa: F401
-from optimizer import ParameterOptimizer
 
+# Stub heavy dependencies before importing the optimizer
 if 'torch' not in sys.modules:
     torch = types.ModuleType('torch')
     torch.cuda = types.SimpleNamespace(is_available=lambda: False)
     import importlib.machinery
     torch.__spec__ = importlib.machinery.ModuleSpec('torch', None)
     sys.modules['torch'] = torch
+
+ray_mod = types.ModuleType('ray')
+ray_mod.remote = lambda *a, **k: (lambda f: f)
+ray_mod.get = lambda x: x
+sys.modules.setdefault('ray', ray_mod)
+
+sk_mod = types.ModuleType('sklearn')
+model_sel = types.ModuleType('sklearn.model_selection')
+model_sel.GridSearchCV = object
+sk_mod.model_selection = model_sel
+base_estimator = types.ModuleType('sklearn.base')
+base_estimator.BaseEstimator = object
+sk_mod.base = base_estimator
+sys.modules.setdefault('sklearn', sk_mod)
+sys.modules.setdefault('sklearn.model_selection', model_sel)
+sys.modules.setdefault('sklearn.base', base_estimator)
+mlflow_mod = types.ModuleType('optuna.integration.mlflow')
+mlflow_mod.MLflowCallback = object
+sys.modules.setdefault('optuna.integration.mlflow', mlflow_mod)
+optuna_mod = types.ModuleType('optuna')
+optuna_samplers = types.ModuleType('optuna.samplers')
+optuna_samplers.TPESampler = object
+optuna_mod.samplers = optuna_samplers
+sys.modules.setdefault('optuna', optuna_mod)
+sys.modules.setdefault('optuna.samplers', optuna_samplers)
+sys.modules.setdefault('httpx', types.ModuleType('httpx'))
+telegram_error_mod = types.ModuleType('telegram.error')
+telegram_error_mod.RetryAfter = Exception
+sys.modules.setdefault('telegram', types.ModuleType('telegram'))
+sys.modules.setdefault('telegram.error', telegram_error_mod)
+psutil_mod = types.ModuleType('psutil')
+psutil_mod.cpu_percent = lambda interval=1: 0
+psutil_mod.virtual_memory = lambda: type('mem', (), {'percent': 0})
+sys.modules.setdefault('psutil', psutil_mod)
+
+from optimizer import ParameterOptimizer  # noqa: E402
 
 numba_mod = types.ModuleType('numba')
 numba_mod.cuda = types.SimpleNamespace(is_available=lambda: False)
@@ -23,27 +59,7 @@ sys.modules.setdefault('numba', numba_mod)
 sys.modules.setdefault('numba.cuda', numba_mod.cuda)
 
 # ensure real optuna
-if 'optuna' in sys.modules and not hasattr(sys.modules['optuna'], 'create_study'):
-    del sys.modules['optuna']
-    sys.modules.pop('optuna.samplers', None)
-    sys.modules.pop('optuna.integration.mlflow', None)
-mlflow_mod = types.ModuleType('optuna.integration.mlflow')
-mlflow_mod.MLflowCallback = object
-sys.modules.setdefault('optuna.integration.mlflow', mlflow_mod)
 
-# stub ray
-ray_mod = types.ModuleType('ray')
-
-def _remote(*args, **kwargs):
-    def decorator(func):
-        def call(*a, **k):
-            return func(*a, **k)
-        return types.SimpleNamespace(remote=call, _function=func)
-    return decorator
-
-ray_mod.remote = _remote
-ray_mod.get = lambda x: x
-sys.modules['ray'] = ray_mod
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 


### PR DESCRIPTION
## Summary
- stub heavy dependencies in optimizer and trade_manager tests
- stub http clients and telegram modules for integration tests
- avoid installing bulky packages for tests

## Testing
- `ruff check .`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685920d7a694832db3506485595c5967