### PR TITLE
Add container name to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    container_name: trading_bot
     command: python trading_bot.py
     depends_on:
       - data_handler


### PR DESCRIPTION
## Summary
- name the trading bot container for easier docker logs access

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6859a0bc40ec832db3a66721de75aebd