### PR TITLE
Improve Telegram bot documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,34 @@
    ```bash
    python trading_bot.py
    ```
-   При старте бот проверяет доступность всех сервисов по маршруту `/ping`.
+  При старте бот проверяет доступность всех сервисов по маршруту `/ping`.
 
 Также можно использовать `docker-compose up --build` для запуска в контейнере.
+
+## Telegram notifications
+
+Set the `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` variables in `.env` to
+enable notifications. Create the bot with `telegram.Bot` and pass it to both
+`DataHandler` and `TradeManager`:
+
+```python
+from telegram import Bot
+import json
+import os
+
+with open("config.json") as f:
+    cfg = json.load(f)
+
+bot = Bot(os.environ["TELEGRAM_BOT_TOKEN"])
+chat_id = os.environ["TELEGRAM_CHAT_ID"]
+
+data_handler = DataHandler(cfg, bot, chat_id)
+model_builder = ModelBuilder(cfg, data_handler, None)
+trade_manager = TradeManager(cfg, data_handler, model_builder, bot, chat_id)
+```
+
+You can run this bot either with long polling or a webhook using the
+`Application` class from `python-telegram-bot`.
 
 ## Лимиты WebSocket-подписок
 

--- a/data_handler.py
+++ b/data_handler.py
@@ -137,6 +137,22 @@ def calc_indicators(df: pd.DataFrame, config: dict, volatility: float, timeframe
 
 
 class DataHandler:
+    """Collects market data and exposes it via an HTTP API.
+
+    Parameters
+    ----------
+    config : dict
+        Bot configuration.
+    telegram_bot : telegram.Bot or compatible
+        Bot instance for sending notifications.
+    chat_id : str | int
+        Identifier of the Telegram chat for notifications.
+    exchange : BybitSDKAsync, optional
+        Preconfigured Bybit client.
+    pro_exchange : ccxtpro.bybit, optional
+        ccxtpro client for WebSocket data.
+    """
+
     def __init__(self, config: dict, telegram_bot, chat_id,
                  exchange: BybitSDKAsync | None = None,
                  pro_exchange: ccxtpro.bybit | None = None):

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -36,6 +36,24 @@ async def _check_df_async(df, context: str = "") -> bool:
 
 
 class TradeManager:
+    """Handles trading logic and sends Telegram notifications.
+
+    Parameters
+    ----------
+    config : dict
+        Bot configuration.
+    data_handler : DataHandler
+        Instance providing market data.
+    model_builder
+        Associated ModelBuilder instance.
+    telegram_bot : telegram.Bot or compatible
+        Bot used to send messages.
+    chat_id : str | int
+        Telegram chat identifier.
+    rl_agent : optional
+        Reinforcement learning agent used for decisions.
+    """
+
     def __init__(
         self,
         config: dict,
@@ -930,9 +948,16 @@ def create_trade_manager() -> TradeManager:
     if trade_manager is None:
         with open("config.json", "r") as f:
             cfg = json.load(f)
-        # Minimal placeholders for Telegram bot integration
+        token = os.environ.get("TELEGRAM_BOT_TOKEN")
+        chat_id = os.environ.get("TELEGRAM_CHAT_ID")
         telegram_bot = None
-        chat_id = None
+        if token:
+            try:
+                from telegram import Bot
+
+                telegram_bot = Bot(token)
+            except Exception as exc:  # pragma: no cover - import/runtime errors
+                logger.error(f"Failed to create Telegram Bot: {exc}")
         from data_handler import DataHandler
         from model_builder import ModelBuilder
 


### PR DESCRIPTION
## Summary
- describe how to pass `telegram.Bot` to bot components
- document environment variables for Telegram notifications
- show creation of `telegram.Bot` in `create_trade_manager`
- add docstrings for Telegram parameters

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685a5480d9b8832da300409846d04c59