### PR TITLE
Comment out container name in compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: trading_bot
+    # container_name: trading_bot
     command: python trading_bot.py
     depends_on:
       - data_handler


### PR DESCRIPTION
## Summary
- comment out the `container_name` field under the `trading_bot` service

## Testing
- `docker-compose down` *(fails: Error while fetching server API version)*
- `docker-compose up -d --build` *(fails: Error while fetching server API version)*

------
https://chatgpt.com/codex/tasks/task_e_685a617427c4832dbdc17c31ae5b0503