### PR TITLE
Improve TelegramLogger error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
   - `enable_grid_search` включает дополнительную проверку лучших параметров через GridSearchCV после оптимизации Optuna.
   - `max_symbols` задаёт количество наиболее ликвидных торговых пар, которые бот выберет из доступных.
    - `max_subscriptions_per_connection` определяет, сколько символов подписывается через одно WebSocket‑соединение.
+   - `telegram_queue_size` ограничивает размер очереди сообщений Telegram.
 4. Запустите бота:
    ```bash
    python trading_bot.py
@@ -56,6 +57,8 @@ chat_id = os.environ["TELEGRAM_CHAT_ID"]
 data_handler = DataHandler(cfg, bot, chat_id)
 model_builder = ModelBuilder(cfg, data_handler, None)
 trade_manager = TradeManager(cfg, data_handler, model_builder, bot, chat_id)
+
+You can limit the logger queue with `telegram_queue_size` in `config.json`.
 ```
 
 You can run this bot either with long polling or a webhook using the

--- a/config.json
+++ b/config.json
@@ -66,6 +66,7 @@
     "ws_min_process_rate": 30,
     "disk_buffer_size": 10000,
     "prediction_history_size": 100,
+    "telegram_queue_size": 100,
     "optuna_trials": 20,
     "enable_grid_search": false,
     "loss_streak_threshold": 3,

--- a/data_handler.py
+++ b/data_handler.py
@@ -159,7 +159,11 @@ class DataHandler:
         self.config = config
         self.exchange = exchange or create_exchange()
         self.pro_exchange = pro_exchange
-        self.telegram_logger = TelegramLogger(telegram_bot, chat_id)
+        self.telegram_logger = TelegramLogger(
+            telegram_bot,
+            chat_id,
+            max_queue_size=config.get("telegram_queue_size"),
+        )
         self.cache = HistoricalDataCache(config["cache_dir"])
         self.ohlcv = pd.DataFrame()
         self.ohlcv_2h = pd.DataFrame()

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -67,7 +67,11 @@ class TradeManager:
         self.data_handler = data_handler
         self.model_builder = model_builder
         self.rl_agent = rl_agent
-        self.telegram_logger = TelegramLogger(telegram_bot, chat_id)
+        self.telegram_logger = TelegramLogger(
+            telegram_bot,
+            chat_id,
+            max_queue_size=config.get("telegram_queue_size"),
+        )
         self.positions = pd.DataFrame(
             columns=[
                 "symbol",


### PR DESCRIPTION
## Summary
- log `telegram.error.BadRequest` and `Forbidden` in `TelegramLogger`
- add queue size option for Telegram logging
- hook up queue size setting from config
- document the new setting

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685a5fd75aac832db95ab406777485ca