### PR TITLE
Document test dependency setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,11 @@ Run `pip install -r requirements.txt` to install all runtime and development dep
 ```bash
 pip install -r requirements.txt
 ```
+Alternatively, run the helper script:
+```bash
+./install_test_deps.sh
+```
+This script simply installs packages from `requirements.txt`.
 
 The `requirements.txt` file already includes test-only packages such as
 `pytest`, `optuna` and `tenacity`, so no separate `requirements-dev.txt`

--- a/install_test_deps.sh
+++ b/install_test_deps.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+# Install packages required for running the test suite.
+# This script installs everything listed in requirements.txt.
+
+set -e
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+pip install -r "$SCRIPT_DIR/requirements.txt"


### PR DESCRIPTION
## Summary
- add `install_test_deps.sh` helper
- note helper script in README for running tests
- refine instructions about installing packages before running tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*
- `./install_test_deps.sh` *(fails: Operation cancelled by user)*


------
https://chatgpt.com/codex/tasks/task_e_685aacb3edd0832d8f60e5f0a358ae95