### PR TITLE
Refactor config loading and cleanup helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,11 +148,6 @@ Run `pip install -r requirements.txt` to install all runtime and development dep
 ```bash
 pip install -r requirements.txt
 ```
-Alternatively, run the helper script:
-```bash
-./install_test_deps.sh
-```
-This script simply installs packages from `requirements.txt`.
 
 The `requirements.txt` file already includes test-only packages such as
 `pytest`, `optuna` and `tenacity`, so no separate `requirements-dev.txt`

--- a/config.py
+++ b/config.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List
 
 # Load defaults from config.json
 CONFIG_PATH = os.getenv(
-    "CONFIG_PATH", os.path.join(os.path.dirname(__file__), "..", "config.json")
+    "CONFIG_PATH", os.path.join(os.path.dirname(__file__), "config.json")
 )
 try:
     with open(CONFIG_PATH, "r") as f:

--- a/install_test_deps.sh
+++ b/install_test_deps.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env sh
-# Install packages required for running the test suite.
-# This script installs everything listed in requirements.txt.
-
-set -e
-SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
-pip install -r "$SCRIPT_DIR/requirements.txt"


### PR DESCRIPTION
## Summary
- inline config package as a single `config.py`
- remove unused `install_test_deps.sh`
- update README to instruct installing requirements directly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ta')*

------
https://chatgpt.com/codex/tasks/task_e_685add59aed8832dac46dcacef13f8e1