### PR TITLE
Add data freshness checks and tests

### DIFF
--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -87,9 +87,8 @@ def test_prepare_lstm_features_shape():
 def test_train_model_remote_returns_state_and_predictions(model_type):
     X = np.random.rand(20, 3, 2).astype(np.float32)
     y = (np.random.rand(20) > 0.5).astype(np.float32)
-    state, preds, labels = _train_model_remote._function(
-        X, y, batch_size=2, model_type=model_type
-    )
+    func = getattr(_train_model_remote, "_function", _train_model_remote)
+    state, preds, labels = func(X, y, batch_size=2, model_type=model_type)
     assert isinstance(state, dict)
     assert len(preds) == len(labels)
     assert isinstance(preds, list)


### PR DESCRIPTION
## Summary
- validate data freshness in DataHandler
- avoid trading on stale data and invalid sides in TradeManager
- update tests for new logic
- fix model builder test when `ray` is stubbed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685adaf1c054832d8204318f265ec482