### PR TITLE
Ensure microservices start on expected ports

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -1166,4 +1166,5 @@ def ping():
 
 if __name__ == "__main__":
     port = int(os.environ.get("PORT", 8000))
+    logger.info("Starting DataHandler service on port %s", port)
     api_app.run(host="0.0.0.0", port=port)

--- a/model_builder.py
+++ b/model_builder.py
@@ -868,4 +868,5 @@ def ping():
 if __name__ == "__main__":
     _load_model()
     port = int(os.environ.get("PORT", 8001))
+    logger.info("Starting ModelBuilder service on port %s", port)
     api_app.run(host="0.0.0.0", port=port)

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -1037,4 +1037,5 @@ def ping():
 
 if __name__ == "__main__":
     port = int(os.environ.get("PORT", 8002))
+    logger.info("Starting TradeManager service on port %s", port)
     api_app.run(host="0.0.0.0", port=port)


### PR DESCRIPTION
## Summary
- add startup log messages for each microservice

## Testing
- `pytest tests/test_integration_services.py::test_service_availability_check -q`

------
https://chatgpt.com/codex/tasks/task_e_685af3a38fd0832dafc06403735f8fa8