### PR TITLE
Add env overrides for service checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,12 @@
    - `max_subscriptions_per_connection` определяет, сколько символов подписывается через одно WebSocket‑соединение.
    - `telegram_queue_size` ограничивает размер очереди сообщений Telegram.
 4. Запустите бота:
-   ```bash
-   python trading_bot.py
-   ```
+  ```bash
+  python trading_bot.py
+  ```
   При старте бот проверяет доступность всех сервисов по маршруту `/ping`.
+  Параметры проверки можно изменить переменными окружения
+  `SERVICE_CHECK_RETRIES` и `SERVICE_CHECK_DELAY` (в секундах).
 
 Также можно использовать `docker-compose up --build` для запуска в контейнере.
 

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -20,12 +20,23 @@ def _load_env() -> dict:
     }
 
 
-def check_services(retries: int = 5, delay: float = 2.0) -> bool:
+def check_services(
+    retries: int | None = None,
+    delay: float | None = None,
+) -> bool:
     """Return True if all dependent services respond to /ping.
+
+    The ``SERVICE_CHECK_RETRIES`` and ``SERVICE_CHECK_DELAY`` environment
+    variables can override the default attempt count (5) and delay between
+    attempts (2 seconds).
 
     Each service is queried several times with a small delay between attempts
     to allow containers time to start accepting connections.
     """
+    if retries is None:
+        retries = int(os.getenv("SERVICE_CHECK_RETRIES", "5"))
+    if delay is None:
+        delay = float(os.getenv("SERVICE_CHECK_DELAY", "2.0"))
 
     env = _load_env()
     services = {


### PR DESCRIPTION
## Summary
- make check_services use SERVICE_CHECK_RETRIES and SERVICE_CHECK_DELAY
- mention new env vars in quick start guide

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685afe20e3c4832da9c7cab4d64e809b