### PR TITLE
Fix import dependencies in integration tests

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -17,7 +17,7 @@ from utils import (
     safe_api_call,
 )
 from tenacity import retry, wait_exponential
-from typing import List, Dict
+from typing import List, Dict, TYPE_CHECKING
 from config import BotConfig
 import ta
 import os
@@ -26,6 +26,9 @@ import pickle
 import psutil
 import ray
 from flask import Flask, jsonify
+
+if TYPE_CHECKING:  # pragma: no cover - for type checkers only
+    import ccxtpro
 
 try:
     from numba import cuda  # type: ignore
@@ -152,13 +155,13 @@ class DataHandler:
         Identifier of the Telegram chat for notifications.
     exchange : BybitSDKAsync, optional
         Preconfigured Bybit client.
-    pro_exchange : ccxtpro.bybit, optional
+    pro_exchange : "ccxtpro.bybit", optional
         ccxtpro client for WebSocket data.
     """
 
     def __init__(self, config: BotConfig, telegram_bot, chat_id,
                  exchange: BybitSDKAsync | None = None,
-                 pro_exchange: ccxtpro.bybit | None = None):
+                 pro_exchange: "ccxtpro.bybit" | None = None):
         self.config = config
         self.exchange = exchange or create_exchange()
         self.pro_exchange = pro_exchange

--- a/tests/test_integration_services.py
+++ b/tests/test_integration_services.py
@@ -18,6 +18,16 @@ telegram_error_mod = types.ModuleType('telegram.error')
 telegram_error_mod.RetryAfter = Exception
 sys.modules.setdefault('telegram', types.ModuleType('telegram'))
 sys.modules.setdefault('telegram.error', telegram_error_mod)
+pybit_mod = types.ModuleType('pybit')
+ut_mod = types.ModuleType('unified_trading')
+ut_mod.HTTP = object
+pybit_mod.unified_trading = ut_mod
+sys.modules.setdefault('pybit', pybit_mod)
+sys.modules.setdefault('pybit.unified_trading', ut_mod)
+psutil_mod = types.ModuleType('psutil')
+psutil_mod.cpu_percent = lambda interval=1: 0
+psutil_mod.virtual_memory = lambda: type('mem', (), {'percent': 0})
+sys.modules.setdefault('psutil', psutil_mod)
 
 import trading_bot  # noqa: E402
 

--- a/tests/test_optimizer_ray.py
+++ b/tests/test_optimizer_ray.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import optuna  # noqa: F401
+from config import BotConfig
 
 # Stub heavy dependencies before importing the optimizer
 if 'torch' not in sys.modules:
@@ -50,7 +51,6 @@ psutil_mod.virtual_memory = lambda: type('mem', (), {'percent': 0})
 sys.modules.setdefault('psutil', psutil_mod)
 
 from optimizer import ParameterOptimizer  # noqa: E402
-from config import BotConfig
 
 numba_mod = types.ModuleType('numba')
 numba_mod.cuda = types.SimpleNamespace(is_available=lambda: False)


### PR DESCRIPTION
## Summary
- stub `psutil` and `pybit` so service integration tests don't require the real libraries

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bc10657dc832d9ca93ac79f140948