### PR TITLE
Add CPU-friendly dependency set

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,13 +151,24 @@ MLFLOW_TRACKING_URI=mlruns python trading_bot.py
 
 ## Running tests
 
-Before executing the test suite, **install all packages from `requirements.txt`**.
-Failure to do so will result in missing module errors.
+Before executing the test suite, **install the required packages**.
+The default `requirements.txt` installs GPU builds of libraries such as
+PyTorch. On systems without CUDA you can use the lighter
+`requirements-cpu.txt` instead. Both variants contain the same package set,
+but the CPU file pins the CPU wheels of heavy libraries using version strings
+like `torch==2.7.1+cpu`, `torchvision==0.22.1+cpu` and
+`tensorflow-cpu==2.16.1`.
 
-Run `pip install -r requirements.txt` to install all runtime and development dependencies before testing:
+Install full GPU versions:
 
 ```bash
 pip install -r requirements.txt
+```
+
+Install lightweight CPU versions:
+
+```bash
+pip install -r requirements-cpu.txt --extra-index-url https://download.pytorch.org/whl/cpu
 ```
 
 The `requirements.txt` file already includes test-only packages such as

--- a/README.md
+++ b/README.md
@@ -156,8 +156,8 @@ The default `requirements.txt` installs GPU builds of libraries such as
 PyTorch. On systems without CUDA you can use the lighter
 `requirements-cpu.txt` instead. Both variants contain the same package set,
 but the CPU file pins the CPU wheels of heavy libraries using version strings
-like `torch==2.7.1+cpu`, `torchvision==0.22.1+cpu` and
-`tensorflow-cpu==2.16.1`.
+like `torch==2.7.1+cpu`, `torchvision==0.22.1+cpu`,
+`tensorflow-cpu==2.16.1` and `numba==0.60.0`.
 
 Install full GPU versions:
 

--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -21,7 +21,7 @@ tenacity>=8.5.0
 pyarrow>=16.1.0
 jsonschema>=4.22.0
 plotly>=5.22.0
-numba>=0.60.0
+numba==0.60.0
 ray>=2.34.0
 stable-baselines3>=2.3.2
 mlflow>=2.12.1

--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -1,7 +1,7 @@
 numpy>=1.26.4
 pandas>=2.2.2
-torch==2.7.1
-torchvision==0.22.1
+torch==2.7.1+cpu
+torchvision==0.22.1+cpu
 ccxt>=4.3.85
 ccxtpro>=0.9.0
 python-telegram-bot>=20.7
@@ -26,10 +26,10 @@ ray>=2.34.0
 stable-baselines3>=2.3.2
 mlflow>=2.12.1
 pytorch-lightning>=2.2.1
-tensorflow>=2.16.1
+tensorflow-cpu==2.16.1
 catalyst==21.4
 gym==0.26.2
---extra-index-url https://download.pytorch.org/whl/cu128
+--extra-index-url https://download.pytorch.org/whl/cpu
 pytest>=8.1.1
 pytest-asyncio>=1.0.0
 flask>=3.0.2


### PR DESCRIPTION
## Summary
- document CPU installation option in README with extra index url
- add `requirements-cpu.txt` for CPU wheels
- include gym runtime dependency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e827fc28c832da077edd8499c47e2