### PR TITLE
Add CPU wheel pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
    source venv/bin/activate
    pip install -r requirements.txt
    ```
- - Для CPU достаточно установить пакеты из `requirements-cpu.txt`, где используются сборки `torch` и `tensorflow` без поддержки GPU:
+ - Для CPU достаточно установить пакеты из `requirements-cpu.txt`, где явно указаны колёсные сборки `torch` и `torchvision` c суффиксом `+cpu`, а также `tensorflow-cpu`:
    ```bash
    pip install -r requirements-cpu.txt
    ```
@@ -157,7 +157,7 @@ MLFLOW_TRACKING_URI=mlruns python trading_bot.py
 ## Running tests
 
 Before executing the test suite, **install all packages from `requirements-cpu.txt`**.
-This list pins CPU-only wheels of PyTorch and TensorFlow, so the tests do not download any CUDA dependencies.
+This list pins CPU-only wheels of PyTorch (with the `+cpu` tag), torchvision and TensorFlow, so the tests do not download any CUDA dependencies.
 GPU builds are not required for the unit tests.
 
 Run one of the following commands depending on your hardware:

--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -1,7 +1,7 @@
 numpy>=1.26.4
 pandas>=2.2.2
-torch==2.7.1
-torchvision==0.22.1
+torch==2.7.1+cpu
+torchvision==0.22.1+cpu
 ccxt>=4.3.85
 ccxtpro>=0.9.0
 python-telegram-bot>=20.7


### PR DESCRIPTION
## Summary
- specify `+cpu` PyTorch and torchvision wheels in `requirements-cpu.txt`
- clarify CPU requirement usage in README

## Testing
- `pip install -r requirements-cpu.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68600cce7700832d8888a1d0e7b69f7c