### PR TITLE
Add flake8 lint instructions without extra config

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,3 +209,18 @@ The test suite relies on the following packages:
 - pytest
 
 GPU libraries such as CUDA-enabled torch or numba may be required for some tests.
+
+## Linting
+
+The project uses **flake8** for style checks. Install dependencies including `flake8`:
+
+```bash
+pip install -r requirements.txt  # or requirements-cpu.txt
+flake8 --install-hook git  # optional Git pre-commit hook
+```
+
+To run linting manually:
+
+```bash
+flake8 . --max-line-length=180 --select=E9,F63,F7,F82 --extend-ignore=E203,W503
+```

--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -34,3 +34,4 @@ pytest-asyncio>=1.0.0
 flask>=3.0.2
 requests>=2.31.0
 pybit>=5.11.0
+flake8>=7.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,4 @@ pytest-asyncio>=1.0.0
 flask>=3.0.2
 requests>=2.31.0
 pybit>=5.11.0
+flake8>=7.3.0


### PR DESCRIPTION
## Summary
- remove standalone flake8 configuration and CI job
- keep flake8 as a dependency
- document optional git pre-commit hook and flake8 command

## Testing
- `flake8 . --max-line-length=180 --select=E9,F63,F7,F82 --extend-ignore=E203,W503`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686013239170832da32efe0360323249