### PR TITLE
Add CPU Dockerfile option

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,0 +1,24 @@
+FROM python:3.12-slim AS builder
+
+WORKDIR /app
+
+COPY requirements-cpu.txt .
+
+ENV VIRTUAL_ENV=/app/venv
+RUN python -m venv $VIRTUAL_ENV && \
+    $VIRTUAL_ENV/bin/pip install --no-cache-dir pip==24.0 setuptools wheel && \
+    $VIRTUAL_ENV/bin/pip install --no-cache-dir -r requirements-cpu.txt && \
+    find $VIRTUAL_ENV -type d -name '__pycache__' -exec rm -rf {} + && \
+    find $VIRTUAL_ENV -type f -name '*.pyc' -delete
+
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY --from=builder /app/venv /app/venv
+COPY . .
+
+ENV VIRTUAL_ENV=/app/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+CMD ["python", "trading_bot.py"]

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@
   ```
 
 Также можно использовать `docker-compose up --build` для запуска в контейнере.
+По умолчанию используется образ с поддержкой GPU. Если она не требуется,
+запустите compose с переменной `DOCKERFILE` и отключите NVIDIA-переменные:
+
+```bash
+DOCKERFILE=Dockerfile.cpu NVIDIA_VISIBLE_DEVICES= NVIDIA_DRIVER_CAPABILITIES= docker-compose up --build
+```
 
 ## Telegram notifications
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,31 @@
 version: '3'
+# Set DOCKERFILE=Dockerfile.cpu to build a CPU-only image
 services:
   data_handler:
-    build: .
+    build:
+      context: .
+      dockerfile: ${DOCKERFILE:-Dockerfile}
     command: python data_handler.py
     networks:
       - trading_bot_default
   model_builder:
-    build: .
+    build:
+      context: .
+      dockerfile: ${DOCKERFILE:-Dockerfile}
     command: python model_builder.py
     networks:
       - trading_bot_default
   trade_manager:
-    build: .
+    build:
+      context: .
+      dockerfile: ${DOCKERFILE:-Dockerfile}
     command: python trade_manager.py
     networks:
       - trading_bot_default
   trading_bot:
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: ${DOCKERFILE:-Dockerfile}
     # container_name: trading_bot
     command: python trading_bot.py
     depends_on:
@@ -29,8 +36,8 @@ services:
       - DATA_HANDLER_URL=http://data_handler:8000
       - MODEL_BUILDER_URL=http://model_builder:8001
       - TRADE_MANAGER_URL=http://trade_manager:8002
-      - NVIDIA_VISIBLE_DEVICES=all
-      - NVIDIA_DRIVER_CAPABILITIES=compute,utility
+      - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-all}
+      - NVIDIA_DRIVER_CAPABILITIES=${NVIDIA_DRIVER_CAPABILITIES:-compute,utility}
       - PYTHONUNBUFFERED=1
       - BYBIT_API_KEY=${BYBIT_API_KEY}
       - BYBIT_API_SECRET=${BYBIT_API_SECRET}


### PR DESCRIPTION
## Summary
- provide `Dockerfile.cpu` for machines without GPUs
- allow selecting Dockerfile via `DOCKERFILE` variable in `docker-compose.yml`
- document how to run CPU image in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ta')*
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686017f9e0d4832dace78c5562a3f22f