### PR TITLE
Fix open_position concat when no positions

### DIFF
--- a/trade_manager.py
+++ b/trade_manager.py
@@ -386,9 +386,12 @@ class TradeManager:
                     ),
                 )
                 async with self.position_lock:
-                    self.positions = pd.concat(
-                        [self.positions, new_position_df], ignore_index=False
-                    )
+                    if self.positions.empty:
+                        self.positions = new_position_df
+                    else:
+                        self.positions = pd.concat(
+                            [self.positions, new_position_df], ignore_index=False
+                        )
                     self.positions_changed = True
                     self.save_state()
                 logger.info(


### PR DESCRIPTION
## Summary
- handle empty positions DataFrame in `open_position`

## Testing
- `flake8 trade_manager.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68613bb52688832d897672b476d66bbf