### PR TITLE
Fix open_position race condition

### DIFF
--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -212,6 +212,27 @@ def test_open_position_skips_existing():
     assert len(tm.positions) == 1
 
 
+def test_open_position_concurrent_single_entry():
+    dh = DummyDataHandler()
+    tm = TradeManager(make_config(), dh, None, None, None)
+
+    async def fake_compute(symbol, vol):
+        return 0.01
+
+    tm.compute_risk_per_trade = fake_compute
+
+    async def run():
+        await asyncio.gather(
+            tm.open_position('BTCUSDT', 'buy', 100, {}),
+            tm.open_position('BTCUSDT', 'buy', 100, {}),
+        )
+
+    import asyncio
+    asyncio.run(run())
+
+    assert len(tm.positions) == 1
+
+
 def test_is_data_fresh():
     fresh_dh = DummyDataHandler(fresh=True)
     stale_dh = DummyDataHandler(fresh=False)

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -386,6 +386,14 @@ class TradeManager:
                     ),
                 )
                 async with self.position_lock:
+                    if (
+                        "symbol" in self.positions.index.names
+                        and symbol in self.positions.index.get_level_values("symbol")
+                    ):
+                        logger.warning(
+                            f"Position for {symbol} already open after order placed"
+                        )
+                        return
                     if self.positions.empty:
                         self.positions = new_position_df
                     else:


### PR DESCRIPTION
## Summary
- hold the position lock before checking/creating positions
- test concurrent calls to `open_position`

## Testing
- `flake8`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68614507098c832d971047a0c1405bbe