### PR TITLE
Add test mode for TelegramLogger

### DIFF
--- a/tests/test_import_order.py
+++ b/tests/test_import_order.py
@@ -1,0 +1,22 @@
+import importlib
+import sys
+import types
+import logging
+import os
+
+os.environ["TEST_MODE"] = "1"
+
+def test_telegramlogger_injection_order():
+    sys.modules.pop('trade_manager', None)
+    utils_stub = types.ModuleType('utils')
+    class StubTL:
+        pass
+    utils_stub.TelegramLogger = StubTL
+    utils_stub.logger = logging.getLogger('test')
+    async def _cde(*a, **k):
+        return False
+    utils_stub.check_dataframe_empty = _cde
+    sys.modules['utils'] = utils_stub
+
+    tm = importlib.import_module('trade_manager')
+    assert tm.TelegramLogger is StubTL

--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -39,6 +39,7 @@ async def _cde_stub(*a, **kw):
     return False
 utils_stub.check_dataframe_empty = _cde_stub
 sys.modules['utils'] = utils_stub
+os.environ["TEST_MODE"] = "1"
 tenacity_mod = types.ModuleType('tenacity')
 tenacity_mod.retry = lambda *a, **k: (lambda f: f)
 tenacity_mod.wait_exponential = lambda *a, **k: None
@@ -58,7 +59,11 @@ psutil_mod.cpu_percent = lambda interval=1: 0
 psutil_mod.virtual_memory = lambda: type('mem', (), {'percent': 0})
 sys.modules.setdefault('psutil', psutil_mod)
 
+import trade_manager
 from trade_manager import TradeManager  # noqa: E402
+
+def test_utils_injected_before_trade_manager_import():
+    assert trade_manager.TelegramLogger is _TL
 
 class DummyTelegramLogger:
     def __init__(self, *a, **kw):

--- a/utils.py
+++ b/utils.py
@@ -267,7 +267,8 @@ class TelegramLogger(logging.Handler):
             TelegramLogger._queue = asyncio.Queue(maxsize=max_queue_size or 0)
             TelegramLogger._bot = bot
             TelegramLogger._stop_event = asyncio.Event()
-            TelegramLogger._worker_task = asyncio.create_task(self._worker())
+            if os.getenv("TEST_MODE") != "1":
+                TelegramLogger._worker_task = asyncio.create_task(self._worker())
 
         self.last_sent_text = ""
 


### PR DESCRIPTION
## Summary
- add `TEST_MODE` safeguard to skip TelegramLogger worker task
- verify `utils_stub.TelegramLogger` injection happens before importing `trade_manager`
- set `TEST_MODE` in trade manager tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68614892c840832d972ad138215495c7