### PR TITLE
Fix locking in open_position

### DIFF
--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -244,6 +244,29 @@ def test_open_position_concurrent_single_entry():
     assert len(tm.positions) == 1
 
 
+def test_open_position_many_concurrent_single_entry():
+    dh = DummyDataHandler()
+    tm = TradeManager(make_config(), dh, None, None, None)
+
+    async def fake_compute(symbol, vol):
+        return 0.01
+
+    tm.compute_risk_per_trade = fake_compute
+
+    async def run():
+        await asyncio.gather(
+            *[
+                tm.open_position('BTCUSDT', 'buy', 100, {})
+                for _ in range(5)
+            ]
+        )
+
+    import asyncio
+    asyncio.run(run())
+
+    assert len(tm.positions) == 1
+
+
 def test_open_position_failed_order_not_recorded():
     dh = DummyDataHandler(fail_order=True)
     tm = TradeManager(make_config(), dh, None, None, None)


### PR DESCRIPTION
## Summary
- ensure `open_position` holds the position lock through order placement
- allow `place_order` to skip locking when a caller already holds the lock
- update trailing-stop logic and close position calls to use the new argument
- avoid numpy bool issues in `breakeven_triggered` column
- add async regression test with multiple concurrent open requests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68614e565a68832d81351ac733e548ad