### PR TITLE
Fix healthcheck dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ WORKDIR /app
 
 # Установка минимальных пакетов для выполнения
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
     python3.12 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -13,6 +13,10 @@ RUN python -m venv $VIRTUAL_ENV && \
 
 FROM python:3.12-slim
 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY --from=builder /app/venv /app/venv


### PR DESCRIPTION
## Summary
- add missing curl dependency in Docker images so service health checks succeed

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68615b0ef914832da48595b59e30c402