### PR TITLE
Add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+*.log
+.env
+pytest_cache/


### PR DESCRIPTION
## Summary
- keep temp files out of git by ignoring common patterns

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ta')*

------
https://chatgpt.com/codex/tasks/task_e_68615ef92998832d9e039952a7940e59