### PR TITLE
Fix gym import and dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ python trading_bot.py
 Модуль `RLAgent` может обучать модели с помощью `stable-baselines3`, `Ray RLlib` или фреймворка `Catalyst` от Яндекса.
 Выберите подходящий движок параметром `rl_framework` в `config.json` (`stable_baselines3`, `rllib` или `catalyst`).
 Алгоритм указывается опцией `rl_model` (`PPO` или `DQN`), продолжительность обучения — `rl_timesteps`.
+Для корректной работы `stable-baselines3` необходим пакет `gymnasium`.
 
 Периодическое переобучение задаётся параметром `retrain_interval` в
 `config.json`. Можно запускать бота по расписанию (например, через `cron`) для

--- a/model_builder.py
+++ b/model_builder.py
@@ -17,12 +17,16 @@ from utils import logger, check_dataframe_empty, HistoricalDataCache
 from config import BotConfig
 from collections import deque
 import ray
-try:
-    import gym
-    from gym import spaces
-except Exception:  # pragma: no cover - optional dependency
-    gym = None
-    spaces = None
+try:  # prefer gymnasium if available
+    import gymnasium as gym  # type: ignore
+    from gymnasium import spaces  # type: ignore
+except Exception:  # pragma: no cover - gymnasium missing
+    try:
+        import gym
+        from gym import spaces
+    except Exception:  # pragma: no cover - optional dependency
+        gym = None
+        spaces = None
 from flask import Flask, request, jsonify
 from stable_baselines3 import PPO, DQN
 from stable_baselines3.common.vec_env import DummyVecEnv

--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -24,6 +24,7 @@ plotly>=5.22.0
 numba>=0.60.0
 ray>=2.34.0
 stable-baselines3>=2.3.2
+gymnasium>=0.29.1
 mlflow>=2.12.1
 pytorch-lightning>=2.2.1
 tensorflow-cpu>=2.16.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ plotly>=5.22.0
 numba>=0.60.0
 ray>=2.34.0
 stable-baselines3>=2.3.2
+gymnasium>=0.29.1
 mlflow>=2.12.1
 pytorch-lightning>=2.2.1
 tensorflow>=2.16.1


### PR DESCRIPTION
## Summary
- handle environments that only ship gymnasium
- require gymnasium in CPU and GPU builds
- document RL dependency in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68617c965a6c832db0372a644380c669