### PR TITLE
Log gymnasium import failure

### DIFF
--- a/model_builder.py
+++ b/model_builder.py
@@ -20,7 +20,8 @@ import ray
 try:  # prefer gymnasium if available
     import gymnasium as gym  # type: ignore
     from gymnasium import spaces  # type: ignore
-except Exception:  # pragma: no cover - gymnasium missing
+except Exception as e:  # pragma: no cover - gymnasium missing
+    logger.warning("gymnasium import failed: %s", e)
     try:
         import gym
         from gym import spaces


### PR DESCRIPTION
## Summary
- log gymnasium import failures in `model_builder`
- fallback to `gym` when `gymnasium` import fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68618380e30c832d8d7d2c886bdf6668