### PR TITLE
Add gymnasium warning note

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ use these steps to diagnose the problem:
 
 3. If services require more time to initialize, increase
    `SERVICE_CHECK_RETRIES` or `SERVICE_CHECK_DELAY` in `.env`.
+4. If logs contain `gymnasium import failed`, install the optional
+   dependency with `pip install gymnasium`.
 
 ## Telegram notifications
 


### PR DESCRIPTION
## Summary
- document how to resolve `gymnasium import failed` warning

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6862362dede4832da3e1d6983e8fa361