### PR TITLE
Load environment variables only when running bot

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -7,8 +7,6 @@ from utils import logger
 from config import load_config, BotConfig
 from tenacity import retry, wait_exponential, stop_after_attempt
 
-# Automatically load environment variables from a .env file if present
-load_dotenv()
 
 SYMBOL = os.getenv("SYMBOL", "TEST")
 INTERVAL = float(os.getenv("INTERVAL", "5"))
@@ -108,6 +106,8 @@ def run_once() -> None:
 
 
 def main():
+    # Load environment variables from a .env file when running as a script
+    load_dotenv()
     try:
         check_services()
         while True:


### PR DESCRIPTION
## Summary
- move `load_dotenv()` call into `main()` in `trading_bot.py`

## Testing
- `flake8 trading_bot.py tests/test_integration_services.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686273f68404832d992db51dcfd21729