### PR TITLE
Support BTCUSDT pair format

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -320,15 +320,16 @@ class DataHandler:
     async def select_liquid_pairs(self, markets: Dict) -> List[str]:
         """Return top liquid USDT futures pairs only.
 
-        Filters out spot markets by selecting symbols that contain a colon
-        (``:``) or explicitly end with ``":USDT"``. Volume ranking and
-        the configured top limit remain unchanged.
+        Filters out spot markets by selecting futures symbols. Both plain
+        notation like ``BTCUSDT`` and the colon-delimited form 
+        ``BTC/USDT:USDT`` are supported. Volume ranking and the configured
+        top limit remain unchanged.
         """
 
         pair_volumes = []
         for symbol, market in markets.items():
             # Only consider active USDT-margined futures symbols
-            if market.get("active") and symbol.endswith("USDT") and (":" in symbol or symbol.endswith(":USDT")):
+            if market.get("active") and symbol.endswith("USDT") and ((":" in symbol) or ("/" not in symbol)):
                 try:
                     ticker = await safe_api_call(self.exchange, "fetch_ticker", symbol)
                     volume = float(ticker.get("quoteVolume") or 0)
@@ -667,8 +668,7 @@ class DataHandler:
         Parameters
         ----------
         symbol : str
-            Symbol in one of the supported formats, e.g. ``BTC/USDT`` or
-            ``BTC/USDT:USDT``.
+            Symbol in one of the supported formats, e.g. ``BTCUSDT``, ``BTC/USDT`` or ``BTC/USDT:USDT``.
 
         Returns
         -------

--- a/tests/test_data_handler.py
+++ b/tests/test_data_handler.py
@@ -1,0 +1,77 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import importlib
+import types
+import logging
+import pytest
+from config import BotConfig
+
+# Stub heavy dependencies before importing data_handler
+sys.modules.setdefault('websockets', types.ModuleType('websockets'))
+pybit_mod = types.ModuleType('pybit')
+ut_mod = types.ModuleType('unified_trading')
+ut_mod.HTTP = object
+pybit_mod.unified_trading = ut_mod
+sys.modules.setdefault('pybit', pybit_mod)
+sys.modules.setdefault('pybit.unified_trading', ut_mod)
+ray_mod = types.ModuleType('ray')
+ray_mod.remote = lambda *a, **k: (lambda f: f)
+sys.modules.setdefault('ray', ray_mod)
+tenacity_mod = types.ModuleType('tenacity')
+tenacity_mod.retry = lambda *a, **k: (lambda f: f)
+tenacity_mod.wait_exponential = lambda *a, **k: None
+tenacity_mod.stop_after_attempt = lambda *a, **k: (lambda f: f)
+sys.modules.setdefault('tenacity', tenacity_mod)
+psutil_mod = types.ModuleType('psutil')
+psutil_mod.cpu_percent = lambda interval=1: 0
+psutil_mod.virtual_memory = lambda: type('mem', (), {'percent': 0})
+sys.modules.setdefault('psutil', psutil_mod)
+sys.modules.setdefault('httpx', types.ModuleType('httpx'))
+telegram_error_mod = types.ModuleType('telegram.error')
+telegram_error_mod.RetryAfter = Exception
+sys.modules.setdefault('telegram', types.ModuleType('telegram'))
+sys.modules.setdefault('telegram.error', telegram_error_mod)
+numba_mod = types.ModuleType('numba')
+numba_mod.cuda = types.SimpleNamespace(is_available=lambda: False)
+numba_mod.jit = lambda *a, **k: (lambda f: f)
+numba_mod.prange = range
+import importlib.machinery
+numba_mod.__spec__ = importlib.machinery.ModuleSpec("numba", None)
+sys.modules.setdefault('numba', numba_mod)
+sys.modules.setdefault('numba.cuda', numba_mod.cuda)
+
+# Replace utils with a stub that overrides TelegramLogger
+real_utils = importlib.import_module('utils')
+utils_stub = types.ModuleType('utils')
+utils_stub.__dict__.update(real_utils.__dict__)
+class DummyTL:
+    def __init__(self, *a, **k):
+        pass
+    async def send_telegram_message(self, *a, **k):
+        pass
+    @classmethod
+    async def shutdown(cls):
+        pass
+utils_stub.TelegramLogger = DummyTL
+utils_stub.logger = logging.getLogger('test')
+sys.modules['utils'] = utils_stub
+os.environ['TEST_MODE'] = '1'
+
+from data_handler import DataHandler
+
+class DummyExchange:
+    def __init__(self, volumes):
+        self.volumes = volumes
+    async def fetch_ticker(self, symbol):
+        return {'quoteVolume': self.volumes.get(symbol, 0)}
+
+@pytest.mark.asyncio
+async def test_select_liquid_pairs_plain_symbol_included():
+    cfg = BotConfig(cache_dir='/tmp', max_symbols=5)
+    dh = DataHandler(cfg, None, None, exchange=DummyExchange({'BTCUSDT': 1.0}))
+    markets = {
+        'BTCUSDT': {'active': True},
+        'BTC/USDT': {'active': True},
+    }
+    pairs = await dh.select_liquid_pairs(markets)
+    assert 'BTCUSDT' in pairs


### PR DESCRIPTION
## Summary
- relax futures pair selection filter to allow `BTCUSDT` names
- document accepted symbol formats in `select_liquid_pairs` and `fix_symbol`
- add regression test for plain pair notation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686275618ef8832d8dc3bb57bbe93e42