### PR TITLE
Fix fix_symbol docstring

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -668,13 +668,15 @@ class DataHandler:
         Parameters
         ----------
         symbol : str
-            Symbol in one of the supported formats, e.g. ``BTCUSDT``, ``BTC/USDT`` or ``BTC/USDT:USDT``.
+            Symbol in one of the supported formats, e.g. ``BTCUSDT``,
+            ``BTC/USDT`` or ``BTC/USDT:USDT``.
 
         Returns
         -------
         str
-            Symbol formatted as ``BTC/USDT:USDT``. If the input already
-            contains ``:USDT`` it will not be duplicated.
+            ``BTCUSDT`` –> ``BTCUSDT``
+            ``BTC/USDT`` –> ``BTC/USDT:USDT``
+            ``BTC/USDT:USDT`` remains unchanged
         """
 
         if symbol.endswith("/USDT"):


### PR DESCRIPTION
## Summary
- clarify the behavior of `fix_symbol` around Bybit symbol formats
- examples now show `BTCUSDT` remains the same, `BTC/USDT` becomes `BTC/USDT:USDT`, and `BTC/USDT:USDT` is unchanged

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686299f2276c832d872e3a66945c2d68