### PR TITLE
Optional shap import

### DIFF
--- a/model_builder.py
+++ b/model_builder.py
@@ -11,9 +11,13 @@ import joblib
 import os
 import time
 import asyncio
-import shap
 import mlflow
 from utils import logger, check_dataframe_empty, HistoricalDataCache
+try:
+    import shap
+except Exception as e:
+    shap = None
+    logger.warning("shap import failed: %s", e)
 from config import BotConfig
 from collections import deque
 import ray
@@ -572,7 +576,7 @@ class ModelBuilder:
 
     async def compute_shap_values(self, symbol, model, X):
         try:
-            if self.nn_framework != 'pytorch':
+            if shap is None or self.nn_framework != 'pytorch':
                 return
             cache_file = os.path.join(self.cache.cache_dir, f"shap_{symbol}.pkl")
             last_time = self.shap_cache_times.get(symbol, 0)


### PR DESCRIPTION
## Summary
- handle optional shap installation in model_builder
- skip SHAP computation if shap isn't available

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68629fe5086c832d919a89f116c6608f