### PR TITLE
Allow Docker CPU files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -36,3 +36,5 @@ venv/
 !.env
 !Dockerfile
 !docker-compose.yml
+!Dockerfile.cpu
+!requirements-cpu.txt


### PR DESCRIPTION
## Summary
- expose CPU-based Docker build files in `.dockerignore`

## Testing
- `docker compose config | head -n 10`

------
https://chatgpt.com/codex/tasks/task_e_6862c745d20c832d8a81bb65b862b550