### PR TITLE
Update CI to Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- update the CI workflow to use Python 3.12

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6862cda2d130832d85a9ce16048a962c