### PR TITLE
Remove deprecated gym dependency

### DIFF
--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -24,7 +24,6 @@ plotly>=5.22.0
 numba>=0.60.0
 ray>=2.34.0
 stable-baselines3>=2.3.2
-gym>=0.26.0
 gymnasium>=0.29.1
 mlflow>=2.12.1
 pytorch-lightning>=2.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,6 @@ plotly>=5.22.0
 numba>=0.60.0
 ray>=2.34.0
 stable-baselines3>=2.3.2
-gym>=0.26.0
 gymnasium>=0.29.1
 mlflow>=2.12.1
 pytorch-lightning>=2.2.1


### PR DESCRIPTION
## Summary
- prune `gym` from requirements

## Testing
- `pre-commit run --files requirements.txt requirements-cpu.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862ce33406c832da3bb34aa31ebc15f