### PR TITLE
Update README on gymnasium requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,13 +101,11 @@ use these steps to diagnose the problem:
 
 3. If services require more time to initialize, increase
    `SERVICE_CHECK_RETRIES` or `SERVICE_CHECK_DELAY` in `.env`.
-4. If logs contain `gymnasium import failed`, install the optional
-  dependency with `pip install gymnasium`. The project now installs
-  `gym` by default as a fallback.
+4. If logs contain `gymnasium import failed`, the package is required.
+  Install it manually with `pip install gymnasium`.
 
-5. When RL components start, they first try to import `gymnasium`.
-  A warning `gymnasium import failed: ...` will be logged if the package
-  is missing, after which the code attempts to load `gym` instead.
+5. When RL components start, they import `gymnasium`.
+  If the package is missing, training will fail until you install it.
 
 ## Telegram notifications
 
@@ -190,8 +188,8 @@ python trading_bot.py
 Выберите подходящий движок параметром `rl_framework` в `config.json` (`stable_baselines3`, `rllib` или `catalyst`).
 Алгоритм указывается опцией `rl_model` (`PPO` или `DQN`), продолжительность обучения — `rl_timesteps`.
 Для корректной работы `stable-baselines3` необходим пакет `gymnasium`. Он
-установлен вместе с базовым `gym`, который используется как резервная
-зависимость.
+устанавливается по умолчанию вместе с зависимостями проекта, поэтому
+альтернативный `gym` не требуется.
 
 Периодическое переобучение задаётся параметром `retrain_interval` в
 `config.json`. Можно запускать бота по расписанию (например, через `cron`) для


### PR DESCRIPTION
## Summary
- clarify troubleshooting note about `gymnasium import failed`
- state no fallback to `gym` for RL setups

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6862cf86b27c832dbb418c4735d91243