### PR TITLE
Enforce gymnasium requirement

### DIFF
--- a/model_builder.py
+++ b/model_builder.py
@@ -25,13 +25,8 @@ try:  # prefer gymnasium if available
     import gymnasium as gym  # type: ignore
     from gymnasium import spaces  # type: ignore
 except Exception as e:  # pragma: no cover - gymnasium missing
-    logger.warning("gymnasium import failed: %s", e)
-    try:
-        import gym
-        from gym import spaces
-    except Exception:  # pragma: no cover - optional dependency
-        gym = None
-        spaces = None
+    logger.error("gymnasium import failed: %s", e)
+    raise ImportError("gymnasium package is required") from e
 from flask import Flask, request, jsonify
 try:
     from stable_baselines3 import PPO, DQN

--- a/tests/test_model_builder_import.py
+++ b/tests/test_model_builder_import.py
@@ -1,0 +1,11 @@
+import importlib
+import sys
+import pytest
+
+
+def test_model_builder_requires_gymnasium(monkeypatch):
+    sys.modules.pop('model_builder', None)
+    sys.modules.pop('utils', None)
+    monkeypatch.setitem(sys.modules, 'gymnasium', None)
+    with pytest.raises(ImportError, match='gymnasium package is required'):
+        importlib.import_module('model_builder')


### PR DESCRIPTION
## Summary
- raise ImportError if `gymnasium` missing during `model_builder` import
- add regression test for absence of `gymnasium`

## Testing
- `pytest -q`
- `docker compose build --no-cache` *(fails: `docker` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6862d409635c832d9c2b55ad6927b529