### PR TITLE
Add torch stub for model_builder import test

### DIFF
--- a/tests/test_model_builder_import.py
+++ b/tests/test_model_builder_import.py
@@ -1,11 +1,28 @@
 import importlib
 import sys
+import types
 import pytest
 
 
 def test_model_builder_requires_gymnasium(monkeypatch):
     sys.modules.pop('model_builder', None)
     sys.modules.pop('utils', None)
+    if 'torch' not in sys.modules:
+        torch_stub = types.ModuleType('torch')
+        nn_stub = types.ModuleType('torch.nn')
+        utils_stub = types.ModuleType('torch.utils')
+        data_stub = types.ModuleType('torch.utils.data')
+        # minimal attributes used during import
+        data_stub.DataLoader = object()
+        data_stub.TensorDataset = object()
+        nn_stub.Module = object
+        torch_stub.nn = nn_stub
+        torch_stub.utils = utils_stub
+        utils_stub.data = data_stub
+        sys.modules['torch'] = torch_stub
+        sys.modules['torch.nn'] = nn_stub
+        sys.modules['torch.utils'] = utils_stub
+        sys.modules['torch.utils.data'] = data_stub
     monkeypatch.setitem(sys.modules, 'gymnasium', None)
     with pytest.raises(ImportError, match='gymnasium package is required'):
         importlib.import_module('model_builder')


### PR DESCRIPTION
## Summary
- allow `model_builder` import test to run without torch by stubbing minimal torch modules

## Testing
- `pre-commit run --files tests/test_model_builder_import.py`
- `pytest tests/test_model_builder_import.py::test_model_builder_requires_gymnasium -vv` *(fails: No module named 'model_builder')*

------
https://chatgpt.com/codex/tasks/task_e_6862e5358390832d8b35101320a453df