### PR TITLE
Async open position route

### DIFF
--- a/tests/test_trading_bot.py
+++ b/tests/test_trading_bot.py
@@ -1,0 +1,17 @@
+import trading_bot
+
+
+def test_send_trade_timeout_env(monkeypatch):
+    called = {}
+
+    def fake_post(url, json=None, timeout=None):
+        called['timeout'] = timeout
+        class Resp:
+            status_code = 200
+        return Resp()
+
+    monkeypatch.setattr(trading_bot.requests, 'post', fake_post)
+    monkeypatch.setenv('TRADE_MANAGER_TIMEOUT', '9')
+    trading_bot.send_trade('BTCUSDT', 'buy', 100.0, {'trade_manager_url': 'http://tm'})
+    assert called['timeout'] == 9.0
+

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -1073,7 +1073,10 @@ def open_position_route():
     symbol = info.get("symbol")
     side = info.get("side")
     price = float(info.get("price", 0))
-    asyncio.run(tm.open_position(symbol, side, price, info))
+    threading.Thread(
+        target=lambda: asyncio.run(tm.open_position(symbol, side, price, info)),
+        daemon=True,
+    ).start()
     return jsonify({"status": "ok"})
 
 

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -84,10 +84,11 @@ def get_prediction(symbol: str, price: float, env: dict) -> str | None:
 def send_trade(symbol: str, side: str, price: float, env: dict) -> None:
     """Send trade request to trade manager."""
     try:
+        timeout = float(os.getenv("TRADE_MANAGER_TIMEOUT", "5"))
         resp = requests.post(
             f"{env['trade_manager_url']}/open_position",
             json={"symbol": symbol, "side": side, "price": price},
-            timeout=5,
+            timeout=timeout,
         )
         if resp.status_code != 200:
             logger.error("Trade manager error: HTTP %s", resp.status_code)


### PR DESCRIPTION
## Summary
- run `open_position_route` in a background thread
- allow trade request timeout to be set via `TRADE_MANAGER_TIMEOUT`
- cover new timeout option in trading_bot tests

## Testing
- `pre-commit run --files trade_manager.py trading_bot.py tests/test_trading_bot.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862f54d7b20832d9c98985ff73dd163