### PR TITLE
Ensure api_v1 emits no warnings

### DIFF
--- a/tests/test_warning_capture.py
+++ b/tests/test_warning_capture.py
@@ -3,8 +3,8 @@ import pytest
 
 
 def api_v1():
-    warnings.warn(UserWarning("api v1, should use functions from v2"))
-    return 1
+    """Legacy API now delegates to :func:`api_v2` without emitting warnings."""
+    return api_v2()
 
 
 def api_v2():
@@ -16,4 +16,11 @@ def test_api_v2_no_warning():
     with warnings.catch_warnings(record=True) as captured:
         warnings.simplefilter("error")
         assert api_v2() == 1
+        assert not captured
+
+
+def test_api_v1_no_warning():
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("error")
+        assert api_v1() == 1
         assert not captured


### PR DESCRIPTION
## Summary
- make `api_v1` delegate to `api_v2` and stop emitting warnings
- test that `api_v1` and `api_v2` both execute without warnings

## Testing
- `pytest tests/test_warning_capture.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68639e9de830832dbf6cea3c2f27fd3f