### PR TITLE
Clean up warning capture test

### DIFF
--- a/tests/test_warning_capture.py
+++ b/tests/test_warning_capture.py
@@ -2,7 +2,6 @@ import warnings
 import pytest
 
 
-main
 def api_v2():
     """Replacement for :func:`api_v1` that does not emit warnings."""
     return 1
@@ -13,4 +12,3 @@ def test_api_v2_no_warning():
         warnings.simplefilter("error")
         assert api_v2() == 1
         assert not captured
-main


### PR DESCRIPTION
## Summary
- remove stray `main` lines in `tests/test_warning_capture.py`

## Testing
- `pre-commit run --files tests/test_warning_capture.py`
- `pytest tests/test_warning_capture.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6863b585cbb4832da8ba8e931e54cea7