### PR TITLE
Centralize heavy module stubs for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,60 @@
+import os
+import sys
+import types
+
+import pytest
+
+# Ensure the project root is available before tests import project modules
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+
+def _stub_modules():
+    """Insert lightweight stubs for optional heavy dependencies."""
+    numba_mod = types.ModuleType("numba")
+    numba_mod.cuda = types.SimpleNamespace(is_available=lambda: False)
+    numba_mod.jit = lambda *a, **k: (lambda f: f)
+    numba_mod.prange = range
+    sys.modules.setdefault("numba", numba_mod)
+    sys.modules.setdefault("numba.cuda", numba_mod.cuda)
+
+    pybit_mod = types.ModuleType("pybit")
+    ut_mod = types.ModuleType("unified_trading")
+    ut_mod.HTTP = object
+    pybit_mod.unified_trading = ut_mod
+    sys.modules.setdefault("pybit", pybit_mod)
+    sys.modules.setdefault("pybit.unified_trading", ut_mod)
+
+    sys.modules.setdefault("httpx", types.ModuleType("httpx"))
+    telegram_error_mod = types.ModuleType("telegram.error")
+    telegram_error_mod.RetryAfter = Exception
+    sys.modules.setdefault("telegram", types.ModuleType("telegram"))
+    sys.modules.setdefault("telegram.error", telegram_error_mod)
+
+    psutil_mod = types.ModuleType("psutil")
+    psutil_mod.cpu_percent = lambda interval=1: 0
+    psutil_mod.virtual_memory = lambda: type("mem", (), {"percent": 0})
+    sys.modules.setdefault("psutil", psutil_mod)
+
+    sys.modules.setdefault("websockets", types.ModuleType("websockets"))
+
+    ray_mod = types.ModuleType("ray")
+    ray_mod.remote = lambda *a, **k: (lambda f: f)
+    ray_mod.get = lambda x: x
+    sys.modules.setdefault("ray", ray_mod)
+
+    tenacity_mod = types.ModuleType("tenacity")
+    tenacity_mod.retry = lambda *a, **k: (lambda f: f)
+    tenacity_mod.wait_exponential = lambda *a, **k: None
+    tenacity_mod.stop_after_attempt = lambda *a, **k: (lambda f: f)
+    sys.modules.setdefault("tenacity", tenacity_mod)
+
+_stub_modules()
+
+
+@pytest.fixture(autouse=True)
+def _add_root_and_stub_modules(monkeypatch):
+    """Ensure stubs exist for each test."""
+    _stub_modules()
+    yield

--- a/tests/test_data_handler.py
+++ b/tests/test_data_handler.py
@@ -1,44 +1,9 @@
 import os, sys
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import importlib
 import types
 import logging
 import pytest
 from config import BotConfig
-
-# Stub heavy dependencies before importing data_handler
-sys.modules.setdefault('websockets', types.ModuleType('websockets'))
-pybit_mod = types.ModuleType('pybit')
-ut_mod = types.ModuleType('unified_trading')
-ut_mod.HTTP = object
-pybit_mod.unified_trading = ut_mod
-sys.modules.setdefault('pybit', pybit_mod)
-sys.modules.setdefault('pybit.unified_trading', ut_mod)
-ray_mod = types.ModuleType('ray')
-ray_mod.remote = lambda *a, **k: (lambda f: f)
-sys.modules.setdefault('ray', ray_mod)
-tenacity_mod = types.ModuleType('tenacity')
-tenacity_mod.retry = lambda *a, **k: (lambda f: f)
-tenacity_mod.wait_exponential = lambda *a, **k: None
-tenacity_mod.stop_after_attempt = lambda *a, **k: (lambda f: f)
-sys.modules.setdefault('tenacity', tenacity_mod)
-psutil_mod = types.ModuleType('psutil')
-psutil_mod.cpu_percent = lambda interval=1: 0
-psutil_mod.virtual_memory = lambda: type('mem', (), {'percent': 0})
-sys.modules.setdefault('psutil', psutil_mod)
-sys.modules.setdefault('httpx', types.ModuleType('httpx'))
-telegram_error_mod = types.ModuleType('telegram.error')
-telegram_error_mod.RetryAfter = Exception
-sys.modules.setdefault('telegram', types.ModuleType('telegram'))
-sys.modules.setdefault('telegram.error', telegram_error_mod)
-numba_mod = types.ModuleType('numba')
-numba_mod.cuda = types.SimpleNamespace(is_available=lambda: False)
-numba_mod.jit = lambda *a, **k: (lambda f: f)
-numba_mod.prange = range
-import importlib.machinery
-numba_mod.__spec__ = importlib.machinery.ModuleSpec("numba", None)
-sys.modules.setdefault('numba', numba_mod)
-sys.modules.setdefault('numba.cuda', numba_mod.cuda)
 
 # Replace utils with a stub that overrides TelegramLogger
 real_utils = importlib.import_module('utils')

--- a/tests/test_indicators_gpu.py
+++ b/tests/test_indicators_gpu.py
@@ -1,7 +1,5 @@
 import os
 import sys
-
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import numpy as np
 import pandas as pd
 import ta
@@ -18,37 +16,6 @@ ccxt_mod.pro.bybit = object
 sys.modules.setdefault('ccxt', ccxt_mod)
 sys.modules.setdefault('ccxt.async_support', ccxt_mod.async_support)
 sys.modules.setdefault('ccxt.pro', ccxt_mod.pro)
-sys.modules.setdefault('websockets', types.ModuleType('websockets'))
-pybit_mod = types.ModuleType('pybit')
-ut_mod = types.ModuleType('unified_trading')
-ut_mod.HTTP = object
-pybit_mod.unified_trading = ut_mod
-sys.modules.setdefault('pybit', pybit_mod)
-sys.modules.setdefault('pybit.unified_trading', ut_mod)
-ray_mod = types.ModuleType('ray')
-ray_mod.remote = lambda *a, **k: (lambda f: f)
-sys.modules.setdefault('ray', ray_mod)
-tenacity_mod = types.ModuleType('tenacity')
-tenacity_mod.retry = lambda *a, **k: (lambda f: f)
-tenacity_mod.wait_exponential = lambda *a, **k: None
-tenacity_mod.stop_after_attempt = lambda *a, **k: (lambda f: f)
-sys.modules.setdefault('tenacity', tenacity_mod)
-psutil_mod = types.ModuleType('psutil')
-psutil_mod.cpu_percent = lambda interval=1: 0
-psutil_mod.virtual_memory = lambda: type('mem', (), {'percent': 0})
-sys.modules.setdefault('psutil', psutil_mod)
-sys.modules.setdefault('httpx', types.ModuleType('httpx'))
-telegram_error_mod = types.ModuleType('telegram.error')
-telegram_error_mod.RetryAfter = Exception
-sys.modules.setdefault('telegram', types.ModuleType('telegram'))
-sys.modules.setdefault('telegram.error', telegram_error_mod)
-if importlib.util.find_spec('numba') is None:
-    numba_mod = types.ModuleType('numba')
-    numba_mod.cuda = types.SimpleNamespace(is_available=lambda: False)
-    numba_mod.jit = lambda *a, **k: (lambda f: f)
-    numba_mod.prange = range
-    sys.modules.setdefault('numba', numba_mod)
-    sys.modules.setdefault('numba.cuda', numba_mod.cuda)
 
 from data_handler import ema_fast, atr_fast  # noqa: E402
 

--- a/tests/test_integration_services.py
+++ b/tests/test_integration_services.py
@@ -3,37 +3,10 @@ import time
 import requests
 import multiprocessing
 from flask import Flask, request, jsonify
-import sys
-import types
 import pytest
 
-# Ensure the project root is on the Python path so that 'trading_bot' can be imported
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-
-# Stub heavy dependencies before importing trading_bot
-numba_mod = types.ModuleType('numba')
-numba_mod.cuda = types.SimpleNamespace(is_available=lambda: False)
-numba_mod.jit = lambda *a, **k: (lambda f: f)
-numba_mod.prange = range
-sys.modules.setdefault('numba', numba_mod)
-sys.modules.setdefault('numba.cuda', numba_mod.cuda)
-sys.modules.setdefault('httpx', types.ModuleType('httpx'))
-telegram_error_mod = types.ModuleType('telegram.error')
-telegram_error_mod.RetryAfter = Exception
-sys.modules.setdefault('telegram', types.ModuleType('telegram'))
-sys.modules.setdefault('telegram.error', telegram_error_mod)
-pybit_mod = types.ModuleType('pybit')
-ut_mod = types.ModuleType('unified_trading')
-ut_mod.HTTP = object
-pybit_mod.unified_trading = ut_mod
-sys.modules.setdefault('pybit', pybit_mod)
-sys.modules.setdefault('pybit.unified_trading', ut_mod)
-psutil_mod = types.ModuleType('psutil')
-psutil_mod.cpu_percent = lambda interval=1: 0
-psutil_mod.virtual_memory = lambda: type('mem', (), {'percent': 0})
-sys.modules.setdefault('psutil', psutil_mod)
-
 import trading_bot  # noqa: E402
+
 
 
 # Minimal stubs for services to avoid heavy dependencies

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -1,8 +1,6 @@
 import os
 import sys
 
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-import asyncio
 import numpy as np
 import pandas as pd
 import types

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -14,10 +14,6 @@ if 'torch' not in sys.modules:
     torch.__spec__ = importlib.machinery.ModuleSpec('torch', None)
     sys.modules['torch'] = torch
 
-ray_mod = types.ModuleType('ray')
-ray_mod.remote = lambda *a, **k: (lambda f: f)
-ray_mod.get = lambda x: x
-sys.modules.setdefault('ray', ray_mod)
 
 sk_mod = types.ModuleType('sklearn')
 model_sel = types.ModuleType('sklearn.model_selection')
@@ -38,21 +34,10 @@ optuna_samplers.TPESampler = object
 optuna_mod.samplers = optuna_samplers
 sys.modules.setdefault('optuna', optuna_mod)
 sys.modules.setdefault('optuna.samplers', optuna_samplers)
-sys.modules.setdefault('httpx', types.ModuleType('httpx'))
-telegram_error_mod = types.ModuleType('telegram.error')
-telegram_error_mod.RetryAfter = Exception
-sys.modules.setdefault('telegram', types.ModuleType('telegram'))
-sys.modules.setdefault('telegram.error', telegram_error_mod)
-psutil_mod = types.ModuleType('psutil')
-psutil_mod.cpu_percent = lambda interval=1: 0
-psutil_mod.virtual_memory = lambda: type('mem', (), {'percent': 0})
-sys.modules.setdefault('psutil', psutil_mod)
 
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from optimizer import ParameterOptimizer  # noqa: E402
 
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 utils = types.ModuleType('utils')
 utils.logger = logging.getLogger('test')

--- a/tests/test_optimizer_ray.py
+++ b/tests/test_optimizer_ray.py
@@ -16,10 +16,6 @@ if 'torch' not in sys.modules:
     torch.__spec__ = importlib.machinery.ModuleSpec('torch', None)
     sys.modules['torch'] = torch
 
-ray_mod = types.ModuleType('ray')
-ray_mod.remote = lambda *a, **k: (lambda f: f)
-ray_mod.get = lambda x: x
-sys.modules.setdefault('ray', ray_mod)
 
 sk_mod = types.ModuleType('sklearn')
 model_sel = types.ModuleType('sklearn.model_selection')
@@ -40,29 +36,13 @@ optuna_samplers.TPESampler = object
 optuna_mod.samplers = optuna_samplers
 sys.modules.setdefault('optuna', optuna_mod)
 sys.modules.setdefault('optuna.samplers', optuna_samplers)
-sys.modules.setdefault('httpx', types.ModuleType('httpx'))
-telegram_error_mod = types.ModuleType('telegram.error')
-telegram_error_mod.RetryAfter = Exception
-sys.modules.setdefault('telegram', types.ModuleType('telegram'))
-sys.modules.setdefault('telegram.error', telegram_error_mod)
-psutil_mod = types.ModuleType('psutil')
-psutil_mod.cpu_percent = lambda interval=1: 0
-psutil_mod.virtual_memory = lambda: type('mem', (), {'percent': 0})
-sys.modules.setdefault('psutil', psutil_mod)
 
 from optimizer import ParameterOptimizer  # noqa: E402
 
-numba_mod = types.ModuleType('numba')
-numba_mod.cuda = types.SimpleNamespace(is_available=lambda: False)
-numba_mod.jit = lambda *a, **k: (lambda f: f)
-numba_mod.prange = range
-sys.modules.setdefault('numba', numba_mod)
-sys.modules.setdefault('numba.cuda', numba_mod.cuda)
 
 # ensure real optuna
 
 
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 
 class DummyDataHandler:

--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -12,10 +12,6 @@ if 'torch' not in sys.modules:
     torch.cuda = types.SimpleNamespace(is_available=lambda: False)
     sys.modules['torch'] = torch
 
-ray_mod = types.ModuleType('ray')
-ray_mod.remote = lambda *a, **k: (lambda f: f)
-ray_mod.get = lambda x: x
-sys.modules.setdefault('ray', ray_mod)
 
 sk_mod = types.ModuleType('sklearn')
 model_sel = types.ModuleType('sklearn.model_selection')
@@ -44,24 +40,10 @@ utils_stub.check_dataframe_empty = _cde_stub
 sys.modules['utils'] = utils_stub
 os.environ["TEST_MODE"] = "1"
 sys.modules.pop('trade_manager', None)
-tenacity_mod = types.ModuleType('tenacity')
-tenacity_mod.retry = lambda *a, **k: (lambda f: f)
-tenacity_mod.wait_exponential = lambda *a, **k: None
-tenacity_mod.stop_after_attempt = lambda *a, **k: None
-sys.modules.setdefault('tenacity', tenacity_mod)
 joblib_mod = types.ModuleType('joblib')
 joblib_mod.dump = lambda *a, **k: None
 joblib_mod.load = lambda *a, **k: {}
 sys.modules.setdefault('joblib', joblib_mod)
-sys.modules.setdefault('httpx', types.ModuleType('httpx'))
-telegram_error_mod = types.ModuleType('telegram.error')
-telegram_error_mod.RetryAfter = Exception
-sys.modules.setdefault('telegram', types.ModuleType('telegram'))
-sys.modules.setdefault('telegram.error', telegram_error_mod)
-psutil_mod = types.ModuleType('psutil')
-psutil_mod.cpu_percent = lambda interval=1: 0
-psutil_mod.virtual_memory = lambda: type('mem', (), {'percent': 0})
-sys.modules.setdefault('psutil', psutil_mod)
 
 import trade_manager
 from trade_manager import TradeManager  # noqa: E402
@@ -91,7 +73,6 @@ async def _cde(*a, **kw):
 utils.check_dataframe_empty = _cde
 sys.modules['utils'] = utils
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 class DummyExchange:
     def __init__(self):

--- a/tests/test_trading_bot.py
+++ b/tests/test_trading_bot.py
@@ -1,33 +1,3 @@
-import os
-import sys
-import types
-
-# Ensure the project root is on the Python path so that 'trading_bot' can be imported
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-
-# Stub heavy dependencies before importing trading_bot
-numba_mod = types.ModuleType('numba')
-numba_mod.cuda = types.SimpleNamespace(is_available=lambda: False)
-numba_mod.jit = lambda *a, **k: (lambda f: f)
-numba_mod.prange = range
-sys.modules.setdefault('numba', numba_mod)
-sys.modules.setdefault('numba.cuda', numba_mod.cuda)
-sys.modules.setdefault('httpx', types.ModuleType('httpx'))
-telegram_error_mod = types.ModuleType('telegram.error')
-telegram_error_mod.RetryAfter = Exception
-sys.modules.setdefault('telegram', types.ModuleType('telegram'))
-sys.modules.setdefault('telegram.error', telegram_error_mod)
-pybit_mod = types.ModuleType('pybit')
-ut_mod = types.ModuleType('unified_trading')
-ut_mod.HTTP = object
-pybit_mod.unified_trading = ut_mod
-sys.modules.setdefault('pybit', pybit_mod)
-sys.modules.setdefault('pybit.unified_trading', ut_mod)
-psutil_mod = types.ModuleType('psutil')
-psutil_mod.cpu_percent = lambda interval=1: 0
-psutil_mod.virtual_memory = lambda: type('mem', (), {'percent': 0})
-sys.modules.setdefault('psutil', psutil_mod)
-
 import trading_bot
 
 


### PR DESCRIPTION
## Summary
- create `tests/conftest.py` with fixture to stub heavy modules
- remove per-test path tweaks and stubs in unit tests

## Testing
- `pip install numpy pandas requests flask ta optuna`
- `pip install scipy python-dotenv`
- `pip install pytest-asyncio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863c8a5f978832d85d9260538d7914b