### PR TITLE
Fix missing asyncio import in test_model_builder

### DIFF
--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -7,6 +7,7 @@ import types
 import pytest
 import importlib.util
 from config import BotConfig
+import asyncio
 
 if importlib.util.find_spec('torch') is None:
     pytest.skip('torch not available', allow_module_level=True)


### PR DESCRIPTION
## Summary
- include missing `asyncio` import in `tests/test_model_builder.py`

## Testing
- `flake8 tests/test_model_builder.py`

------
https://chatgpt.com/codex/tasks/task_e_6863cf2d25f0832db50aa4b86af6dd62