### PR TITLE
Instantiate ParameterOptimizer in DataHandler

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -26,6 +26,7 @@ import pickle
 import psutil
 import ray
 from flask import Flask, jsonify
+from optimizer import ParameterOptimizer
 
 if TYPE_CHECKING:  # pragma: no cover - for type checkers only
     import ccxtpro
@@ -214,6 +215,7 @@ class DataHandler:
         self.load_threshold = 0.8
         self.ws_pool = {}
         self.tasks = []
+        self.parameter_optimizer = ParameterOptimizer(self.config, self)
 
     async def get_atr(self, symbol: str) -> float:
         """Return the latest ATR value for a symbol, recalculating if missing."""


### PR DESCRIPTION
## Summary
- import `ParameterOptimizer`
- create `self.parameter_optimizer` in `DataHandler.__init__`

## Testing
- `pre-commit run --files data_handler.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'optuna_integration', 'gymnasium')*

------
https://chatgpt.com/codex/tasks/task_e_686419edaec4832d8d66e559bb1f556c