### PR TITLE
Suppress optuna ExperimentalWarning in optimizer ray test

### DIFF
--- a/tests/test_optimizer_ray.py
+++ b/tests/test_optimizer_ray.py
@@ -37,6 +37,18 @@ optuna_mod.samplers = optuna_samplers
 sys.modules.setdefault('optuna', optuna_mod)
 sys.modules.setdefault('optuna.samplers', optuna_samplers)
 
+scipy_mod = types.ModuleType('scipy')
+stats_mod = types.ModuleType('scipy.stats')
+stats_mod.zscore = lambda a, axis=0: (a - a.mean()) / a.std()
+scipy_mod.__version__ = "1.0"
+scipy_mod.stats = stats_mod
+sys.modules.setdefault('scipy', scipy_mod)
+sys.modules.setdefault('scipy.stats', stats_mod)
+
+import builtins
+from optuna.exceptions import ExperimentalWarning as _OptunaExperimentalWarning
+builtins.ExperimentalWarning = _OptunaExperimentalWarning
+
 from optimizer import ParameterOptimizer  # noqa: E402
 
 
@@ -64,6 +76,7 @@ def make_df():
     return df.set_index(['symbol', df.index])
 
 
+@pytest.mark.filterwarnings("ignore:.*multivariate.*:ExperimentalWarning")
 @pytest.mark.asyncio
 async def test_optimize_returns_params():
     df = make_df()


### PR DESCRIPTION
## Summary
- stub scipy ExperimentalWarning for optuna
- silence multivariate ExperimentalWarning in `test_optimize_returns_params`

## Testing
- `pytest tests/test_optimizer_ray.py::test_optimize_returns_params -q`

------
https://chatgpt.com/codex/tasks/task_e_686421e32bb4832dadeb5563c26ddc45