### PR TITLE
Fix runtime warning in optimizer objective

### DIFF
--- a/optimizer.py
+++ b/optimizer.py
@@ -78,7 +78,7 @@ def _objective_remote(
                     },
                     test_df["close"].pct_change().std(),
                 )
-            result = asyncio.run(_check_df_async(indicators.df, f"objective {symbol}"))
+            result = check_dataframe_empty(indicators.df, f"objective {symbol}")
             if not indicators or result:
                 return 0.0
             returns = []


### PR DESCRIPTION
## Summary
- avoid `asyncio.run` inside `_objective_remote` to prevent unawaited coroutine warning

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686435b0e324832d9a7ae76fa4cf37cd