### PR TITLE
Switch services to gunicorn

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       dockerfile: ${DOCKERFILE:-Dockerfile}
-    command: python data_handler.py
+    command: gunicorn -w 2 -b 0.0.0.0:8000 data_handler:api_app
     runtime: nvidia
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/ping"]
@@ -19,7 +19,7 @@ services:
     build:
       context: .
       dockerfile: ${DOCKERFILE:-Dockerfile}
-    command: python model_builder.py
+    command: gunicorn -w 2 -b 0.0.0.0:8001 model_builder:api_app
     runtime: nvidia
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8001/ping"]
@@ -33,7 +33,7 @@ services:
     build:
       context: .
       dockerfile: ${DOCKERFILE:-Dockerfile}
-    command: python trade_manager.py
+    command: gunicorn -w 2 -b 0.0.0.0:8002 trade_manager:api_app
     runtime: nvidia
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8002/ping"]

--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -36,3 +36,5 @@ flask>=3.0.2
 requests>=2.31.0
 pybit>=5.11.0
 flake8>=7.3.0
+gunicorn>=21.2.0
+httpx>=0.27.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,5 @@ flask>=3.0.2
 requests>=2.31.0
 pybit>=5.11.0
 flake8>=7.3.0
+gunicorn>=21.2.0
+httpx>=0.27.0


### PR DESCRIPTION
## Summary
- run `data_handler`, `model_builder`, and `trade_manager` with gunicorn in docker-compose
- add gunicorn and httpx to dependency lists

## Testing
- `pytest -q`
- `gunicorn -w 2 -b 127.0.0.1:8000 data_handler:api_app` and `curl -s http://127.0.0.1:8000/ping`

------
https://chatgpt.com/codex/tasks/task_e_68643a9985c8832da6368f21a267306f