### PR TITLE
Set TF_CPP_MIN_LOG_LEVEL in Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       context: .
       dockerfile: ${DOCKERFILE:-Dockerfile}
     command: python model_builder.py
+    environment:
+      - TF_CPP_MIN_LOG_LEVEL=2
     runtime: nvidia
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8001/ping"]


### PR DESCRIPTION
## Summary
- silence verbose TensorFlow logging by setting `TF_CPP_MIN_LOG_LEVEL=2` for the `model_builder` service in `docker-compose.yml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68643a5a8060832d96cefe81a418fff1