### PR TITLE
Add TF log level variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       dockerfile: ${DOCKERFILE:-Dockerfile}
     command: gunicorn -w 2 -b 0.0.0.0:8001 model_builder:api_app
     runtime: nvidia
+    environment:
+      - TF_CPP_MIN_LOG_LEVEL=2
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8001/ping"]
       interval: 5s


### PR DESCRIPTION
## Summary
- silence TensorFlow `cu* factory` warnings by setting `TF_CPP_MIN_LOG_LEVEL=2` for the model builder service

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas numpy requests`
- `pytest -q tests/test_import_order.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68643d11c504832d992d5b8d4e9fae83