### PR TITLE
Avoid zero division in optimizer interval

### DIFF
--- a/optimizer.py
+++ b/optimizer.py
@@ -150,8 +150,9 @@ class ParameterOptimizer:
     def get_opt_interval(self, symbol: str, volatility: float) -> float:
         """Return optimization interval for a symbol based on its volatility."""
         try:
+            threshold = max(self.volatility_threshold, 1e-6)
             interval = self.base_optimization_interval / (
-                1 + volatility / self.volatility_threshold
+                1 + volatility / threshold
             )
             interval = max(1800, min(self.base_optimization_interval * 2, interval))
             return interval

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -74,3 +74,10 @@ def test_get_opt_interval(vol, expected):
     max_int = max(1800, min(opt.base_optimization_interval * 2, expected))
     assert interval == pytest.approx(max_int)
 
+
+def test_get_opt_interval_zero_threshold():
+    cfg = BotConfig(optimization_interval=7200, volatility_threshold=0)
+    opt_zero = ParameterOptimizer(cfg, data_handler)
+    interval = opt_zero.get_opt_interval("BTCUSDT", 0.01)
+    assert interval >= 1800
+


### PR DESCRIPTION
## Summary
- guard against zero `volatility_threshold` in `get_opt_interval`
- test optimizer interval with zero threshold

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864fa80df10832d905fcab728820884