### PR TITLE
Fix risk calculation with zero threshold

### DIFF
--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -286,3 +286,17 @@ def test_is_data_fresh():
     assert asyncio.run(fresh_dh.is_data_fresh('BTCUSDT')) is True
     assert asyncio.run(stale_dh.is_data_fresh('BTCUSDT')) is False
 
+
+def test_compute_risk_per_trade_zero_threshold():
+    cfg = make_config()
+    cfg.update({'volatility_threshold': 0})
+    dh = DummyDataHandler()
+    tm = TradeManager(cfg, dh, None, None, None)
+
+    async def run():
+        return await tm.compute_risk_per_trade('BTCUSDT', 0.01)
+
+    import asyncio
+    risk = asyncio.run(run())
+    assert tm.min_risk_per_trade <= risk <= tm.max_risk_per_trade
+

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -125,7 +125,8 @@ class TradeManager:
             base_risk *= 0.5
         elif sharpe > 1:
             base_risk *= 1.5
-        vol_coeff = volatility / self.config.get("volatility_threshold", 0.02)
+        threshold = max(self.config.get("volatility_threshold", 0.02), 1e-6)
+        vol_coeff = volatility / threshold
         base_risk *= max(0.5, min(2.0, vol_coeff))
         return min(self.max_risk_per_trade, max(self.min_risk_per_trade, base_risk))
 


### PR DESCRIPTION
## Summary
- protect against division by zero in `TradeManager.compute_risk_per_trade`
- test risk calculation when volatility threshold is zero

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68651a682838832d9036637630841b7e