### PR TITLE
Fix optimization interval when volatility threshold is zero

### DIFF
--- a/optimizer.py
+++ b/optimizer.py
@@ -181,8 +181,9 @@ class ParameterOptimizer:
                 volatility - self.last_volatility.get(symbol, 0.0)
             ) / max(self.last_volatility.get(symbol, 0.01), 0.01)
             self.last_volatility[symbol] = volatility
+            threshold = max(self.volatility_threshold, 1e-6)
             optimization_interval = self.base_optimization_interval / (
-                1 + volatility / self.volatility_threshold
+                1 + volatility / threshold
             )
             optimization_interval = max(
                 1800, min(self.base_optimization_interval * 2, optimization_interval)

--- a/tests/test_optimizer_ray.py
+++ b/tests/test_optimizer_ray.py
@@ -101,3 +101,30 @@ async def test_optimize_returns_params():
     params = await opt.optimize('BTCUSDT')
     assert isinstance(params, dict)
     assert 'ema30_period' in params
+
+
+@pytest.mark.filterwarnings("ignore:.*multivariate.*:ExperimentalWarning")
+@pytest.mark.asyncio
+async def test_optimize_zero_vol_threshold():
+    df = make_df()
+    config = BotConfig(
+        timeframe='1m',
+        optuna_trials=1,
+        optimization_interval=1,
+        volatility_threshold=0,
+        ema30_period=30,
+        ema100_period=100,
+        ema200_period=200,
+        atr_period_default=14,
+        tp_multiplier=2.0,
+        sl_multiplier=1.0,
+        base_probability_threshold=0.5,
+        loss_streak_threshold=2,
+        win_streak_threshold=2,
+        threshold_adjustment=0.05,
+        mlflow_enabled=False,
+    )
+    opt = ParameterOptimizer(config, DummyDataHandler(df))
+    params = await opt.optimize('BTCUSDT')
+    assert isinstance(params, dict)
+    assert 'ema30_period' in params


### PR DESCRIPTION
## Summary
- guard against zero `volatility_threshold` in `ParameterOptimizer.optimize`
- add regression test for `volatility_threshold=0`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865225d7ddc832db646e9b25fc54b1d