### PR TITLE
Adjust ws_rate_limit logic

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -818,7 +818,8 @@ class DataHandler:
                         await ws.send(
                             json.dumps({"op": "subscribe", "args": [f"kline.{selected_timeframe}.{ws_symbol}"]})
                         )
-                        await asyncio.sleep(max(0, 1 / self.config["ws_rate_limit"]))
+                        rate = max(self.config.get("ws_rate_limit", 1), 1)
+                        await asyncio.sleep(1 / rate)
 
                 confirmations_needed = len(symbols)
                 confirmations = 0

--- a/tests/test_data_handler.py
+++ b/tests/test_data_handler.py
@@ -40,3 +40,21 @@ async def test_select_liquid_pairs_plain_symbol_included():
     }
     pairs = await dh.select_liquid_pairs(markets)
     assert 'BTCUSDT' in pairs
+
+
+class DummyWS:
+    def __init__(self):
+        self.sent = []
+    async def send(self, message):
+        self.sent.append(message)
+    async def recv(self):
+        return '{"success": true}'
+
+
+@pytest.mark.asyncio
+async def test_ws_rate_limit_zero_no_exception():
+    cfg = BotConfig(cache_dir='/tmp', ws_rate_limit=0)
+    dh = DataHandler(cfg, None, None, exchange=DummyExchange({'BTCUSDT': 1.0}))
+    ws = DummyWS()
+    await dh._send_subscriptions(ws, ['BTCUSDT'], 'primary')
+    assert ws.sent


### PR DESCRIPTION
## Summary
- protect against zero `ws_rate_limit` in websocket subscription logic
- add regression test for `ws_rate_limit=0`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865250eba30832db1b646a35245d605