### PR TITLE
Fix incorrect ray remote decorator

### DIFF
--- a/model_builder.py
+++ b/model_builder.py
@@ -256,7 +256,7 @@ def _train_model_lightning(X, y, batch_size, model_type):
     return net.state_dict(), preds, labels
 
 
-@ray.remote()
+@ray.remote
 def _train_model_remote(X, y, batch_size, model_type="cnn_lstm", framework="pytorch"):
     if framework in {"keras", "tensorflow"}:
         return _train_model_keras(X, y, batch_size, model_type)


### PR DESCRIPTION
## Summary
- fix `@ray.remote` usage so model_builder loads

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686592e49f1c832d8872a4a9a6d2e2c1