### PR TITLE
Remove unused CONFIG variable

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -4,14 +4,12 @@ import asyncio
 import requests
 from dotenv import load_dotenv
 from utils import logger
-from config import load_config, BotConfig
 from tenacity import retry, wait_exponential, stop_after_attempt
 
 
 # Default trading symbol. Override with the SYMBOL environment variable.
 SYMBOL = os.getenv("SYMBOL", "BTCUSDT")
 INTERVAL = float(os.getenv("INTERVAL", "5"))
-CONFIG: BotConfig = load_config("config.json")
 
 
 def _load_env() -> dict:


### PR DESCRIPTION
## Summary
- drop unused `CONFIG` variable from `trading_bot.py`

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686623f869a4832d9d1e94951469fd00