### PR TITLE
Fix async Ray get

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -527,14 +527,22 @@ class DataHandler:
             if timeframe == "primary":
                 async with self.ohlcv_lock:
                     if cache_key not in self.indicators_cache:
-                        obj_ref = calc_indicators.remote(df.droplevel("symbol"), self.config, volatility, "primary")
-                        self.indicators_cache[cache_key] = ray.get(obj_ref)
+                        obj_ref = calc_indicators.remote(
+                            df.droplevel("symbol"), self.config, volatility, "primary"
+                        )
+                        self.indicators_cache[cache_key] = await asyncio.to_thread(
+                            ray.get, obj_ref
+                        )
                     self.indicators[symbol] = self.indicators_cache[cache_key]
             else:
                 async with self.ohlcv_2h_lock:
                     if cache_key not in self.indicators_cache_2h:
-                        obj_ref = calc_indicators.remote(df.droplevel("symbol"), self.config, volatility, "secondary")
-                        self.indicators_cache_2h[cache_key] = ray.get(obj_ref)
+                        obj_ref = calc_indicators.remote(
+                            df.droplevel("symbol"), self.config, volatility, "secondary"
+                        )
+                        self.indicators_cache_2h[cache_key] = await asyncio.to_thread(
+                            ray.get, obj_ref
+                        )
                     self.indicators_2h[symbol] = self.indicators_cache_2h[cache_key]
             self.cache.save_cached_data(f"{timeframe}_{symbol}", timeframe, df)
         except Exception as e:

--- a/optimizer.py
+++ b/optimizer.py
@@ -220,7 +220,9 @@ class ParameterOptimizer:
                 trial = study.ask()
                 obj_refs.append(self.objective(trial, symbol, df))
                 trials.append(trial)
-            results = ray.get(obj_refs)
+            results = await asyncio.gather(
+                *[asyncio.to_thread(ray.get, ref) for ref in obj_refs]
+            )
             for trial, value in zip(trials, results):
                 study.tell(trial, value)
                 for cb in callbacks:


### PR DESCRIPTION
## Summary
- use non-blocking `ray.get` in data sync and optimization routines

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6866291eab48832db3e17bd19d97b21d