### PR TITLE
Use non-blocking Ray awaits

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -530,9 +530,7 @@ class DataHandler:
                         obj_ref = calc_indicators.remote(
                             df.droplevel("symbol"), self.config, volatility, "primary"
                         )
-                        self.indicators_cache[cache_key] = await asyncio.to_thread(
-                            ray.get, obj_ref
-                        )
+                        self.indicators_cache[cache_key] = await obj_ref
                     self.indicators[symbol] = self.indicators_cache[cache_key]
             else:
                 async with self.ohlcv_2h_lock:
@@ -540,9 +538,7 @@ class DataHandler:
                         obj_ref = calc_indicators.remote(
                             df.droplevel("symbol"), self.config, volatility, "secondary"
                         )
-                        self.indicators_cache_2h[cache_key] = await asyncio.to_thread(
-                            ray.get, obj_ref
-                        )
+                        self.indicators_cache_2h[cache_key] = await obj_ref
                     self.indicators_2h[symbol] = self.indicators_cache_2h[cache_key]
             self.cache.save_cached_data(f"{timeframe}_{symbol}", timeframe, df)
         except Exception as e:

--- a/optimizer.py
+++ b/optimizer.py
@@ -220,9 +220,7 @@ class ParameterOptimizer:
                 trial = study.ask()
                 obj_refs.append(self.objective(trial, symbol, df))
                 trials.append(trial)
-            results = await asyncio.gather(
-                *[asyncio.to_thread(ray.get, ref) for ref in obj_refs]
-            )
+            results = await asyncio.gather(*obj_refs)
             for trial, value in zip(trials, results):
                 study.tell(trial, value)
                 for cb in callbacks:


### PR DESCRIPTION
## Summary
- await Ray tasks to avoid blocking the event loop

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866532ccfbc832dbf3c91dbbef2861c