### PR TITLE
Make mlflow optional

### DIFF
--- a/model_builder.py
+++ b/model_builder.py
@@ -18,7 +18,11 @@ from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import brier_score_loss
 from sklearn.calibration import calibration_curve
 import joblib
-import mlflow
+try:
+    import mlflow
+except Exception as e:  # pragma: no cover - optional dependency
+    mlflow = None  # type: ignore
+    logger.warning("mlflow import failed: %s", e)
 
 # Delay heavy SHAP import until needed to avoid CUDA warnings at startup
 shap = None
@@ -563,7 +567,7 @@ class ModelBuilder:
             'prob_true': prob_true.tolist(),
             'prob_pred': prob_pred.tolist()
         }
-        if self.config.get("mlflow_enabled", False):
+        if self.config.get("mlflow_enabled", False) and mlflow is not None:
             mlflow.set_tracking_uri(self.config.get("mlflow_tracking_uri", "mlruns"))
             with mlflow.start_run(run_name=f"{symbol}_retrain"):
                 mlflow.log_params({

--- a/tests/test_model_builder_import.py
+++ b/tests/test_model_builder_import.py
@@ -26,3 +26,29 @@ def test_model_builder_requires_gymnasium(monkeypatch):
     monkeypatch.setitem(sys.modules, 'gymnasium', None)
     with pytest.raises(ImportError, match='gymnasium package is required'):
         importlib.import_module('model_builder')
+
+
+def test_model_builder_imports_without_mlflow(monkeypatch):
+    sys.modules.pop('model_builder', None)
+    sys.modules.pop('utils', None)
+    if 'torch' not in sys.modules:
+        torch_stub = types.ModuleType('torch')
+        nn_stub = types.ModuleType('torch.nn')
+        utils_stub = types.ModuleType('torch.utils')
+        data_stub = types.ModuleType('torch.utils.data')
+        data_stub.DataLoader = object()
+        data_stub.TensorDataset = object()
+        nn_stub.Module = object
+        torch_stub.nn = nn_stub
+        torch_stub.utils = utils_stub
+        utils_stub.data = data_stub
+        sys.modules['torch'] = torch_stub
+        sys.modules['torch.nn'] = nn_stub
+        sys.modules['torch.utils'] = utils_stub
+        sys.modules['torch.utils.data'] = data_stub
+    gym_stub = types.ModuleType('gymnasium')
+    gym_stub.Env = object
+    gym_stub.spaces = types.ModuleType('spaces')
+    monkeypatch.setitem(sys.modules, 'gymnasium', gym_stub)
+    monkeypatch.setitem(sys.modules, 'mlflow', None)
+    importlib.import_module('model_builder')


### PR DESCRIPTION
## Summary
- allow using `model_builder` without mlflow installed
- test that model_builder can be imported when mlflow is missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68665ed9d1b8832da1007a7581734d93