### PR TITLE
Add Pylint config for 180-char lines

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[FORMAT]
+max-line-length=180


### PR DESCRIPTION
## Summary
- configure Pylint to allow 180-character lines

## Testing
- `pytest -q`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_6866c78242a4832dadb3440e26c4482a