### PR TITLE
Adjust TensorFlow log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@
 DOCKERFILE=Dockerfile.cpu NVIDIA_VISIBLE_DEVICES= NVIDIA_DRIVER_CAPABILITIES= docker-compose up --build
 ```
 
+The `model_builder` service sets `TF_CPP_MIN_LOG_LEVEL=3` to hide verbose TensorFlow
+GPU warnings. Adjust or remove this variable if you need more detailed logs.
+
 ## Docker Compose logs
 
 Просмотреть вывод контейнеров можно через `docker compose logs` (или

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     command: gunicorn -w 2 -b 0.0.0.0:8001 model_builder:api_app
     runtime: nvidia
     environment:
-      - TF_CPP_MIN_LOG_LEVEL=2
+      - TF_CPP_MIN_LOG_LEVEL=3
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8001/ping"]
       interval: 5s

--- a/model_builder.py
+++ b/model_builder.py
@@ -164,6 +164,10 @@ def _get_torch_modules():
     return _torch_modules
 
 
+# Reduce verbose TensorFlow logs before any TF import
+os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
+
+
 def _train_model_keras(X, y, batch_size, model_type):
     import tensorflow as tf
     from tensorflow import keras


### PR DESCRIPTION
## Summary
- silence TensorFlow's verbose messages in model_builder.py
- match docker-compose to use TF_CPP_MIN_LOG_LEVEL=3
- document the setting under Docker Compose usage

## Testing
- `pytest -q` *(fails: No module named 'scipy')*

------
https://chatgpt.com/codex/tasks/task_e_6866f61cc4c8832d964c38eadf0a4ded