### PR TITLE
Remove unused pytest import

### DIFF
--- a/tests/test_warning_capture.py
+++ b/tests/test_warning_capture.py
@@ -1,5 +1,4 @@
 import warnings
-import pytest
 
 
 def api_v2():


### PR DESCRIPTION
## Summary
- delete unused pytest import from warning capture test

## Testing
- `pytest tests/test_warning_capture.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6867d48e7e18832dbd1481cac1d7f3c0