### PR TITLE
Initialize Ray at trade manager startup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,8 +57,15 @@ def _stub_modules():
         return _RayRemoteFunction(func)
 
     ray_mod = types.ModuleType("ray")
+    _ray_state = {"initialized": False}
+    def _init(*a, **k):
+        _ray_state["initialized"] = True
+    def _is_initialized():
+        return _ray_state["initialized"]
     ray_mod.remote = _ray_remote
     ray_mod.get = lambda x: x
+    ray_mod.init = _init
+    ray_mod.is_initialized = _is_initialized
     sys.modules.setdefault("ray", ray_mod)
 
     tenacity_mod = types.ModuleType("tenacity")

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -5,6 +5,7 @@ notifications while interacting with the :class:`ModelBuilder` and exchange.
 """
 
 import asyncio
+import ray
 import pandas as pd
 import numpy as np
 from tenacity import retry, wait_exponential, stop_after_attempt
@@ -1052,6 +1053,8 @@ def create_trade_manager() -> TradeManager:
     global trade_manager
     if trade_manager is None:
         cfg = load_config("config.json")
+        if not ray.is_initialized():
+            ray.init(num_cpus=cfg["ray_num_cpus"], ignore_reinit_error=True)
         token = os.environ.get("TELEGRAM_BOT_TOKEN")
         chat_id = os.environ.get("TELEGRAM_CHAT_ID")
         telegram_bot = None


### PR DESCRIPTION
## Summary
- import `ray` in `trade_manager.py`
- initialize Ray when creating the trade manager
- extend test stubs to include `ray.init` and `ray.is_initialized`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867e9240bcc832dbaddc84860e386db