### PR TITLE
Fix Ray result retrieval

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -538,7 +538,7 @@ class DataHandler:
                         obj_ref = calc_indicators.remote(
                             df.droplevel("symbol"), self.config, volatility, "primary"
                         )
-                        self.indicators_cache[cache_key] = await obj_ref
+                        self.indicators_cache[cache_key] = ray.get(obj_ref)
                     self.indicators[symbol] = self.indicators_cache[cache_key]
             else:
                 async with self.ohlcv_2h_lock:
@@ -546,7 +546,7 @@ class DataHandler:
                         obj_ref = calc_indicators.remote(
                             df.droplevel("symbol"), self.config, volatility, "secondary"
                         )
-                        self.indicators_cache_2h[cache_key] = await obj_ref
+                        self.indicators_cache_2h[cache_key] = ray.get(obj_ref)
                     self.indicators_2h[symbol] = self.indicators_cache_2h[cache_key]
             self.cache.save_cached_data(f"{timeframe}_{symbol}", timeframe, df)
         except (KeyError, ValueError, TypeError) as e:

--- a/model_builder.py
+++ b/model_builder.py
@@ -527,8 +527,14 @@ class ModelBuilder:
             torch_mods = _get_torch_modules()
             torch = torch_mods['torch']
             train_task = _train_model_remote.options(num_gpus=1 if torch.cuda.is_available() else 0)
-        model_state, val_preds, val_labels = await train_task.remote(
-            X, y, self.config['lstm_batch_size'], self.model_type, self.nn_framework
+        model_state, val_preds, val_labels = ray.get(
+            train_task.remote(
+                X,
+                y,
+                self.config['lstm_batch_size'],
+                self.model_type,
+                self.nn_framework,
+            )
         )
         if self.nn_framework in {'keras', 'tensorflow'}:
             import tensorflow as tf


### PR DESCRIPTION
## Summary
- use `ray.get` after `ray.init` in `synchronize_and_update`
- consistently fetch remote results with `ray.get`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867ea49839c832dbfeb3d505f96e3fe