### PR TITLE
Enhance logging around remote tasks

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -542,18 +542,36 @@ class DataHandler:
             if timeframe == "primary":
                 async with self.ohlcv_lock:
                     if cache_key not in self.indicators_cache:
+                        logger.debug(
+                            "Dispatching calc_indicators for %s %s", symbol, timeframe
+                        )
                         obj_ref = calc_indicators.remote(
                             df.droplevel("symbol"), self.config, volatility, "primary"
                         )
                         self.indicators_cache[cache_key] = ray.get(obj_ref)
+                        logger.debug(
+                            "calc_indicators completed for %s %s (key=%s)",
+                            symbol,
+                            timeframe,
+                            cache_key,
+                        )
                     self.indicators[symbol] = self.indicators_cache[cache_key]
             else:
                 async with self.ohlcv_2h_lock:
                     if cache_key not in self.indicators_cache_2h:
+                        logger.debug(
+                            "Dispatching calc_indicators for %s %s", symbol, timeframe
+                        )
                         obj_ref = calc_indicators.remote(
                             df.droplevel("symbol"), self.config, volatility, "secondary"
                         )
                         self.indicators_cache_2h[cache_key] = ray.get(obj_ref)
+                        logger.debug(
+                            "calc_indicators completed for %s %s (key=%s)",
+                            symbol,
+                            timeframe,
+                            cache_key,
+                        )
                     self.indicators_2h[symbol] = self.indicators_cache_2h[cache_key]
             self.cache.save_cached_data(f"{timeframe}_{symbol}", timeframe, df)
         except (KeyError, ValueError, TypeError) as e:

--- a/model_builder.py
+++ b/model_builder.py
@@ -534,6 +534,7 @@ class ModelBuilder:
             torch_mods = _get_torch_modules()
             torch = torch_mods['torch']
             train_task = _train_model_remote.options(num_gpus=1 if torch.cuda.is_available() else 0)
+        logger.debug("Dispatching _train_model_remote for %s", symbol)
         model_state, val_preds, val_labels = ray.get(
             train_task.remote(
                 X,
@@ -543,6 +544,7 @@ class ModelBuilder:
                 self.nn_framework,
             )
         )
+        logger.debug("_train_model_remote completed for %s", symbol)
         if self.nn_framework in {'keras', 'tensorflow'}:
             import tensorflow as tf
             from tensorflow import keras


### PR DESCRIPTION
## Summary
- debug logs when dispatching and completing remote indicator calculations
- debug logging of optimizer remote trials
- debug logging for grid search
- debug logs around model training tasks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6867ed00e0bc832db9c422a4353d519f