### PR TITLE
Add host-based URL defaults

### DIFF
--- a/tests/test_trading_bot.py
+++ b/tests/test_trading_bot.py
@@ -15,3 +15,25 @@ def test_send_trade_timeout_env(monkeypatch):
     trading_bot.send_trade('BTCUSDT', 'buy', 100.0, {'trade_manager_url': 'http://tm'})
     assert called['timeout'] == 9.0
 
+
+def test_load_env_uses_host(monkeypatch):
+    monkeypatch.delenv('DATA_HANDLER_URL', raising=False)
+    monkeypatch.delenv('MODEL_BUILDER_URL', raising=False)
+    monkeypatch.delenv('TRADE_MANAGER_URL', raising=False)
+    monkeypatch.setenv('HOST', 'localhost')
+    env = trading_bot._load_env()
+    assert env['data_handler_url'] == 'http://localhost:8000'
+    assert env['model_builder_url'] == 'http://localhost:8001'
+    assert env['trade_manager_url'] == 'http://localhost:8002'
+
+
+def test_load_env_explicit_urls(monkeypatch):
+    monkeypatch.setenv('DATA_HANDLER_URL', 'http://127.0.0.1:9000')
+    monkeypatch.setenv('MODEL_BUILDER_URL', 'http://127.0.0.1:9001')
+    monkeypatch.setenv('TRADE_MANAGER_URL', 'http://127.0.0.1:9002')
+    monkeypatch.setenv('HOST', 'should_not_use')
+    env = trading_bot._load_env()
+    assert env['data_handler_url'] == 'http://127.0.0.1:9000'
+    assert env['model_builder_url'] == 'http://127.0.0.1:9001'
+    assert env['trade_manager_url'] == 'http://127.0.0.1:9002'
+

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -14,11 +14,29 @@ INTERVAL = float(os.getenv("INTERVAL", "5"))
 
 
 def _load_env() -> dict:
-    """Load service URLs from environment variables."""
+    """Load service URLs from environment variables.
+
+    If explicit ``*_URL`` variables are not provided, fall back to the ``HOST``
+    value when constructing defaults. This allows running the bot locally by
+    specifying only ``HOST`` without overriding every service URL.
+    """
+
+    host = os.getenv("HOST")
+    data_handler = os.getenv("DATA_HANDLER_URL")
+    model_builder = os.getenv("MODEL_BUILDER_URL")
+    trade_manager = os.getenv("TRADE_MANAGER_URL")
+
+    if data_handler is None:
+        data_handler = f"http://{host}:8000" if host else "http://data_handler:8000"
+    if model_builder is None:
+        model_builder = f"http://{host}:8001" if host else "http://model_builder:8001"
+    if trade_manager is None:
+        trade_manager = f"http://{host}:8002" if host else "http://trade_manager:8002"
+
     return {
-        "data_handler_url": os.getenv("DATA_HANDLER_URL", "http://data_handler:8000"),
-        "model_builder_url": os.getenv("MODEL_BUILDER_URL", "http://model_builder:8001"),
-        "trade_manager_url": os.getenv("TRADE_MANAGER_URL", "http://trade_manager:8002"),
+        "data_handler_url": data_handler,
+        "model_builder_url": model_builder,
+        "trade_manager_url": trade_manager,
     }
 
 


### PR DESCRIPTION
## Summary
- derive default URLs from `HOST` in `trading_bot._load_env`
- test that `_load_env` respects `HOST` and explicit URL vars

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868fd1d7e14832d993ed43b77fcab68