### PR TITLE
Add fallback HOST tests

### DIFF
--- a/tests/test_integration_services.py
+++ b/tests/test_integration_services.py
@@ -172,3 +172,29 @@ def test_check_services_failure():
             p.terminate()
         for p in processes:
             p.join()
+
+
+def test_check_services_host_only():
+    import trading_bot  # noqa: E402
+    os.environ['HOST'] = '127.0.0.1'
+    for var in ('DATA_HANDLER_URL', 'MODEL_BUILDER_URL', 'TRADE_MANAGER_URL'):
+        os.environ.pop(var, None)
+    os.environ.update({
+        'SERVICE_CHECK_RETRIES': '2',
+        'SERVICE_CHECK_DELAY': '0.1',
+    })
+    processes = [
+        ctx.Process(target=_run_dh),
+        ctx.Process(target=_run_mb),
+        ctx.Process(target=_run_tm),
+    ]
+    for p in processes:
+        p.start()
+    time.sleep(1)
+    try:
+        trading_bot.check_services()
+    finally:
+        for p in processes:
+            p.terminate()
+        for p in processes:
+            p.join()

--- a/tests/test_trading_bot.py
+++ b/tests/test_trading_bot.py
@@ -37,3 +37,15 @@ def test_load_env_explicit_urls(monkeypatch):
     assert env['model_builder_url'] == 'http://127.0.0.1:9001'
     assert env['trade_manager_url'] == 'http://127.0.0.1:9002'
 
+
+
+
+def test_load_env_uses_host_when_missing(monkeypatch):
+    """Fallback to HOST when service URLs are absent."""
+    for var in ('DATA_HANDLER_URL', 'MODEL_BUILDER_URL', 'TRADE_MANAGER_URL'):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv('HOST', '127.0.0.1')
+    env = trading_bot._load_env()
+    assert env['data_handler_url'] == 'http://127.0.0.1:8000'
+    assert env['model_builder_url'] == 'http://127.0.0.1:8001'
+    assert env['trade_manager_url'] == 'http://127.0.0.1:8002'


### PR DESCRIPTION
## Summary
- verify that `_load_env()` uses HOST when service URLs are missing
- ensure `check_services()` works with only the HOST variable

## Testing
- `flake8`
- `pytest tests/test_trading_bot.py::test_load_env_uses_host_when_missing tests/test_integration_services.py::test_check_services_host_only -q`

------
https://chatgpt.com/codex/tasks/task_e_6868feaf5310832da7d8e7af6e3f67a0