### PR TITLE
Fix subscription retry loop

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -905,7 +905,7 @@ class DataHandler:
                 if attempts >= max_attempts:
                     raise
                 await asyncio.sleep(delay)
-                raise
+                continue
 
     async def _read_messages(
         self,


### PR DESCRIPTION
## Summary
- allow `_send_subscriptions` to retry rather than raising immediately

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686900188b58832dae5501ae1f1ca2ee