### PR TITLE
Update README tests note

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,10 @@ executing `pytest`:
 pip install -r requirements-cpu.txt
 ```
 
+As noted above, make sure to run `pip install -r requirements-cpu.txt` before
+executing `pytest`; otherwise imports such as `numpy`, `pandas` and `requests`
+will fail.
+
 Чтобы выполнить тесты на машине без GPU, создайте виртуальное окружение и установите зависимости из `requirements-cpu.txt`.
 Пакет включает CPU‑сборки `torch` и `tensorflow`, поэтому тесты не подтягивают CUDA‑библиотеки.
 


### PR DESCRIPTION
## Summary
- emphasize installing `requirements-cpu.txt` before running tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas, numpy, requests)*

------
https://chatgpt.com/codex/tasks/task_e_686916f2ad18832da5e92d67679f05df