### PR TITLE
Fix backup_ws_urls parsing

### DIFF
--- a/tests/test_config_env.py
+++ b/tests/test_config_env.py
@@ -1,0 +1,10 @@
+import os
+from config import load_config
+
+
+def test_backup_ws_urls_env(monkeypatch, tmp_path):
+    cfg_file = tmp_path / "c.json"
+    cfg_file.write_text("{}")
+    monkeypatch.setenv("BACKUP_WS_URLS", "['wss://a','wss://b']")
+    cfg = load_config(str(cfg_file))
+    assert cfg.backup_ws_urls == ['wss://a', 'wss://b']


### PR DESCRIPTION
## Summary
- derive actual field types for `BotConfig`
- improve `_convert` to handle list values from env vars
- test env parsing of `backup_ws_urls`

## Testing
- `pytest -q tests/test_config_env.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68691906b1c8832da14847011b2061d6