### PR TITLE
Add dotenv loading to services

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -28,6 +28,7 @@ import psutil
 import ray
 from flask import Flask, jsonify
 from optimizer import ParameterOptimizer
+from dotenv import load_dotenv
 
 if TYPE_CHECKING:  # pragma: no cover - for type checkers only
     import ccxtpro
@@ -1356,6 +1357,7 @@ def ping():
 
 
 if __name__ == "__main__":
+    load_dotenv()
     port = int(os.environ.get("PORT", "8000"))
     host = os.environ.get("HOST", "0.0.0.0")
     logger.info("Starting DataHandler service on %s:%s", host, port)

--- a/model_builder.py
+++ b/model_builder.py
@@ -13,6 +13,7 @@ from config import BotConfig
 from collections import deque
 import ray
 from utils import logger, check_dataframe_empty, HistoricalDataCache
+from dotenv import load_dotenv
 try:  # prefer gymnasium if available
     import gymnasium as gym  # type: ignore
     from gymnasium import spaces  # type: ignore
@@ -998,6 +999,7 @@ def ping():
 
 
 if __name__ == "__main__":
+    load_dotenv()
     _load_model()
     port = int(os.environ.get("PORT", "8001"))
     host = os.environ.get("HOST", "0.0.0.0")

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -28,6 +28,7 @@ import os
 import time
 from typing import Dict, Optional, Tuple
 import shutil
+from dotenv import load_dotenv
 from flask import Flask, request, jsonify
 import threading
 
@@ -1202,6 +1203,7 @@ def ping():
 
 
 if __name__ == "__main__":
+    load_dotenv()
     port = int(os.environ.get("PORT", "8002"))
     host = os.environ.get("HOST", "0.0.0.0")
     logger.info("Initializing TradeManager")


### PR DESCRIPTION
## Summary
- import `load_dotenv` in service modules
- load environment variables in main blocks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68693d307b70832db5a376c2be5e722f