### PR TITLE
Make volume profile interval configurable

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -101,7 +101,9 @@ class IndicatorsCache:
         self.config = config
         self.volatility = volatility
         self.last_volume_profile_update = 0
-        self.volume_profile_update_interval = 5
+        self.volume_profile_update_interval = config.get(
+            "volume_profile_update_interval", 300
+        )
         try:
             if timeframe == "primary":
                 close_np = df["close"].to_numpy()

--- a/tests/test_data_handler.py
+++ b/tests/test_data_handler.py
@@ -20,9 +20,21 @@ class DummyTL:
 utils_stub.TelegramLogger = DummyTL
 utils_stub.logger = logging.getLogger('test')
 sys.modules['utils'] = utils_stub
+optimizer_stubbed = False
+if 'optimizer' not in sys.modules:
+    optimizer_stubbed = True
+    optimizer_stub = types.ModuleType('optimizer')
+    class _PO:
+        def __init__(self, *a, **k):
+            pass
+    optimizer_stub.ParameterOptimizer = _PO
+    sys.modules['optimizer'] = optimizer_stub
 os.environ['TEST_MODE'] = '1'
 
 from data_handler import DataHandler
+
+if optimizer_stubbed:
+    sys.modules.pop('optimizer', None)
 
 class DummyExchange:
     def __init__(self, volumes):

--- a/tests/test_indicators_cache.py
+++ b/tests/test_indicators_cache.py
@@ -1,0 +1,49 @@
+import sys
+import types
+import pandas as pd
+import numpy as np
+from config import BotConfig
+
+optimizer_stubbed = False
+if 'optimizer' not in sys.modules:
+    optimizer_stubbed = True
+    optimizer_stub = types.ModuleType('optimizer')
+    class _PO:
+        def __init__(self, *a, **k):
+            pass
+    optimizer_stub.ParameterOptimizer = _PO
+    sys.modules['optimizer'] = optimizer_stub
+
+from data_handler import IndicatorsCache
+
+if optimizer_stubbed:
+    sys.modules.pop('optimizer', None)
+
+
+def make_df(length=30):
+    data = {
+        "close": np.linspace(1, 2, length),
+        "high": np.linspace(1, 2, length) + 0.1,
+        "low": np.linspace(1, 2, length) - 0.1,
+        "volume": np.ones(length),
+    }
+    return pd.DataFrame(data)
+
+
+def test_interval_from_config():
+    cfg = BotConfig(volume_profile_update_interval=7)
+    df = make_df(30)
+    ind = IndicatorsCache(df, cfg, 0.1)
+    assert ind.volume_profile_update_interval == 7
+
+
+def test_volume_profile_respects_interval():
+    cfg = BotConfig(volume_profile_update_interval=3)
+    df = make_df(30)
+    ind = IndicatorsCache(df, cfg, 0.1)
+    assert ind.volume_profile is not None
+
+    cfg = BotConfig(volume_profile_update_interval=100)
+    df = make_df(30)
+    ind = IndicatorsCache(df, cfg, 0.1)
+    assert ind.volume_profile is None

--- a/tests/test_model_builder_import.py
+++ b/tests/test_model_builder_import.py
@@ -51,4 +51,22 @@ def test_model_builder_imports_without_mlflow(monkeypatch):
     gym_stub.spaces = types.ModuleType('spaces')
     monkeypatch.setitem(sys.modules, 'gymnasium', gym_stub)
     monkeypatch.setitem(sys.modules, 'mlflow', None)
+    sk_mod = types.ModuleType('sklearn')
+    preproc = types.ModuleType('sklearn.preprocessing')
+    preproc.StandardScaler = object
+    sk_mod.preprocessing = preproc
+    linear_mod = types.ModuleType('sklearn.linear_model')
+    linear_mod.LogisticRegression = object
+    metrics_mod = types.ModuleType('sklearn.metrics')
+    metrics_mod.brier_score_loss = lambda *a, **k: 0.0
+    calib_mod = types.ModuleType('sklearn.calibration')
+    calib_mod.calibration_curve = lambda *a, **k: ([], [])
+    sk_mod.linear_model = linear_mod
+    sk_mod.metrics = metrics_mod
+    sk_mod.calibration = calib_mod
+    monkeypatch.setitem(sys.modules, 'sklearn', sk_mod)
+    monkeypatch.setitem(sys.modules, 'sklearn.preprocessing', preproc)
+    monkeypatch.setitem(sys.modules, 'sklearn.linear_model', linear_mod)
+    monkeypatch.setitem(sys.modules, 'sklearn.metrics', metrics_mod)
+    monkeypatch.setitem(sys.modules, 'sklearn.calibration', calib_mod)
     importlib.import_module('model_builder')

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -32,6 +32,7 @@ optuna_mod = types.ModuleType('optuna')
 optuna_samplers = types.ModuleType('optuna.samplers')
 optuna_samplers.TPESampler = object
 optuna_mod.samplers = optuna_samplers
+optuna_mod.create_study = lambda *a, **k: types.SimpleNamespace(optimize=lambda *a, **k: None, best_params={})
 optuna_exceptions = types.ModuleType('optuna.exceptions')
 class ExperimentalWarning(Warning):
     pass
@@ -43,6 +44,7 @@ sys.modules.setdefault('optuna.exceptions', optuna_exceptions)
 
 
 from optimizer import ParameterOptimizer  # noqa: E402
+sys.modules.pop("optimizer", None)
 
 
 utils = types.ModuleType('utils')
@@ -87,3 +89,6 @@ def test_get_opt_interval_zero_threshold():
     interval = opt_zero.get_opt_interval("BTCUSDT", 0.01)
     assert interval >= 1800
 
+sys.modules.pop('optuna', None)
+sys.modules.pop('optuna.exceptions', None)
+sys.modules.pop('optuna.samplers', None)

--- a/tests/test_optimizer_ray.py
+++ b/tests/test_optimizer_ray.py
@@ -32,7 +32,10 @@ mlflow_mod.MLflowCallback = object
 sys.modules.setdefault('optuna.integration.mlflow', mlflow_mod)
 optuna_mod = types.ModuleType('optuna')
 optuna_samplers = types.ModuleType('optuna.samplers')
-optuna_samplers.TPESampler = object
+class _TPESampler:
+    def __init__(self, *a, **k):
+        pass
+optuna_samplers.TPESampler = _TPESampler
 optuna_mod.samplers = optuna_samplers
 sys.modules.setdefault('optuna', optuna_mod)
 sys.modules.setdefault('optuna.samplers', optuna_samplers)


### PR DESCRIPTION
## Summary
- let `IndicatorsCache` read `volume_profile_update_interval` from config
- stub heavy optimizer dependency in tests
- cover update interval logic with new unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686977e8aea8832da3545dbcf6657e17