### PR TITLE
Expose Flask service ports in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       dockerfile: ${DOCKERFILE:-Dockerfile}
     command: gunicorn -w 2 -b 0.0.0.0:8000 data_handler:api_app
     runtime: nvidia
+    ports:
+      - "8000:8000"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/ping"]
       interval: 5s
@@ -21,6 +23,8 @@ services:
       dockerfile: ${DOCKERFILE:-Dockerfile}
     command: gunicorn -w 2 -b 0.0.0.0:8001 model_builder:api_app
     runtime: nvidia
+    ports:
+      - "8001:8001"
     environment:
       - TF_CPP_MIN_LOG_LEVEL=3
     healthcheck:
@@ -37,6 +41,8 @@ services:
       dockerfile: ${DOCKERFILE:-Dockerfile}
     command: gunicorn -w 2 -b 0.0.0.0:8002 trade_manager:api_app
     runtime: nvidia
+    ports:
+      - "8002:8002"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8002/ping"]
       interval: 5s


### PR DESCRIPTION
## Summary
- expose ports for data_handler, model_builder and trade_manager in docker-compose

## Testing
- `docker compose up --build -d` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68697c54480c832da91152a30f4b2bf4