### PR TITLE
Fix torch check in tests

### DIFF
--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -9,7 +9,10 @@ import importlib.util
 from config import BotConfig
 import asyncio
 
-if importlib.util.find_spec('torch') is None:
+try:  # require functional torch installation for these tests
+    import torch
+    import torch.nn  # noqa: F401
+except Exception:
     pytest.skip('torch not available', allow_module_level=True)
 
 # Provide dummy stable_baselines3 if missing


### PR DESCRIPTION
## Summary
- skip test_model_builder when PyTorch is missing or incomplete

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'scipy')*

------
https://chatgpt.com/codex/tasks/task_e_686a71ccc844832d8b5080d7c9ed3a4d