### PR TITLE
Fix fillna deprecation

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -403,7 +403,7 @@ class DataHandler:
                     symbol,
                     timeframe,
                 )
-                df = df.fillna(method="ffill")
+                df = df.ffill()
             time_diffs = df.index.to_series().diff().dt.total_seconds()
             max_gap = pd.Timedelta(timeframe).total_seconds() * 2
             if time_diffs.max() > max_gap:

--- a/utils.py
+++ b/utils.py
@@ -513,8 +513,8 @@ def filter_outliers_zscore(df, column="close", threshold=3.0):
             return df
 
         filled = (
-            series.fillna(method="ffill")
-            .fillna(method="bfill")
+            series.ffill()
+            .bfill()
             .fillna(series.mean())
         )
         z_scores = zscore(filled)


### PR DESCRIPTION
## Summary
- use `ffill`/`bfill` in `filter_outliers_zscore`
- forward fill missing prices in `DataHandler` with `df.ffill()`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a75a0b874832dbb173d89a59c4bfb