### PR TITLE
Fix README intro line break

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 Этот репозиторий содержит пример торгового бота на Python. Для запуска необходимы файлы `config.json` и `.env` с ключами API.
 
-
 **Disclaimer**: This project is provided for educational purposes only and does not constitute financial advice. Use at your own risk.
 
 ## Быстрый старт


### PR DESCRIPTION
## Summary
- keep intro sentence on one line in README

## Testing
- `pytest tests/test_config_env.py::test_backup_ws_urls_env -q`

------
https://chatgpt.com/codex/tasks/task_e_686a7a747a6c832d9b9631e0905efd8f