### PR TITLE
chore: ignore pytest cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 *.py[cod]
 *.log
 pytest_cache/
+.pytest_cache/


### PR DESCRIPTION
## Summary
- ignore `.pytest_cache/`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a7cd684bc832d8e8ed67740019c85