### PR TITLE
Fix gunicorn timeouts for long tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ use these steps to diagnose the problem:
 
 5. When RL components start, they import `gymnasium`.
   If the package is missing, training will fail until you install it.
+6. If `gunicorn` logs show `WORKER TIMEOUT` messages, the service
+   might need more time to respond. Set `GUNICORN_TIMEOUT` in your
+   environment to increase the timeout in seconds. The compose file
+   defaults to `120` seconds.
 
 ## Telegram notifications
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       dockerfile: ${DOCKERFILE:-Dockerfile}
-    command: gunicorn -w 2 -b 0.0.0.0:8000 data_handler:api_app
+    command: gunicorn -w 2 -b 0.0.0.0:8000 --timeout ${GUNICORN_TIMEOUT:-120} data_handler:api_app
     runtime: nvidia
     ports:
       - "8000:8000"
@@ -21,7 +21,7 @@ services:
     build:
       context: .
       dockerfile: ${DOCKERFILE:-Dockerfile}
-    command: gunicorn -w 2 -b 0.0.0.0:8001 model_builder:api_app
+    command: gunicorn -w 2 -b 0.0.0.0:8001 --timeout ${GUNICORN_TIMEOUT:-120} model_builder:api_app
     runtime: nvidia
     ports:
       - "8001:8001"
@@ -39,7 +39,7 @@ services:
     build:
       context: .
       dockerfile: ${DOCKERFILE:-Dockerfile}
-    command: gunicorn -w 2 -b 0.0.0.0:8002 trade_manager:api_app
+    command: gunicorn -w 2 -b 0.0.0.0:8002 --timeout ${GUNICORN_TIMEOUT:-120} trade_manager:api_app
     runtime: nvidia
     ports:
       - "8002:8002"


### PR DESCRIPTION
## Summary
- bump gunicorn timeout via environment variable
- document how to raise GUNICORN_TIMEOUT when worker timeouts appear

## Testing
- `pytest -q` *(fails: No module named 'pandas')*
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a81455ebc832dab2b7a07402e2529