### PR TITLE
Add runtime override

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,11 @@ python trading_bot.py
 запустите compose с переменной `DOCKERFILE` и отключите NVIDIA-переменные:
 
 ```bash
-DOCKERFILE=Dockerfile.cpu NVIDIA_VISIBLE_DEVICES= NVIDIA_DRIVER_CAPABILITIES= docker-compose up --build
+DOCKERFILE=Dockerfile.cpu RUNTIME= NVIDIA_VISIBLE_DEVICES= NVIDIA_DRIVER_CAPABILITIES= docker-compose up --build
 ```
+
+Переменная `RUNTIME` используется в `docker-compose.yml`. Если она пуста,
+контейнеры запускаются без NVIDIA runtime, что позволяет использовать CPU-образы.
 
 The `model_builder` service sets `TF_CPP_MIN_LOG_LEVEL=3` to hide verbose TensorFlow
 GPU warnings. Adjust or remove this variable if you need more detailed logs.
@@ -111,10 +114,11 @@ use these steps to diagnose the problem:
    docker compose run --rm data_handler nvidia-smi
    ```
 
-   If no GPU is detected, rebuild with the CPU Dockerfile:
+   If no GPU is detected, rebuild with the CPU Dockerfile and disable the NVIDIA
+   runtime:
 
    ```bash
-   DOCKERFILE=Dockerfile.cpu docker compose up --build
+   DOCKERFILE=Dockerfile.cpu RUNTIME= docker compose up --build
    ```
 
 3. If services require more time to initialize, increase

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: ${DOCKERFILE:-Dockerfile}
     command: gunicorn -w 2 -b 0.0.0.0:8000 data_handler:api_app
-    runtime: nvidia
+    runtime: ${RUNTIME:-nvidia}
     ports:
       - "8000:8000"
     healthcheck:
@@ -22,7 +22,7 @@ services:
       context: .
       dockerfile: ${DOCKERFILE:-Dockerfile}
     command: gunicorn -w 2 -b 0.0.0.0:8001 model_builder:api_app
-    runtime: nvidia
+    runtime: ${RUNTIME:-nvidia}
     ports:
       - "8001:8001"
     environment:
@@ -40,7 +40,7 @@ services:
       context: .
       dockerfile: ${DOCKERFILE:-Dockerfile}
     command: gunicorn -w 2 -b 0.0.0.0:8002 trade_manager:api_app
-    runtime: nvidia
+    runtime: ${RUNTIME:-nvidia}
     ports:
       - "8002:8002"
     healthcheck:
@@ -57,7 +57,7 @@ services:
       dockerfile: ${DOCKERFILE:-Dockerfile}
     # container_name: trading_bot
     command: python trading_bot.py
-    runtime: nvidia
+    runtime: ${RUNTIME:-nvidia}
     depends_on:
       data_handler:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- make NVIDIA runtime configurable via `RUNTIME`
- document how to disable the runtime for CPU images

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a8912adf0832dac665378f738b7c2