### PR TITLE
Make runtime configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,10 @@ python trading_bot.py
 запустите compose с переменной `DOCKERFILE` и отключите NVIDIA-переменные:
 
 ```bash
-DOCKERFILE=Dockerfile.cpu NVIDIA_VISIBLE_DEVICES= NVIDIA_DRIVER_CAPABILITIES= docker-compose up --build
+RUNTIME= DOCKERFILE=Dockerfile.cpu NVIDIA_VISIBLE_DEVICES= NVIDIA_DRIVER_CAPABILITIES= docker-compose up --build
 ```
+
+Set `RUNTIME=` if you want to run these CPU images without the NVIDIA runtime.
 
 The `model_builder` service sets `TF_CPP_MIN_LOG_LEVEL=3` to hide verbose TensorFlow
 GPU warnings. Adjust or remove this variable if you need more detailed logs.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: ${DOCKERFILE:-Dockerfile}
     command: gunicorn -w 2 -b 0.0.0.0:8000 --timeout ${GUNICORN_TIMEOUT:-120} data_handler:api_app
-    runtime: nvidia
+    runtime: ${RUNTIME:-nvidia}
     ports:
       - "8000:8000"
     healthcheck:
@@ -22,7 +22,7 @@ services:
       context: .
       dockerfile: ${DOCKERFILE:-Dockerfile}
     command: gunicorn -w 2 -b 0.0.0.0:8001 --timeout ${GUNICORN_TIMEOUT:-120} model_builder:api_app
-    runtime: nvidia
+    runtime: ${RUNTIME:-nvidia}
     ports:
       - "8001:8001"
     environment:
@@ -40,7 +40,7 @@ services:
       context: .
       dockerfile: ${DOCKERFILE:-Dockerfile}
     command: gunicorn -w 2 -b 0.0.0.0:8002 --timeout ${GUNICORN_TIMEOUT:-120} trade_manager:api_app
-    runtime: nvidia
+    runtime: ${RUNTIME:-nvidia}
     ports:
       - "8002:8002"
     healthcheck:
@@ -57,7 +57,7 @@ services:
       dockerfile: ${DOCKERFILE:-Dockerfile}
     # container_name: trading_bot
     command: python trading_bot.py
-    runtime: nvidia
+    runtime: ${RUNTIME:-nvidia}
     depends_on:
       data_handler:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- make the runtime overridable in `docker-compose.yml`
- document `RUNTIME` usage in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686a89e6f494832d9345075eb32f12df