### PR TITLE
Fix Python install in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,9 @@ WORKDIR /app
 
 # Установка минимальных пакетов для выполнения
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    software-properties-common \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt-get update && apt-get install -y --no-install-recommends \
     curl \
     python3.12 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- add `software-properties-common` and `deadsnakes` PPA in runtime stage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686a9dabdd18832da8206f144e3de224