### PR TITLE
Initialize TradeManager during app setup

### DIFF
--- a/trade_manager.py
+++ b/trade_manager.py
@@ -1169,6 +1169,16 @@ def create_trade_manager() -> TradeManager:
             ).start()
     return trade_manager
 
+# Initialize the trade manager once when the API app starts
+load_dotenv()
+if os.getenv("TEST_MODE") != "1":
+    try:
+        trade_manager = create_trade_manager()
+    except Exception as exc:  # pragma: no cover - initialization failure
+        logger.exception("TradeManager initialization failed: %s", exc)
+        trade_manager = None
+
+
 
 @api_app.route("/open_position", methods=["POST"])
 def open_position_route():


### PR DESCRIPTION
## Summary
- create `TradeManager` once on Flask app startup and reuse it
- load `.env` variables before creating the manager

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ad4506e40832d8b4d7a6d0ec75a86