### PR TITLE
Switch trade manager to asyncio tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ use these steps to diagnose the problem:
    might need more time to respond. Set `GUNICORN_TIMEOUT` in your
    environment to increase the timeout in seconds. The compose file
    defaults to `120` seconds.
+7. Use an async-capable worker for `gunicorn` (e.g. `--worker-class
+   uvicorn.workers.UvicornWorker`) so async views like the trade
+   manager's `/open_position` route can schedule tasks properly.
 
 ## Telegram notifications
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
     build:
       context: .
       dockerfile: ${DOCKERFILE:-Dockerfile}
-    command: gunicorn -w 2 -b 0.0.0.0:8002 --timeout ${GUNICORN_TIMEOUT:-120} trade_manager:api_app
+    command: gunicorn -w 2 -k uvicorn.workers.UvicornWorker -b 0.0.0.0:8002 --timeout ${GUNICORN_TIMEOUT:-120} trade_manager:api_app
     runtime: ${RUNTIME:-nvidia}
     ports:
       - "8002:8002"

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -1181,17 +1181,14 @@ if os.getenv("TEST_MODE") != "1":
 
 
 @api_app.route("/open_position", methods=["POST"])
-def open_position_route():
+async def open_position_route():
     info = request.get_json(force=True)
     POSITIONS.append(info)
     tm = trade_manager or create_trade_manager()
     symbol = info.get("symbol")
     side = info.get("side")
     price = float(info.get("price", 0))
-    threading.Thread(
-        target=lambda: asyncio.run(tm.open_position(symbol, side, price, info)),
-        daemon=True,
-    ).start()
+    asyncio.create_task(tm.open_position(symbol, side, price, info))
     return jsonify({"status": "ok"})
 
 


### PR DESCRIPTION
## Summary
- asyncify `/open_position` route and schedule trade opens via `asyncio.create_task`
- run trade manager with an async-compatible worker in docker-compose
- document using Gunicorn with `UvicornWorker`

## Testing
- `flake8 trade_manager.py docker-compose.yml README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ae03c18d8832dae01c380237efe7e