### PR TITLE
Add CI troubleshooting docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+# If a job fails with a temporary runner error, rerun the workflow.
+# Self-hosted runners are also supported. When contacting GitHub Support
+# include the correlation ID from the run's raw logs.
+
 on:
   push:
   pull_request:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing
+
+Thank you for your interest in contributing to this project!
+
+## Development workflow
+
+1. Install dependencies from `requirements-cpu.txt` in a virtual environment.
+2. Run `flake8` and `pytest` before submitting a pull request.
+
+## CI troubleshooting
+
+GitHub Actions occasionally fails to start a runner or download dependencies, reporting a temporary error. In most cases simply rerunning the workflow resolves the problem. If failures persist you can set up a [self-hosted runner](https://docs.github.com/actions/hosting-your-own-runners) to avoid queueing delays and network issues. For stubborn issues contact [GitHub Support](https://support.github.com/). Include the **correlation ID** from the failed run's `View raw logs` page so they can investigate.


### PR DESCRIPTION
## Summary
- add contributing guidelines
- document runner error workaround in the CI workflow

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686bb4b45624832d94b0af905decfffb