### PR TITLE
Add Telegram logger cleanup on exit

### DIFF
--- a/tests/test_telegram_logger.py
+++ b/tests/test_telegram_logger.py
@@ -4,6 +4,8 @@ import types
 import asyncio
 import importlib.util
 import sys
+import threading
+import time
 
 ROOT = os.path.dirname(os.path.dirname(__file__))
 spec = importlib.util.spec_from_file_location("utils_real", os.path.join(ROOT, "utils.py"))
@@ -32,3 +34,31 @@ def test_emit_without_running_loop_no_exception():
     logger.error("test message")
 
     asyncio.run(TelegramLogger.shutdown())
+
+
+def test_worker_thread_stops_after_shutdown():
+    os.environ.pop("TEST_MODE", None)
+
+    spec = importlib.util.spec_from_file_location("utils_real", os.path.join(ROOT, "utils.py"))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    TL = mod.TelegramLogger
+
+    class _Bot:
+        async def send_message(self, chat_id, text):
+            return types.SimpleNamespace(message_id=1)
+
+    start_threads = threading.active_count()
+    TL(_Bot(), chat_id=1)
+    for _ in range(20):
+        if threading.active_count() > start_threads:
+            break
+        time.sleep(0.05)
+    assert threading.active_count() > start_threads
+
+    asyncio.run(mod.TelegramLogger.shutdown())
+    for _ in range(20):
+        if threading.active_count() <= start_threads:
+            break
+        time.sleep(0.05)
+    assert threading.active_count() <= start_threads

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -56,6 +56,11 @@ def _register_cleanup_handlers(tm: "TradeManager") -> None:
     def _handler(*_args):
         logger.info("Stopping TradeManager")
         tm.shutdown()
+        try:
+            asyncio.run(TelegramLogger.shutdown())
+        except RuntimeError:
+            # event loop may already be closed
+            pass
 
     atexit.register(_handler)
     for sig in (signal.SIGTERM, signal.SIGINT):

--- a/utils.py
+++ b/utils.py
@@ -295,9 +295,11 @@ class TelegramLogger(logging.Handler):
         self.last_sent_text = ""
 
     async def _worker(self):
-        assert TelegramLogger._queue is not None
-        assert TelegramLogger._stop_event is not None
-        while not TelegramLogger._stop_event.is_set():
+        while True:
+            if TelegramLogger._queue is None or TelegramLogger._stop_event is None:
+                return
+            if TelegramLogger._stop_event.is_set():
+                return
             try:
                 item = await asyncio.wait_for(TelegramLogger._queue.get(), 1.0)
             except asyncio.TimeoutError:


### PR DESCRIPTION
## Summary
- ensure Telegram logger shutdown runs on process exit
- test that Telegram background thread ends on shutdown
- avoid race when TelegramLogger worker stops

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c07d4480c832da9c381676e9cd91a