### PR TITLE
Add pytest pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,9 @@ repos:
     rev: 7.3.0
     hooks:
       - id: flake8
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest
+        language: system

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,8 @@ Thank you for your interest in contributing to this project!
 ## Development workflow
 
 1. Install dependencies from `requirements-cpu.txt` in a virtual environment.
-2. Run `flake8` and `pytest` before submitting a pull request.
+2. Run `flake8` and `pytest` before submitting a pull request. These tests are
+   also executed automatically by `pre-commit`.
 
 ## CI troubleshooting
 


### PR DESCRIPTION
## Summary
- run tests automatically by adding pytest hook
- document automatic pre-commit tests

## Testing
- `pre-commit run pytest --all-files` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686c089ad4b0832d82a55275e7c7aa2e