### PR TITLE
Change TradeManager worker count

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
     build:
       context: .
       dockerfile: ${DOCKERFILE:-Dockerfile}
-    command: gunicorn -w 2 -k uvicorn.workers.UvicornWorker -b 0.0.0.0:8002 --timeout ${GUNICORN_TIMEOUT:-120} trade_manager:api_app
+    command: gunicorn -w 1 -k uvicorn.workers.UvicornWorker -b 0.0.0.0:8002 --timeout ${GUNICORN_TIMEOUT:-120} trade_manager:api_app
     runtime: ${RUNTIME:-nvidia}
     ports:
       - "8002:8002"


### PR DESCRIPTION
## Summary
- run TradeManager with only a single gunicorn worker

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `docker compose down` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c28275428832db58e5f744eff2130