### PR TITLE
Clarify gunicorn worker for trade manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,10 @@ filters repeated messages and checks that `send_message` returns HTTP 200.
 You can run this bot either with long polling or a webhook using the
 `Application` class from `python-telegram-bot`.
 
+When deploying the `trade_manager` service with Gunicorn, use a single worker
+(`-w 1`). This ensures only one `TelegramUpdateListener` polls the bot token,
+preventing duplicated updates.
+
 ## Лимиты WebSocket-подписок
 
 Количество подписок через одно соединение ограничивается параметром `max_subscriptions_per_connection`. Если список пар превышает это значение, бот откроет дополнительные WebSocket-соединения.


### PR DESCRIPTION
## Summary
- document that `trade_manager` must run with a single gunicorn worker so only one `TelegramUpdateListener` polls the bot token

## Testing
- `flake8`
- `pytest -q` *(fails: cannot import name 'check_dataframe_empty_async' from 'utils')*

------
https://chatgpt.com/codex/tasks/task_e_686c2bc6ecb0832da2e5367bb0a38f20