### PR TITLE
Add sync fallback for dataframe check

### DIFF
--- a/optimizer.py
+++ b/optimizer.py
@@ -13,8 +13,20 @@ try:
     import torch
 except ImportError:  # pragma: no cover - optional dependency
     torch = None  # type: ignore
+import inspect
 import ray
-from utils import logger, check_dataframe_empty_async as _check_df_async
+from utils import logger
+
+try:
+    from utils import check_dataframe_empty_async as _check_df_async
+except Exception:  # pragma: no cover - tests may stub this
+    from utils import check_dataframe_empty as _check_df_sync
+
+    async def _check_df_async(*a, **kw):
+        res = _check_df_sync(*a, **kw)
+        if inspect.isawaitable(res):
+            res = await res
+        return res
 from config import BotConfig
 from optuna.samplers import TPESampler
 try:

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -11,11 +11,22 @@ import ray
 import pandas as pd
 import numpy as np
 from tenacity import retry, wait_exponential, stop_after_attempt
+import inspect
 from utils import (
     logger,
-    check_dataframe_empty_async as _check_df_async,
     TelegramLogger,
 )
+
+try:
+    from utils import check_dataframe_empty_async as _check_df_async
+except Exception:  # pragma: no cover - tests may stub this
+    from utils import check_dataframe_empty as _check_df_sync
+
+    async def _check_df_async(*a, **kw):
+        res = _check_df_sync(*a, **kw)
+        if inspect.isawaitable(res):
+            res = await res
+        return res
 from config import BotConfig, load_config
 
 try:


### PR DESCRIPTION
## Summary
- handle sync fallback for dataframe checks in `optimizer` and `trade_manager`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c2c2c0348832db2d163a24b2c84d6