### PR TITLE
Add pip cache in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements-cpu.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- cache the pip download directory in GitHub Actions

## Testing
- `pytest` *(fails: ModuleNotFoundError for packages)*

------
https://chatgpt.com/codex/tasks/task_e_686d3193cdcc832da33fa2dd0dfb59fd