### PR TITLE
Fix telegram message truncation

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -374,7 +374,10 @@ class TelegramLogger(logging.Handler):
                         return
 
     async def send_telegram_message(self, message, urgent: bool = False):
-        msg = message[:512]
+        # Telegram allows up to 4096 characters per message. The worker will
+        # further split messages into 500 character chunks, so only trim to the
+        # API limit here instead of the previous 512 characters.
+        msg = message[:4096]
         try:
             TelegramLogger._queue.put_nowait((self.chat_id, msg, urgent))
         except asyncio.QueueFull:


### PR DESCRIPTION
## Summary
- avoid truncating Telegram messages at 512 characters
- keep worker chunking messages every 500 characters
- test that a long message is delivered in full

## Testing
- `pytest tests/test_telegram_logger.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686e344672e4832da14a143061f98612