### PR TITLE
Improve training loop resilience

### DIFF
--- a/model_builder.py
+++ b/model_builder.py
@@ -634,8 +634,8 @@ class ModelBuilder:
                 await asyncio.sleep(self.config['retrain_interval'])
             except Exception as e:
                 logger.exception("Ошибка цикла обучения: %s", e)
-                await asyncio.sleep(60)
-                raise
+                await asyncio.sleep(1)
+                continue
 
     async def adjust_thresholds(self, symbol, prediction: float):
         base_long = self.config.get('base_probability_threshold', 0.6)


### PR DESCRIPTION
## Summary
- handle errors in `ModelBuilder.train` without exiting
- test that the training loop recovers from failures

## Testing
- `pre-commit run --files model_builder.py tests/test_model_builder.py`

------
https://chatgpt.com/codex/tasks/task_e_686e67155bf0832d9c2c6af45feffe82