### PR TITLE
Improve TelegramLogger shutdown handling

### DIFF
--- a/tests/test_telegram_logger.py
+++ b/tests/test_telegram_logger.py
@@ -92,3 +92,18 @@ async def test_long_message_split_into_parts():
     assert bot.sent[0] == long_message[:500]
     assert bot.sent[1] == long_message[500:]
     assert "".join(bot.sent) == long_message
+
+
+@pytest.mark.asyncio
+async def test_send_after_shutdown_warning(caplog):
+    os.environ["TEST_MODE"] = "1"
+
+    bot = DummyBot()
+    tl = TelegramLogger(bot, chat_id=1)
+
+    await TelegramLogger.shutdown()
+
+    caplog.set_level(logging.WARNING)
+    await tl.send_telegram_message("test")
+
+    assert any(rec.levelno == logging.WARNING for rec in caplog.records)

--- a/utils.py
+++ b/utils.py
@@ -377,6 +377,9 @@ class TelegramLogger(logging.Handler):
         # Telegram allows up to 4096 characters per message. The worker will
         # further split messages into 500 character chunks, so only trim to the
         # API limit here instead of the previous 512 characters.
+        if TelegramLogger._queue is None:
+            logger.warning("TelegramLogger queue is None, message dropped")
+            return
         msg = message[:4096]
         try:
             TelegramLogger._queue.put_nowait((self.chat_id, msg, urgent))


### PR DESCRIPTION
## Summary
- ignore new Telegram messages after calling `TelegramLogger.shutdown`
- test that sending messages after shutdown logs a warning and doesn't throw

## Testing
- `pip install -q -r requirements-cpu.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e6df880e4832daab4c4746e30d0a6