### PR TITLE
Fix stop error handling

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -1338,7 +1338,7 @@ class DataHandler:
                     await ws.close()
                 except Exception as e:
                     logger.exception("Ошибка закрытия WebSocket %s: %s", url, e)
-                    raise
+                    continue
         self.ws_pool.clear()
 
         if self.pro_exchange is not None and hasattr(self.pro_exchange, "close"):
@@ -1346,7 +1346,7 @@ class DataHandler:
                 await self.pro_exchange.close()
             except Exception as e:
                 logger.exception("Ошибка закрытия ccxtpro: %s", e)
-                raise
+                pass
 
         await TelegramLogger.shutdown()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,13 @@ def _stub_modules():
 
     sys.modules.setdefault("websockets", types.ModuleType("websockets"))
 
+    optimizer_mod = types.ModuleType("optimizer")
+    class _PO:
+        def __init__(self, *a, **k):
+            pass
+    optimizer_mod.ParameterOptimizer = _PO
+    sys.modules.setdefault("optimizer", optimizer_mod)
+
     class _RayRemoteFunction:
         def __init__(self, func):
             self._function = func

--- a/tests/test_data_handler.py
+++ b/tests/test_data_handler.py
@@ -223,3 +223,22 @@ async def test_process_ws_queue_recovery(monkeypatch):
 
     assert processed == ['BTCUSDT']
     assert call['n'] >= 2
+
+
+@pytest.mark.asyncio
+async def test_stop_handles_close_errors():
+    cfg = BotConfig(cache_dir='/tmp')
+    dh = DataHandler(cfg, None, None, exchange=DummyExchange({'BTCUSDT': 1.0}))
+
+    class BadWS:
+        async def close(self):
+            raise RuntimeError('boom')
+
+    class BadPro:
+        async def close(self):
+            raise RuntimeError('boom')
+
+    dh.ws_pool = {'ws://': [BadWS()]}
+    dh.pro_exchange = BadPro()
+
+    await dh.stop()  # should not raise


### PR DESCRIPTION
## Summary
- log but ignore errors when closing connections in `stop`
- stub optimizer module for tests
- test graceful shutdown despite socket errors

## Testing
- `pre-commit run --files data_handler.py tests/test_data_handler.py tests/conftest.py`

------
https://chatgpt.com/codex/tasks/task_e_686e809c7804832dbc2a6c8735c20d2a