### PR TITLE
Fix ASGI errors for TradeManager

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,9 @@ services:
     build:
       context: .
       dockerfile: ${DOCKERFILE:-Dockerfile}
-    command: gunicorn -w 1 -k uvicorn.workers.UvicornWorker -b 0.0.0.0:8002 --timeout ${GUNICORN_TIMEOUT:-120} trade_manager:api_app
+    # Use the ASGI wrapper exported by trade_manager so UvicornWorker can
+    # serve the Flask app correctly.
+    command: gunicorn -w 1 -k uvicorn.workers.UvicornWorker -b 0.0.0.0:8002 --timeout ${GUNICORN_TIMEOUT:-120} trade_manager:asgi_app
     runtime: ${RUNTIME:-nvidia}
     ports:
       - "8002:8002"

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -1167,6 +1167,13 @@ class TradeManager:
 
 api_app = Flask(__name__)
 
+# Expose an ASGI-compatible application for Gunicorn's UvicornWorker. Using
+# ``WSGIMiddleware`` avoids issues when Flask's built-in ``asgi_app`` attribute
+# is unavailable or behaves differently across versions.
+from uvicorn.middleware.wsgi import WSGIMiddleware
+
+asgi_app = WSGIMiddleware(api_app)
+
 # Track when the TradeManager initialization finishes
 _ready_event = threading.Event()
 


### PR DESCRIPTION
## Summary
- export an ASGI `asgi_app` from `trade_manager.py`
- update docker-compose to use the ASGI app with UvicornWorker
- always wrap the Flask app with `WSGIMiddleware`

## Testing
- `python -m py_compile trade_manager.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_686ed07a853c832d9dad5963a2ff0cc5