### PR TITLE
Fix readiness event in trade_manager

### DIFF
--- a/trade_manager.py
+++ b/trade_manager.py
@@ -1262,9 +1262,13 @@ def _initialize_trade_manager() -> None:
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
             loop.create_task(trade_manager.run())
+            _ready_event.set()
             loop.run_forever()
-    finally:
+        else:
+            _ready_event.set()
+    except Exception:
         _ready_event.set()
+        raise
 
 
 # Start initialization when the module is imported


### PR DESCRIPTION
## Summary
- ensure `/ready` endpoint becomes available once TradeManager initializes

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687003e86638832dad969c77c93d5876