### PR TITLE
Fix deprecation warning by using a2wsgi

### DIFF
--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -37,4 +37,5 @@ requests>=2.31.0
 pybit>=5.11.0
 flake8>=7.3.0
 gunicorn>=21.2.0
+a2wsgi>=1.4
 httpx>=0.27.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,4 +37,5 @@ requests>=2.31.0
 pybit>=5.11.0
 flake8>=7.3.0
 gunicorn>=21.2.0
+a2wsgi>=1.4
 httpx>=0.27.0

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -1172,7 +1172,10 @@ api_app = Flask(__name__)
 try:  # Flask 2.2+ provides ``asgi_app`` for native ASGI support
     asgi_app = api_app.asgi_app
 except AttributeError:  # pragma: no cover - older Flask versions
-    from uvicorn.middleware.wsgi import WSGIMiddleware
+    try:
+        from a2wsgi import WSGIMiddleware  # type: ignore
+    except Exception:  # pragma: no cover - fallback if a2wsgi isn't installed
+        from uvicorn.middleware.wsgi import WSGIMiddleware
 
     asgi_app = WSGIMiddleware(api_app)
 


### PR DESCRIPTION
## Summary
- use `a2wsgi.WSGIMiddleware` when Flask doesn't provide `asgi_app`
- include `a2wsgi` in dependency lists

## Testing
- `pytest -q`
- `pytest -q --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_687009037e50832da1ed4baa933a68a0