### PR TITLE
Update CUDA base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Этап сборки
-FROM nvidia/cuda:12.0.0-cudnn8-devel-ubuntu22.04 AS builder
+FROM nvidia/cuda:12.5.0-cudnn8-devel-ubuntu22.04 AS builder
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
 
@@ -37,7 +37,7 @@ RUN pip install --no-cache-dir pip==24.0 setuptools wheel && \
     find /app/venv -type f -name '*.pyc' -delete
 
 # Этап выполнения
-FROM nvidia/cuda:12.0.0-cudnn8-runtime-ubuntu22.04
+FROM nvidia/cuda:12.5.0-cudnn8-runtime-ubuntu22.04
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- update CUDA images to 12.5 in Dockerfile

## Testing
- `pre-commit run --files Dockerfile` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `docker compose build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687027df0b88832d88d64d77c0c6b9f5