### PR TITLE
Deduplicate symbols when selecting liquid pairs

### DIFF
--- a/tests/test_data_handler.py
+++ b/tests/test_data_handler.py
@@ -59,6 +59,19 @@ async def test_select_liquid_pairs_plain_symbol_included():
     assert 'BTCUSDT' in pairs
 
 
+@pytest.mark.asyncio
+async def test_select_liquid_pairs_prefers_highest_volume():
+    cfg = BotConfig(cache_dir='/tmp', max_symbols=5)
+    volumes = {'BTCUSDT': 1.0, 'BTC/USDT:USDT': 2.0}
+    dh = DataHandler(cfg, None, None, exchange=DummyExchange(volumes))
+    markets = {
+        'BTCUSDT': {'active': True},
+        'BTC/USDT:USDT': {'active': True},
+    }
+    pairs = await dh.select_liquid_pairs(markets)
+    assert pairs == ['BTC/USDT:USDT']
+
+
 class DummyWS:
     def __init__(self):
         self.sent = []


### PR DESCRIPTION
## Summary
- deduplicate symbols by canonical name in `select_liquid_pairs`
- test that the highest volume representation is chosen

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pytest tests/test_data_handler.py::test_select_liquid_pairs_prefers_highest_volume -q` *(fails: ModuleNotFoundError: No module named 'ta')*

------
https://chatgpt.com/codex/tasks/task_e_6870b0c2cb58832d97459396fb275e02