### PR TITLE
Fix queue timeout handling in WebSocket reader

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -1021,20 +1021,15 @@ class DataHandler:
                                     timeframe=timeframe,
                                 )
                     break
+                data = json.loads(message)
+                topic = data.get("topic", "")
+                symbol = topic.split(".")[-1] if isinstance(topic, str) else ""
+                priority = self.symbol_priority.get(symbol, 0)
                 try:
-                    data = json.loads(message)
-                    topic = data.get("topic", "")
-                    symbol = topic.split(".")[-1] if isinstance(topic, str) else ""
-                    priority = self.symbol_priority.get(symbol, 0)
-                    try:
-                        await self.ws_queue.put((priority, (symbols, message, timeframe)), timeout=5)
-                    except asyncio.TimeoutError:
-                        logger.warning("Очередь WebSocket переполнена, сохранение в дисковый буфер")
-                        await self.save_to_disk_buffer(priority, (symbols, message, timeframe))
+                    await self.ws_queue.put((priority, (symbols, message, timeframe)), timeout=5)
                 except asyncio.TimeoutError:
                     logger.warning("Очередь WebSocket переполнена, сохранение в дисковый буфер")
                     await self.save_to_disk_buffer(priority, (symbols, message, timeframe))
-                    continue
             except asyncio.TimeoutError:
                 logger.warning(
                     "Тайм-аут WebSocket для %s (%s), отправка пинга",


### PR DESCRIPTION
## Summary
- remove redundant outer queue timeout handler
- keep timeout handling within internal queue push block

## Testing
- `pre-commit run --files data_handler.py` *(fails: ModuleNotFoundError: No module named 'websockets')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'scipy')*

------
https://chatgpt.com/codex/tasks/task_e_6870bf213e1c832d8bcbb8d6cf317103