### PR TITLE
Fix latency calculation in DataHandler

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -983,9 +983,9 @@ class DataHandler:
         connection_timeout: int,
     ):
         """Read messages from ``ws`` and enqueue them for processing."""
-        start_time = time.time()
         while True:
             try:
+                start_time = time.time()
                 message = await asyncio.wait_for(ws.recv(), timeout=connection_timeout)
                 latency = time.time() - start_time
                 for symbol in symbols:


### PR DESCRIPTION
## Summary
- update `_read_messages` to measure latency per message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870da3587e0832d923de418f15cd6da