### PR TITLE
Catch all exceptions in fetch_volume

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -358,7 +358,7 @@ class DataHandler:
                 try:
                     ticker = await safe_api_call(self.exchange, "fetch_ticker", sym)
                     volume = float(ticker.get("quoteVolume") or 0)
-                except (KeyError, ValueError) as e:
+                except Exception as e:  # noqa: BLE001
                     logger.error("Ошибка получения тикера для %s: %s", sym, e)
                     volume = 0.0
                 return sym, volume


### PR DESCRIPTION
## Summary
- handle all exceptions when obtaining ticker data so volume falls back to 0

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871007face8832dbd45c198e2a55f0c