### PR TITLE
Resolve duplicate train method

### DIFF
--- a/model_builder.py
+++ b/model_builder.py
@@ -922,7 +922,7 @@ class RLAgent:
             self.models[symbol] = model
         logger.info("RL-модель обучена для %s", symbol)
 
-    async def train(self):
+    async def train_rl(self):
         for symbol in self.data_handler.usdt_pairs:
             await self.train_symbol(symbol)
 


### PR DESCRIPTION
## Summary
- avoid confusion with RLAgent training routine by renaming its `train` method to `train_rl`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'scipy')*

------
https://chatgpt.com/codex/tasks/task_e_687104e199b4832d9965c73589a0a5e4