### PR TITLE
Update CUDA base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Этап сборки
-FROM nvidia/cuda:12.5.0-cudnn8-devel-ubuntu22.04 AS builder
+FROM nvidia/cuda:12.5.1-cudnn-devel-ubuntu22.04 AS builder
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
 
@@ -37,7 +37,7 @@ RUN pip install --no-cache-dir pip==24.0 setuptools wheel && \
     find /app/venv -type f -name '*.pyc' -delete
 
 # Этап выполнения
-FROM nvidia/cuda:12.5.0-cudnn8-runtime-ubuntu22.04
+FROM nvidia/cuda:12.5.1-cudnn-runtime-ubuntu22.04
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- update CUDA base images in Dockerfile to version 12.5.1

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `docker-compose build` *(fails: Error while fetching server API version: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6874d1d6fe20832d81e89ae8d024a491