### PR TITLE
Fix README duplicate tests section

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,18 +78,6 @@ registered`. These lines appear while each framework loads CUDA plugins and
 tries to register them more than once. They are warnings, not fatal errors, and
 can be safely ignored. Building the image with `Dockerfile.cpu` avoids them
 entirely.
-## Running tests
-
-Install the CPU requirements and execute `pytest`:
-
-```bash
-pip install -r requirements-cpu.txt
-pytest
-```
-
-The `requirements-cpu.txt` file already includes `pytest` and all other
-packages required by the test suite.
-## Demo services
 
 The docker-compose configuration launches minimal placeholder services. `data_handler` exposes `/price/<symbol>` which always returns a fixed value (100 for `TEST`), and `model_builder` starts with no trained model. The bot will not open any real positions until these stubs are replaced with implementations that fetch live data and train a model.
 


### PR DESCRIPTION
## Summary
- remove repeated `Running tests` lines from README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687531da70f0832db566af4278a10539