### PR TITLE
Add simple reference services

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,12 @@ The `requirements-cpu.txt` file already includes `pytest` and all other
 packages required by the test suite.
 ## Demo services
 
-The docker-compose configuration launches minimal placeholder services. `data_handler` exposes `/price/<symbol>` which always returns a fixed value (100 for `TEST`), and `model_builder` starts with no trained model. The bot will not open any real positions until these stubs are replaced with implementations that fetch live data and train a model.
+Earlier revisions started lightweight stubs for the supporting services.  This
+repository now includes simple reference implementations in the `services`
+directory. `data_handler_service.py` fetches live prices from Bybit using
+`ccxt`, while `model_builder_service.py` trains a small logistic regression
+model when you POST data to `/train`.  Use these scripts as a starting point or
+replace them with more advanced versions for real trading.
 
 
 ## Docker Compose logs

--- a/services/data_handler_service.py
+++ b/services/data_handler_service.py
@@ -1,0 +1,32 @@
+"""Simple reference data handler service fetching real prices from Bybit."""
+from flask import Flask, jsonify
+import ccxt
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+app = Flask(__name__)
+
+exchange = ccxt.bybit({
+    'apiKey': os.getenv('BYBIT_API_KEY', ''),
+    'secret': os.getenv('BYBIT_API_SECRET', ''),
+})
+
+@app.route('/price/<symbol>')
+def price(symbol: str):
+    try:
+        ticker = exchange.fetch_ticker(symbol)
+        last = float(ticker.get('last') or 0.0)
+    except Exception as exc:  # pragma: no cover - network errors
+        last = 0.0
+    return jsonify({'price': last})
+
+@app.route('/ping')
+def ping():
+    return jsonify({'status': 'ok'})
+
+if __name__ == '__main__':
+    port = int(os.environ.get('PORT', '8000'))
+    host = os.environ.get('HOST', '0.0.0.0')
+    app.run(host=host, port=port)

--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -1,0 +1,64 @@
+"""Reference model builder service using logistic regression."""
+from flask import Flask, request, jsonify
+import numpy as np
+import joblib
+import os
+from dotenv import load_dotenv
+from sklearn.linear_model import LogisticRegression
+
+load_dotenv()
+
+app = Flask(__name__)
+
+MODEL_FILE = os.getenv('MODEL_FILE', 'model.pkl')
+_model = None
+
+
+def _load_model():
+    global _model
+    if _model is None and os.path.exists(MODEL_FILE):
+        try:
+            _model = joblib.load(MODEL_FILE)
+        except Exception:  # pragma: no cover
+            _model = None
+
+
+@app.route('/train', methods=['POST'])
+def train():
+    data = request.get_json(force=True)
+    prices = np.array(data.get('prices', []), dtype=np.float32).reshape(-1, 1)
+    labels = np.array(data.get('labels', []), dtype=np.float32)
+    if len(prices) == 0 or len(prices) != len(labels):
+        return jsonify({'error': 'invalid training data'}), 400
+    model = LogisticRegression()
+    model.fit(prices, labels)
+    joblib.dump(model, MODEL_FILE)
+    global _model
+    _model = model
+    return jsonify({'status': 'trained'})
+
+
+@app.route('/predict', methods=['POST'])
+def predict():
+    data = request.get_json(force=True)
+    price = float(data.get('price', 0))
+    _load_model()
+    if _model is None:
+        signal = 'buy' if price > 0 else None
+        prob = 1.0 if signal else 0.0
+    else:
+        prob = float(_model.predict_proba([[price]])[0, 1])
+        signal = 'buy' if prob >= 0.5 else 'sell'
+    return jsonify({'signal': signal, 'prob': prob})
+
+
+@app.route('/ping')
+def ping():
+    return jsonify({'status': 'ok'})
+
+
+if __name__ == '__main__':
+    port = int(os.environ.get('PORT', '8001'))
+    host = os.environ.get('HOST', '0.0.0.0')
+    _load_model()
+    app.run(host=host, port=port)


### PR DESCRIPTION
## Summary
- provide example service code under `services/`
- document the new implementations in the README

## Testing
- `python3 -m pip install -r requirements-cpu.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687618aa1a78832dabc1406ec05e5081