### PR TITLE
Add OHLCV caching and per-symbol models

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@
     ```
 
     Непрерывный вывод смотрите в файлах внутри `./logs/`.
+
+    Дополнительные переменные для вспомогательных сервисов:
+
+    - `STREAM_SYMBOLS` — список пар через запятую, которые `data_handler_service`
+      обновляет в фоне.
+    - `CACHE_TTL` и `UPDATE_INTERVAL` — время жизни кэша OHLCV и интервал
+      фонового обновления (в секундах).
+    - `MODEL_DIR` — каталог, где `model_builder_service` хранит обученные модели
+      по символам.
 3. Отредактируйте `config.json` под свои нужды. Помимо основных настроек можно
    задать параметры адаптации порогов:
    - `loss_streak_threshold` и `win_streak_threshold` контролируют количество
@@ -83,8 +92,25 @@ Earlier revisions started lightweight stubs for the supporting services.  This
 repository now includes simple reference implementations in the `services`
 directory. `data_handler_service.py` fetches live prices from Bybit using
 `ccxt`, while `model_builder_service.py` trains a small logistic regression
-model when you POST data to `/train`.  Use these scripts as a starting point or
-replace them with more advanced versions for real trading.
+model when you POST data to `/train`.
+
+The data handler exposes two endpoints:
+
+``/price/<symbol>``
+    Return the latest ticker price.
+
+``/ohlcv/<symbol>``
+    Return cached OHLCV bars for ``symbol``. The service periodically refreshes
+    data for symbols listed in ``STREAM_SYMBOLS``.  Cache lifetime is controlled
+    by ``CACHE_TTL``.
+
+The model builder maintains separate models per trading pair.  POST JSON data
+of the form::
+
+    {"symbol": "BTC/USDT", "features": [[...], [...]], "labels": [0, 1]}
+
+to ``/train`` and send similar ``features`` with ``symbol`` to ``/predict`` to
+receive buy/sell signals.
 
 
 ## Docker Compose logs

--- a/services/data_handler_service.py
+++ b/services/data_handler_service.py
@@ -1,7 +1,16 @@
-"""Simple reference data handler service fetching real prices from Bybit."""
+"""Simple reference data handler service fetching real prices from Bybit.
+
+This version also exposes cached OHLCV data for basic backtesting or model
+training.  Prices are refreshed periodically in the background for any symbols
+listed in ``STREAM_SYMBOLS``.  Historical bars can be retrieved via the new
+``/ohlcv/<symbol>`` endpoint.  The cache lifetime is controlled by
+``CACHE_TTL``.
+"""
 from flask import Flask, jsonify
 import ccxt
 import os
+import time
+import threading
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -13,6 +22,34 @@ exchange = ccxt.bybit({
     'secret': os.getenv('BYBIT_API_SECRET', ''),
 })
 
+TIMEFRAME = os.getenv('TIMEFRAME', '1m')
+OHLCV_LIMIT = int(os.getenv('OHLCV_LIMIT', '100'))
+CACHE_TTL = int(os.getenv('CACHE_TTL', '60'))
+STREAM_SYMBOLS = [s for s in os.getenv('STREAM_SYMBOLS', '').split(',') if s]
+UPDATE_INTERVAL = int(os.getenv('UPDATE_INTERVAL', '60'))
+
+_cache = {}
+
+
+def _update_symbol(symbol: str) -> None:
+    try:
+        data = exchange.fetch_ohlcv(symbol, timeframe=TIMEFRAME, limit=OHLCV_LIMIT)
+        _cache[symbol] = {'timestamp': time.time(), 'data': data}
+    except Exception:  # pragma: no cover - network errors
+        pass
+
+
+def _background_worker():
+    while True:
+        for sym in STREAM_SYMBOLS:
+            _update_symbol(sym)
+        time.sleep(UPDATE_INTERVAL)
+
+
+if STREAM_SYMBOLS:
+    thread = threading.Thread(target=_background_worker, daemon=True)
+    thread.start()
+
 @app.route('/price/<symbol>')
 def price(symbol: str):
     try:
@@ -21,6 +58,16 @@ def price(symbol: str):
     except Exception as exc:  # pragma: no cover - network errors
         last = 0.0
     return jsonify({'price': last})
+
+
+@app.route('/ohlcv/<symbol>')
+def ohlcv(symbol: str):
+    now = time.time()
+    cached = _cache.get(symbol)
+    if not cached or now - cached['timestamp'] > CACHE_TTL:
+        _update_symbol(symbol)
+        cached = _cache.get(symbol, {'data': []})
+    return jsonify({'ohlcv': cached['data']})
 
 @app.route('/ping')
 def ping():

--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -1,4 +1,10 @@
-"""Reference model builder service using logistic regression."""
+"""Reference model builder service using logistic regression.
+
+The service now supports multiple input features and keeps separate models for
+each trading symbol.  POST JSON data to ``/train`` with ``symbol``, ``features``
+and ``labels``.  Predictions are returned from ``/predict`` for the provided
+feature vectors.
+"""
 from flask import Flask, request, jsonify
 import numpy as np
 import joblib
@@ -10,45 +16,63 @@ load_dotenv()
 
 app = Flask(__name__)
 
-MODEL_FILE = os.getenv('MODEL_FILE', 'model.pkl')
-_model = None
+MODEL_DIR = os.getenv('MODEL_DIR', '.')
+os.makedirs(MODEL_DIR, exist_ok=True)
+
+_models = {}
 
 
-def _load_model():
-    global _model
-    if _model is None and os.path.exists(MODEL_FILE):
-        try:
-            _model = joblib.load(MODEL_FILE)
-        except Exception:  # pragma: no cover
-            _model = None
+def _model_path(symbol: str) -> str:
+    return os.path.join(MODEL_DIR, f'{symbol}_model.pkl')
+
+
+def _load_model(symbol: str):
+    model = _models.get(symbol)
+    if model is None:
+        path = _model_path(symbol)
+        if os.path.exists(path):
+            try:
+                model = joblib.load(path)
+            except Exception:  # pragma: no cover
+                model = None
+        _models[symbol] = model
+    return model
 
 
 @app.route('/train', methods=['POST'])
 def train():
     data = request.get_json(force=True)
-    prices = np.array(data.get('prices', []), dtype=np.float32).reshape(-1, 1)
+    symbol = data.get('symbol', 'default')
+    feats = np.array(data.get('features', []), dtype=np.float32)
     labels = np.array(data.get('labels', []), dtype=np.float32)
-    if len(prices) == 0 or len(prices) != len(labels):
+    if feats.ndim != 2 or len(feats) == 0 or len(feats) != len(labels):
         return jsonify({'error': 'invalid training data'}), 400
     model = LogisticRegression()
-    model.fit(prices, labels)
-    joblib.dump(model, MODEL_FILE)
-    global _model
-    _model = model
+    model.fit(feats, labels)
+    joblib.dump(model, _model_path(symbol))
+    _models[symbol] = model
     return jsonify({'status': 'trained'})
 
 
 @app.route('/predict', methods=['POST'])
 def predict():
     data = request.get_json(force=True)
-    price = float(data.get('price', 0))
-    _load_model()
-    if _model is None:
-        signal = 'buy' if price > 0 else None
-        prob = 1.0 if signal else 0.0
-    else:
-        prob = float(_model.predict_proba([[price]])[0, 1])
+    symbol = data.get('symbol', 'default')
+    feats = np.array(data.get('features', []), dtype=np.float32)
+    if feats.ndim == 1:
+        feats = feats.reshape(1, -1)
+    model = _load_model(symbol)
+    if model is None:
+        val = feats[0, 0] if feats.size else 0.0
+        prob = float(val > 0)
         signal = 'buy' if prob >= 0.5 else 'sell'
+    else:
+        probs = model.predict_proba(feats)[:, 1]
+        prob = probs.tolist() if len(probs) > 1 else float(probs[0])
+        if isinstance(prob, list):
+            signal = ['buy' if p >= 0.5 else 'sell' for p in prob]
+        else:
+            signal = 'buy' if prob >= 0.5 else 'sell'
     return jsonify({'signal': signal, 'prob': prob})
 
 
@@ -60,5 +84,4 @@ def ping():
 if __name__ == '__main__':
     port = int(os.environ.get('PORT', '8001'))
     host = os.environ.get('HOST', '0.0.0.0')
-    _load_model()
     app.run(host=host, port=port)


### PR DESCRIPTION
## Summary
- cache OHLCV data in `data_handler_service.py`
- expose `/ohlcv/<symbol>` endpoint and periodic background updates
- store trained models per symbol in `model_builder_service.py`
- extend `/train` and `/predict` to handle multi-feature input
- document new endpoints and environment variables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68763272a830832d9bfebd20d4ea81a8