### PR TITLE
Add Trade Manager service

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@
       фонового обновления (в секундах).
     - `MODEL_DIR` — каталог, где `model_builder_service` хранит обученные модели
       по символам.
+    - `BYBIT_API_KEY` и `BYBIT_API_SECRET` — ключи API, которые использует
+      `trade_manager_service` для размещения ордеров.
 3. Отредактируйте `config.json` под свои нужды. Помимо основных настроек можно
    задать параметры адаптации порогов:
    - `loss_streak_threshold` и `win_streak_threshold` контролируют количество
@@ -91,8 +93,15 @@ entirely.
 Earlier revisions started lightweight stubs for the supporting services.  This
 repository now includes simple reference implementations in the `services`
 directory. `data_handler_service.py` fetches live prices from Bybit using
-`ccxt`, while `model_builder_service.py` trains a small logistic regression
-model when you POST data to `/train`.
+`ccxt`, `model_builder_service.py` trains a small logistic regression
+model when you POST data to `/train`, and `trade_manager_service.py` can
+place market orders on Bybit when you POST to `/open_position` or
+`/close_position`.  Start it with:
+
+```
+python services/trade_manager_service.py
+```
+It also exposes `/positions` and `/ping` routes for status checks.
 
 The data handler exposes two endpoints:
 

--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -1,0 +1,82 @@
+"""Minimal trade manager service using Bybit via ccxt.
+
+This reference service exposes endpoints to open and close positions on
+Bybit. API keys are taken from ``BYBIT_API_KEY`` and ``BYBIT_API_SECRET``
+environment variables.
+"""
+
+from flask import Flask, request, jsonify
+import ccxt
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+app = Flask(__name__)
+
+exchange = ccxt.bybit({
+    'apiKey': os.getenv('BYBIT_API_KEY', ''),
+    'secret': os.getenv('BYBIT_API_SECRET', ''),
+})
+
+POSITIONS: list[dict] = []
+
+
+def _record(order: dict, symbol: str, side: str, amount: float, action: str) -> None:
+    POSITIONS.append({
+        'id': order.get('id'),
+        'symbol': symbol,
+        'side': side,
+        'amount': amount,
+        'action': action,
+    })
+
+
+@app.route('/open_position', methods=['POST'])
+def open_position() -> tuple:
+    data = request.get_json(force=True)
+    symbol = data.get('symbol')
+    side = str(data.get('side', 'buy')).lower()
+    amount = float(data.get('amount', 0))
+    if not symbol or amount <= 0:
+        return jsonify({'error': 'invalid order'}), 400
+    try:
+        order = exchange.create_order(symbol, 'market', side, amount)
+        _record(order, symbol, side, amount, 'open')
+        return jsonify({'status': 'ok', 'order_id': order.get('id')})
+    except Exception as exc:  # pragma: no cover - network errors
+        return jsonify({'error': str(exc)}), 500
+
+
+@app.route('/close_position', methods=['POST'])
+def close_position() -> tuple:
+    data = request.get_json(force=True)
+    symbol = data.get('symbol')
+    side = str(data.get('side', 'buy')).lower()
+    side = 'sell' if side == 'buy' else 'buy'
+    amount = float(data.get('amount', 0))
+    if not symbol or amount <= 0:
+        return jsonify({'error': 'invalid order'}), 400
+    params = {'reduce_only': True}
+    try:
+        order = exchange.create_order(symbol, 'market', side, amount, params=params)
+        _record(order, symbol, side, amount, 'close')
+        return jsonify({'status': 'ok', 'order_id': order.get('id')})
+    except Exception as exc:  # pragma: no cover - network errors
+        return jsonify({'error': str(exc)}), 500
+
+
+@app.route('/positions')
+def positions():
+    return jsonify({'positions': POSITIONS})
+
+
+@app.route('/ping')
+def ping():
+    return jsonify({'status': 'ok'})
+
+
+if __name__ == '__main__':
+    port = int(os.environ.get('PORT', '8002'))
+    host = os.environ.get('HOST', '0.0.0.0')
+    app.run(host=host, port=port)


### PR DESCRIPTION
## Summary
- implement reference trade_manager_service using ccxt
- document service in README

## Testing
- `flake8 services/trade_manager_service.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876346f95e4832d9906e806ddaa69fb