### PR TITLE
Use reference data/model services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,8 @@ services:
     build:
       context: .
       dockerfile: ${DOCKERFILE:-Dockerfile}
-    command: gunicorn -w 2 -b 0.0.0.0:8000 --timeout ${GUNICORN_TIMEOUT:-120} data_handler:api_app
+    # Run the lightweight reference implementation instead of the full module
+    command: python services/data_handler_service.py
     runtime: ${RUNTIME:-nvidia}
     ports:
       - "8000:8000"
@@ -21,7 +22,8 @@ services:
     build:
       context: .
       dockerfile: ${DOCKERFILE:-Dockerfile}
-    command: gunicorn -w 2 -b 0.0.0.0:8001 --timeout ${GUNICORN_TIMEOUT:-120} model_builder:api_app
+    # Run the lightweight reference implementation instead of the full module
+    command: python services/model_builder_service.py
     runtime: ${RUNTIME:-nvidia}
     ports:
       - "8001:8001"

--- a/services/data_handler_service.py
+++ b/services/data_handler_service.py
@@ -1,4 +1,7 @@
-
+"""Simple reference data handler service fetching real prices from Bybit."""
+from flask import Flask, jsonify
+import ccxt
+import os
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -10,7 +13,6 @@ exchange = ccxt.bybit({
     'secret': os.getenv('BYBIT_API_SECRET', ''),
 })
 
-
 @app.route('/price/<symbol>')
 def price(symbol: str):
     try:
@@ -19,7 +21,6 @@ def price(symbol: str):
     except Exception as exc:  # pragma: no cover - network errors
         last = 0.0
     return jsonify({'price': last})
-
 
 @app.route('/ping')
 def ping():

--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -1,4 +1,4 @@
-
+"""Reference model builder service using logistic regression."""
 from flask import Flask, request, jsonify
 import numpy as np
 import joblib
@@ -10,20 +10,45 @@ load_dotenv()
 
 app = Flask(__name__)
 
+MODEL_FILE = os.getenv('MODEL_FILE', 'model.pkl')
+_model = None
 
+
+def _load_model():
+    global _model
+    if _model is None and os.path.exists(MODEL_FILE):
+        try:
+            _model = joblib.load(MODEL_FILE)
+        except Exception:  # pragma: no cover
+            _model = None
 
 
 @app.route('/train', methods=['POST'])
 def train():
     data = request.get_json(force=True)
-
+    features = np.array(data.get('features', []), dtype=np.float32).reshape(-1, 1)
+    labels = np.array(data.get('labels', []), dtype=np.float32)
+    if len(features) == 0 or len(features) != len(labels):
+        return jsonify({'error': 'invalid training data'}), 400
+    model = LogisticRegression()
+    model.fit(features, labels)
+    joblib.dump(model, MODEL_FILE)
+    global _model
+    _model = model
     return jsonify({'status': 'trained'})
 
 
 @app.route('/predict', methods=['POST'])
 def predict():
     data = request.get_json(force=True)
-
+    feature = float(np.array(data.get('features', [0]), dtype=np.float32)[0])
+    _load_model()
+    if _model is None:
+        signal = 'buy' if feature > 0 else None
+        prob = 1.0 if signal else 0.0
+    else:
+        prob = float(_model.predict_proba([[feature]])[0, 1])
+        signal = 'buy' if prob >= 0.5 else 'sell'
     return jsonify({'signal': signal, 'prob': prob})
 
 
@@ -35,5 +60,5 @@ def ping():
 if __name__ == '__main__':
     port = int(os.environ.get('PORT', '8001'))
     host = os.environ.get('HOST', '0.0.0.0')
-
+    _load_model()
     app.run(host=host, port=port)


### PR DESCRIPTION
## Summary
- run reference data_handler_service and model_builder_service in compose
- restore reference service implementations for tests

## Testing
- `pip install -q -r requirements-cpu.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68763ea6e040832dadf64b82473ef64f