### PR TITLE
Switch services to gunicorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,11 @@ RUN echo "Checking library versions and CUDA availability..." && \
     /app/venv/bin/python3.12 -c "import ray; print('Ray Version:', ray.__version__)" || echo "Ray check failed" && \
     /app/venv/bin/python3.12 -c "import optuna; print('Optuna Version:', optuna.__version__)" || echo "Optuna check failed" && \
     /app/venv/bin/python3.12 -c "import shap; print('SHAP Version:', shap.__version__)" || echo "SHAP check failed" && \
-    /app/venv/bin/python3.12 -c "import numba; print('Numba Version:', numba.__version__)" || echo "Numba check failed"
+    /app/venv/bin/python3.12 -c "import numba; print('Numba Version:', numba.__version__)" || echo "Numba check failed" && \
+    /app/venv/bin/python3.12 -c "import tensorflow as tf; print('TF Version:', tf.__version__)" || echo "TensorFlow check failed" && \
+    /app/venv/bin/python3.12 -c "import stable_baselines3 as sb3; print('SB3 Version:', sb3.__version__)" || echo "SB3 check failed" && \
+    /app/venv/bin/python3.12 -c "import pytorch_lightning as pl; print('Lightning Version:', pl.__version__)" || echo "Lightning check failed" && \
+    /app/venv/bin/python3.12 -c "import mlflow; print('MLflow Version:', mlflow.__version__)" || echo "MLflow check failed"
 
 # Указываем команду для запуска
 CMD ["/app/venv/bin/python3.12", "trading_bot.py"]

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -25,4 +25,9 @@ COPY . .
 ENV VIRTUAL_ENV=/app/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
+# Verify that all heavy packages were installed
+RUN echo "Checking package versions..." && \
+    $VIRTUAL_ENV/bin/python -c "import torch, tensorflow as tf; print('Torch:', torch.__version__, 'TF:', tf.__version__)" && \
+    $VIRTUAL_ENV/bin/python -c "import stable_baselines3 as sb3, mlflow, pytorch_lightning as pl; print('SB3:', sb3.__version__, 'MLflow:', mlflow.__version__, 'Lightning:', pl.__version__)"
+
 CMD ["python", "trading_bot.py"]

--- a/README.md
+++ b/README.md
@@ -118,6 +118,25 @@ of the form::
 
     {"symbol": "BTC/USDT", "features": [[...], [...]], "labels": [0, 1]}
 
+### Switching implementations
+
+`docker-compose.yml` uses the full implementations in `data_handler.py` and
+`model_builder.py`. They depend on heavy packages like TensorFlow and PyTorch
+which are installed in the Docker image. For lightweight testing you can run
+the reference services instead. Replace the `command` entries for each service
+with the scripts from the `services` directory:
+
+```yaml
+data_handler:
+  command: python services/data_handler_service.py
+model_builder:
+  command: python services/model_builder_service.py
+trade_manager:
+  command: python services/trade_manager_service.py
+```
+
+Restore the Gunicorn commands when you want to launch the full services.
+
 
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       dockerfile: ${DOCKERFILE:-Dockerfile}
-
+    command: gunicorn -w 2 -b 0.0.0.0:8000 --timeout ${GUNICORN_TIMEOUT:-120} data_handler:api_app
     runtime: ${RUNTIME:-nvidia}
     ports:
       - "8000:8000"
@@ -21,7 +21,7 @@ services:
     build:
       context: .
       dockerfile: ${DOCKERFILE:-Dockerfile}
-
+    command: gunicorn -w 2 -b 0.0.0.0:8001 --timeout ${GUNICORN_TIMEOUT:-120} model_builder:api_app
     runtime: ${RUNTIME:-nvidia}
     ports:
       - "8001:8001"


### PR DESCRIPTION
## Summary
- serve `data_handler` and `model_builder` with gunicorn
- verify heavyweight packages during Docker build
- explain how to swap the reference services in README

## Testing
- `pre-commit run --files Dockerfile Dockerfile.cpu README.md docker-compose.yml` *(fails: pytest could not find files)*
- `pytest` *(fails: ModuleNotFoundError for pandas and other deps)*

------
https://chatgpt.com/codex/tasks/task_e_68765f618d38832d9d95107d85264c73