### PR TITLE
Configure trade_manager env

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,11 @@
     - `MODEL_DIR` — каталог, где `model_builder_service` хранит обученные модели
       по символам.
     - `BYBIT_API_KEY` и `BYBIT_API_SECRET` — ключи API, которые использует
-      `trade_manager_service` для размещения ордеров.
+      `trade_manager_service` для размещения ордеров. Переменные
+      `TELEGRAM_BOT_TOKEN` и `TELEGRAM_CHAT_ID` нужны для уведомлений.
+      Убедитесь, что эти значения доступны контейнеру `trade_manager`,
+      например через `env_file: .env` или через секцию `environment:` в
+      `docker-compose.yml`.
 3. Отредактируйте `config.json` под свои нужды. Помимо основных настроек можно
    задать параметры адаптации порогов:
    - `loss_streak_threshold` и `win_streak_threshold` контролируют количество

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,12 +45,18 @@ services:
     runtime: ${RUNTIME:-nvidia}
     ports:
       - "8002:8002"
+    env_file: .env
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8002/ping"]
       interval: 5s
       timeout: 2s
       retries: 12
       start_period: 5s
+    volumes:
+      - ./logs:/app/logs
+      - ./models:/app/models
+      - ./cache:/app/cache
+      - ./config.json:/app/config.json
     networks:
       - trading_bot_default
   trading_bot:


### PR DESCRIPTION
## Summary
- expose `.env` to `trade_manager` in compose and mount log/model volumes
- mention environment requirements for `trade_manager` container in docs

## Testing
- `pip install -r requirements-cpu.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687665a19fe0832da6fc6a644c3f923b