### PR TITLE
Fix model builder service

### DIFF
--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -1,4 +1,5 @@
 """Reference model builder service using logistic regression."""
+
 from flask import Flask, request, jsonify
 import numpy as np
 import joblib
@@ -11,19 +12,31 @@ load_dotenv()
 app = Flask(__name__)
 
 MODEL_FILE = os.getenv('MODEL_FILE', 'model.pkl')
+_model = None
 
+
+def _load_model() -> None:
+    """Load model from ``MODEL_FILE`` if it exists."""
     global _model
-    if _model is None and os.path.exists(MODEL_FILE):
+    if os.path.exists(MODEL_FILE):
         try:
             _model = joblib.load(MODEL_FILE)
-        except Exception:  # pragma: no cover
+        except Exception:  # pragma: no cover - model may be corrupted
             _model = None
+            raise
 
 
 @app.route('/train', methods=['POST'])
-def train():
+def train() -> tuple:
     data = request.get_json(force=True)
-
+    features = np.array(data.get('features', []), dtype=np.float32)
+    labels = np.array(data.get('labels', []), dtype=np.float32)
+    if features.ndim == 1:
+        features = features.reshape(-1, 1)
+    if len(features) == 0 or len(features) != len(labels):
+        return jsonify({'error': 'invalid training data'}), 400
+    model = LogisticRegression()
+    model.fit(features, labels)
     joblib.dump(model, MODEL_FILE)
     global _model
     _model = model
@@ -31,14 +44,25 @@ def train():
 
 
 @app.route('/predict', methods=['POST'])
-def predict():
+def predict() -> tuple:
     data = request.get_json(force=True)
-
+    features = np.array(data.get('features', []), dtype=np.float32)
+    if features.ndim == 0:
+        features = np.array([[features]], dtype=np.float32)
+    elif features.ndim == 1:
+        features = features.reshape(1, -1)
+    if _model is None:
+        price = float(features[0, 0]) if features.size else 0.0
+        signal = 'buy' if price > 0 else None
+        prob = 1.0 if signal else 0.0
+    else:
+        prob = float(_model.predict_proba(features)[0, 1])
+        signal = 'buy' if prob >= 0.5 else 'sell'
     return jsonify({'signal': signal, 'prob': prob})
 
 
 @app.route('/ping')
-def ping():
+def ping() -> tuple:
     return jsonify({'status': 'ok'})
 
 


### PR DESCRIPTION
## Summary
- rewrite model_builder_service using code from main model_builder module
- add helper to load saved model
- implement /train, /predict and /ping routes

## Testing
- `flake8`
- `pytest tests/test_service_scripts.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687672963cb4832d9788063245043893