### PR TITLE
Add API key validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,12 @@
     - `MODEL_DIR` — каталог, где `model_builder_service` хранит обученные модели
       по символам.
     - `BYBIT_API_KEY` и `BYBIT_API_SECRET` — ключи API, которые использует
-      `trade_manager_service` для размещения ордеров. Переменные
-      `TELEGRAM_BOT_TOKEN` и `TELEGRAM_CHAT_ID` нужны для уведомлений.
-      Убедитесь, что эти значения доступны контейнеру `trade_manager`,
-      например через `env_file: .env` или через секцию `environment:` в
-      `docker-compose.yml`.
+      `trade_manager_service` для размещения ордеров. Теперь эти переменные
+      обязательны также для `data_handler`, который проверяет их наличие при
+      инициализации. Переменные `TELEGRAM_BOT_TOKEN` и `TELEGRAM_CHAT_ID`
+      нужны для уведомлений. Убедитесь, что все значения доступны
+      контейнеру `trade_manager`, например через `env_file: .env` или через
+      секцию `environment:` в `docker-compose.yml`.
 3. Отредактируйте `config.json` под свои нужды. Помимо основных настроек можно
    задать параметры адаптации порогов:
    - `loss_streak_threshold` и `win_streak_threshold` контролируют количество

--- a/data_handler.py
+++ b/data_handler.py
@@ -42,11 +42,20 @@ except Exception as e:  # pragma: no cover - numba without cuda support
 
 
 def create_exchange() -> BybitSDKAsync:
-    """Create an authenticated Bybit SDK instance."""
-    return BybitSDKAsync(
-        api_key=os.environ.get("BYBIT_API_KEY", ""),
-        api_secret=os.environ.get("BYBIT_API_SECRET", ""),
-    )
+    """Create an authenticated Bybit SDK instance.
+
+    Raises
+    ------
+    RuntimeError
+        If required API credentials are missing.
+    """
+    api_key = os.environ.get("BYBIT_API_KEY", "")
+    api_secret = os.environ.get("BYBIT_API_SECRET", "")
+    if not api_key or not api_secret:
+        raise RuntimeError(
+            "BYBIT_API_KEY and BYBIT_API_SECRET must be set for DataHandler"
+        )
+    return BybitSDKAsync(api_key=api_key, api_secret=api_secret)
 
 
 def ema_fast(values: np.ndarray, window: int, wilder: bool = False) -> np.ndarray:


### PR DESCRIPTION
## Summary
- require non-empty BYBIT_API_KEY and BYBIT_API_SECRET when creating the exchange
- document the new requirement in README

## Testing
- `pip install -r requirements-cpu.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68767b31d120832dba4474f7633b35ac