### PR TITLE
Warn when telegram env vars missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@
       нужны для уведомлений. Убедитесь, что все значения доступны
       контейнеру `trade_manager`, например через `env_file: .env` или через
       секцию `environment:` в `docker-compose.yml`.
+      `DataHandler` и `TradeManager` проверяют эти переменные при запуске и
+      выводят предупреждение, если они отсутствуют. В этом случае Telegram
+      уведомления отправляться не будут.
 3. Отредактируйте `config.json` под свои нужды. Помимо основных настроек можно
    задать параметры адаптации порогов:
    - `loss_streak_threshold` и `win_streak_threshold` контролируют количество
@@ -259,6 +262,10 @@ trade_manager = TradeManager(cfg, data_handler, model_builder, bot, chat_id)
 
 You can limit the logger queue with `telegram_queue_size` in `config.json`.
 ```
+
+Both services check the `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID`
+variables at startup. If either variable is missing, a warning is logged and
+no Telegram alerts are sent.
 
 To avoid processing old updates after a restart, store the `update_id` and pass
 it to the `offset` parameter when calling `get_updates`. The helper class

--- a/data_handler.py
+++ b/data_handler.py
@@ -184,6 +184,10 @@ class DataHandler:
             config.get("max_symbols"),
             GPU_AVAILABLE,
         )
+        if not os.environ.get("TELEGRAM_BOT_TOKEN") or not os.environ.get("TELEGRAM_CHAT_ID"):
+            logger.warning(
+                "TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID not set; Telegram alerts will not be sent"
+            )
         self.config = config
         self.exchange = exchange or create_exchange()
         self.pro_exchange = pro_exchange

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -107,6 +107,10 @@ class TradeManager:
         self.data_handler = data_handler
         self.model_builder = model_builder
         self.rl_agent = rl_agent
+        if not os.environ.get("TELEGRAM_BOT_TOKEN") or not os.environ.get("TELEGRAM_CHAT_ID"):
+            logger.warning(
+                "TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID not set; Telegram alerts will not be sent"
+            )
         self.telegram_logger = TelegramLogger(
             telegram_bot,
             chat_id,


### PR DESCRIPTION
## Summary
- warn if `TELEGRAM_BOT_TOKEN` or `TELEGRAM_CHAT_ID` aren't set
- mention new warning behaviour in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68767d40b620832d92494a8f896efb19