### PR TITLE
Add logging in run_once

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -122,8 +122,11 @@ def run_once() -> None:
     price = fetch_price(SYMBOL, env)
     if price is None:
         return
+    logger.info("Price for %s: %s", SYMBOL, price)
     signal = get_prediction(SYMBOL, price, env)
+    logger.info("Prediction: %s", signal)
     if signal:
+        logger.info("Sending trade: %s %s @ %s", SYMBOL, signal, price)
         send_trade(SYMBOL, signal, price, env)
 
 


### PR DESCRIPTION
## Summary
- log fetched price and prediction in `run_once`
- log trade details before sending trades

## Testing
- `pytest -q`
- `docker compose logs -f trading_bot` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687688865030832da9bea8e815ad711e