### PR TITLE
Fix env for data handler

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     runtime: ${RUNTIME:-nvidia}
     ports:
       - "8000:8000"
+    env_file: .env
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/ping"]
       interval: 5s


### PR DESCRIPTION
## Summary
- add `.env` to `data_handler` in docker-compose so BYBIT keys are loaded

## Testing
- `pytest tests/test_service_scripts.py::test_data_handler_service_price -q`
- ✅ `curl -s http://127.0.0.1:8000/price/BTCUSDT` with env vars

------
https://chatgpt.com/codex/tasks/task_e_6876b79e9d20832daccc67109be6a068