### PR TITLE
Fix price endpoint loop handling

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -1468,7 +1468,13 @@ def price(symbol: str):
             logger.error("Ticker fetch failed for %s: %s", sym, exc)
             return DEFAULT_PRICE
 
-    price_val = asyncio.run(_lookup(symbol))
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        price_val = asyncio.run(_lookup(symbol))
+    else:
+        fut = asyncio.run_coroutine_threadsafe(_lookup(symbol), loop)
+        price_val = fut.result()
     return jsonify({"price": price_val})
 
 


### PR DESCRIPTION
## Summary
- ensure `/price/<symbol>` reuses the running loop instead of always starting a new one

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68779437ec34832d87df570682d211d8