### PR TITLE
Update service check defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ use these steps to diagnose the problem:
 
 3. If services require more time to initialize, increase
    `SERVICE_CHECK_RETRIES` or `SERVICE_CHECK_DELAY` in `.env`.
+   The defaults are 30 retries and a 2‑second delay.
 4. If logs contain `gymnasium import failed`, install the package manually with `pip install gymnasium`.
 5. When RL components start, they import `gymnasium`.
   If the package is missing, training will fail until you install it.

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -43,8 +43,8 @@ def _load_env() -> dict:
 def check_services() -> None:
     """Ensure dependent services are responsive."""
     env = _load_env()
-    retries = int(os.getenv("SERVICE_CHECK_RETRIES", "5"))
-    delay = float(os.getenv("SERVICE_CHECK_DELAY", "1"))
+    retries = int(os.getenv("SERVICE_CHECK_RETRIES", "30"))
+    delay = float(os.getenv("SERVICE_CHECK_DELAY", "2"))
     services = {
         "data_handler": (env["data_handler_url"], "ping"),
         "model_builder": (env["model_builder_url"], "ping"),


### PR DESCRIPTION
## Summary
- bump default service health check retries and delay
- document new retry defaults

## Testing
- `pre-commit run --files trading_bot.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687898aa0338832d94468537366b9ce3