### PR TITLE
Fix Bybit timeframe mapping

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -16,6 +16,7 @@ from utils import (
     TelegramLogger,
     calculate_volume_profile as utils_volume_profile,
     safe_api_call,
+    bybit_interval,
 )
 from tenacity import retry, wait_exponential
 from typing import List, Dict, TYPE_CHECKING, Any
@@ -968,8 +969,9 @@ class DataHandler:
                             await asyncio.sleep(1)
                             self.ws_rate_timestamps = [t for t in self.ws_rate_timestamps if current_time - t < 1]
                         ws_symbol = self.fix_ws_symbol(symbol)
+                        interval = bybit_interval(selected_timeframe)
                         await ws.send(
-                            json.dumps({"op": "subscribe", "args": [f"kline.{selected_timeframe}.{ws_symbol}"]})
+                            json.dumps({"op": "subscribe", "args": [f"kline.{interval}.{ws_symbol}"]})
                         )
                         rate = max(self.config.get("ws_rate_limit", 1), 1)
                         await asyncio.sleep(1 / rate)

--- a/utils.py
+++ b/utils.py
@@ -39,6 +39,29 @@ except Exception:  # pragma: no cover - allow missing telegram package
         pass
 from pybit.unified_trading import HTTP
 
+# Mapping from ccxt/ccxtpro style timeframes to Bybit interval strings
+_BYBIT_INTERVALS = {
+    "1m": "1",
+    "3m": "3",
+    "5m": "5",
+    "15m": "15",
+    "30m": "30",
+    "1h": "60",
+    "2h": "120",
+    "4h": "240",
+    "6h": "360",
+    "12h": "720",
+    "1d": "D",
+    "1w": "W",
+    "1M": "M",
+}
+
+
+def bybit_interval(timeframe: str) -> str:
+    """Return the interval string accepted by Bybit APIs."""
+
+    return _BYBIT_INTERVALS.get(timeframe, timeframe)
+
 
 async def handle_rate_limits(exchange) -> None:
     """Sleep if Bybit rate limit is close to exhaustion."""
@@ -147,7 +170,7 @@ class BybitSDKAsync:
             params = {
                 "category": "linear",
                 "symbol": self._format_symbol(symbol),
-                "interval": timeframe,
+                "interval": bybit_interval(timeframe),
                 "limit": limit,
             }
             if since is not None:


### PR DESCRIPTION
## Summary
- normalize common timeframe strings to Bybit's expected intervals
- use the helper when subscribing to websockets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687815ac7448832d86efa4db3d3d2f29