### PR TITLE
Fix CUDA detection crash

### DIFF
--- a/optimizer.py
+++ b/optimizer.py
@@ -18,6 +18,12 @@ import ray
 from utils import logger
 
 try:
+    from utils import is_cuda_available  # type: ignore
+except Exception:  # pragma: no cover - tests may stub this
+    def is_cuda_available() -> bool:
+        return False
+
+try:
     from utils import check_dataframe_empty_async as _check_df_async
 except Exception:  # pragma: no cover - tests may stub this
     from utils import check_dataframe_empty as _check_df_sync
@@ -37,7 +43,7 @@ from sklearn.model_selection import GridSearchCV
 from sklearn.base import BaseEstimator
 
 
-@ray.remote(num_gpus=1 if torch and torch.cuda.is_available() else 0)
+@ray.remote(num_gpus=1 if is_cuda_available() else 0)
 def _objective_remote(
     df,
     symbol,

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -18,6 +18,12 @@ from utils import (
 )
 
 try:
+    from utils import is_cuda_available  # type: ignore
+except Exception:  # pragma: no cover - tests may stub this
+    def is_cuda_available() -> bool:
+        return False
+
+try:
     from utils import check_dataframe_empty_async as _check_df_async
 except Exception:  # pragma: no cover - tests may stub this
     from utils import check_dataframe_empty as _check_df_sync
@@ -46,7 +52,7 @@ import threading
 
 # Determine computation device once
 
-device_type = "cuda" if torch.cuda.is_available() else "cpu"
+device_type = "cuda" if is_cuda_available() else "cpu"
 
 
 def _register_cleanup_handlers(tm: "TradeManager") -> None:

--- a/utils.py
+++ b/utils.py
@@ -57,6 +57,19 @@ _BYBIT_INTERVALS = {
 }
 
 
+def is_cuda_available() -> bool:
+    """Safely check whether CUDA is available via PyTorch."""
+
+    try:  # Lazy import to avoid heavy initialization when unused
+        import torch  # type: ignore
+        return torch.cuda.is_available()
+    except Exception as exc:  # pragma: no cover - optional dependency
+        logging.getLogger("TradingBot").warning(
+            "CUDA availability check failed: %s", exc
+        )
+        return False
+
+
 def bybit_interval(timeframe: str) -> str:
     """Return the interval string accepted by Bybit APIs."""
 


### PR DESCRIPTION
## Summary
- add `is_cuda_available` helper in utils to safely check CUDA
- use it for device selection in model builder, trade manager and optimizer
- provide fallback definitions when tests stub utils

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68795174e9bc832db644faf6ad97c00c