### PR TITLE
Add shared memory config for trade_manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ RUNTIME= DOCKERFILE=Dockerfile.cpu NVIDIA_VISIBLE_DEVICES= NVIDIA_DRIVER_CAPABIL
 
 Set `RUNTIME=` if you want to run these CPU images without the NVIDIA runtime.
 
+The `trade_manager` container needs extra shared memory. The compose file
+allocates 2GB via `shm_size: '2gb'` to enlarge `/dev/shm`.
+
 The `model_builder` service sets `TF_CPP_MIN_LOG_LEVEL=3` to hide verbose TensorFlow
 GPU warnings. Adjust or remove this variable if you need more detailed logs.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,7 @@ services:
       - ./models:/app/models
       - ./cache:/app/cache
       - ./config.json:/app/config.json
+    shm_size: '2gb'
     networks:
       - trading_bot_default
   trading_bot:


### PR DESCRIPTION
## Summary
- set `shm_size: '2gb'` for `trade_manager` service
- mention the shared memory requirement in README

## Testing
- `pip install -r requirements-cpu.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68795858aca0832d9790e52346250d9f