### PR TITLE
Remove utils fallbacks and adjust tests

### DIFF
--- a/model_builder.py
+++ b/model_builder.py
@@ -12,12 +12,7 @@ import asyncio
 from config import BotConfig
 from collections import deque
 import ray
-from utils import logger, check_dataframe_empty, HistoricalDataCache
-try:
-    from utils import is_cuda_available  # type: ignore
-except Exception:  # pragma: no cover - tests may stub this
-    def is_cuda_available() -> bool:
-        return False
+from utils import logger, check_dataframe_empty, HistoricalDataCache, is_cuda_available
 from dotenv import load_dotenv
 try:  # prefer gymnasium if available
     import gymnasium as gym  # type: ignore

--- a/optimizer.py
+++ b/optimizer.py
@@ -15,24 +15,11 @@ except ImportError:  # pragma: no cover - optional dependency
     torch = None  # type: ignore
 import inspect
 import ray
-from utils import logger
-
-try:
-    from utils import is_cuda_available  # type: ignore
-except Exception:  # pragma: no cover - tests may stub this
-    def is_cuda_available() -> bool:
-        return False
-
-try:
-    from utils import check_dataframe_empty_async as _check_df_async
-except Exception:  # pragma: no cover - tests may stub this
-    from utils import check_dataframe_empty as _check_df_sync
-
-    async def _check_df_async(*a, **kw):
-        res = _check_df_sync(*a, **kw)
-        if inspect.isawaitable(res):
-            res = await res
-        return res
+from utils import (
+    logger,
+    is_cuda_available,
+    check_dataframe_empty_async as _check_df_async,
+)
 from config import BotConfig
 from optuna.samplers import TPESampler
 try:

--- a/tests/test_import_order.py
+++ b/tests/test_import_order.py
@@ -16,6 +16,11 @@ def test_telegramlogger_injection_order():
     async def _cde(*a, **k):
         return False
     utils_stub.check_dataframe_empty = _cde
+    utils_stub.check_dataframe_empty_async = _cde
+    utils_stub.is_cuda_available = lambda: False
+    async def _safe_api_call(exchange, method: str, *args, **kwargs):
+        return await getattr(exchange, method)(*args, **kwargs)
+    utils_stub.safe_api_call = _safe_api_call
     sys.modules['utils'] = utils_stub
 
     tm = importlib.import_module('trade_manager')

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -53,6 +53,7 @@ async def _cde(*a, **kw):
     return False
 utils.check_dataframe_empty = _cde
 utils.check_dataframe_empty_async = _cde
+utils.is_cuda_available = lambda: False
 sys.modules['utils'] = utils
 
 scipy_mod = types.ModuleType('scipy')

--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -38,6 +38,10 @@ async def _cde_stub(*a, **kw):
     return False
 utils_stub.check_dataframe_empty = _cde_stub
 utils_stub.check_dataframe_empty_async = _cde_stub
+utils_stub.is_cuda_available = lambda: False
+async def _safe_api_call(exchange, method: str, *args, **kwargs):
+    return await getattr(exchange, method)(*args, **kwargs)
+utils_stub.safe_api_call = _safe_api_call
 sys.modules['utils'] = utils_stub
 os.environ["TEST_MODE"] = "1"
 sys.modules.pop('trade_manager', None)
@@ -73,6 +77,10 @@ async def _cde(*a, **kw):
     return False
 utils.check_dataframe_empty = _cde
 utils.check_dataframe_empty_async = _cde
+utils.is_cuda_available = lambda: False
+async def _safe_api_call(exchange, method: str, *args, **kwargs):
+    return await getattr(exchange, method)(*args, **kwargs)
+utils.safe_api_call = _safe_api_call
 sys.modules['utils'] = utils
 
 

--- a/tests/test_trade_manager_loops.py
+++ b/tests/test_trade_manager_loops.py
@@ -40,6 +40,10 @@ async def _cde_stub(*a, **kw):
     return False
 utils_stub.check_dataframe_empty = _cde_stub
 utils_stub.check_dataframe_empty_async = _cde_stub
+utils_stub.is_cuda_available = lambda: False
+async def _safe_api_call(exchange, method: str, *args, **kwargs):
+    return await getattr(exchange, method)(*args, **kwargs)
+utils_stub.safe_api_call = _safe_api_call
 sys.modules['utils'] = utils_stub
 os.environ['TEST_MODE'] = '1'
 sys.modules.pop('trade_manager', None)

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -15,31 +15,11 @@ import inspect
 from utils import (
     logger,
     TelegramLogger,
+    is_cuda_available,
+    check_dataframe_empty_async as _check_df_async,
+    safe_api_call,
 )
-
-try:
-    from utils import is_cuda_available  # type: ignore
-except Exception:  # pragma: no cover - tests may stub this
-    def is_cuda_available() -> bool:
-        return False
-
-try:
-    from utils import check_dataframe_empty_async as _check_df_async
-except Exception:  # pragma: no cover - tests may stub this
-    from utils import check_dataframe_empty as _check_df_sync
-
-    async def _check_df_async(*a, **kw):
-        res = _check_df_sync(*a, **kw)
-        if inspect.isawaitable(res):
-            res = await res
-        return res
 from config import BotConfig, load_config
-
-try:
-    from utils import safe_api_call
-except ImportError:  # pragma: no cover - tests provide stub without this func
-    async def safe_api_call(exchange, method: str, *args, **kwargs):
-        return await getattr(exchange, method)(*args, **kwargs)
 import torch
 import joblib
 import os


### PR DESCRIPTION
## Summary
- import `is_cuda_available` directly from utils
- drop local fallbacks across the codebase
- extend unit test stubs with `is_cuda_available` and `safe_api_call`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687959d1dc28832d97374b1f1a1b669e