### PR TITLE
Improve CUDA detection with FORCE_CPU and is_built check

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ RUNTIME= DOCKERFILE=Dockerfile.cpu NVIDIA_VISIBLE_DEVICES= NVIDIA_DRIVER_CAPABIL
 
 Set `RUNTIME=` if you want to run these CPU images without the NVIDIA runtime.
 
+Setting `FORCE_CPU=1` disables all CUDA checks, useful when running GPU images on machines without working drivers.
+
 The `trade_manager` container needs extra shared memory. The compose file
 allocates 2GB via `shm_size: '2gb'` to enlarge `/dev/shm`.
 

--- a/utils.py
+++ b/utils.py
@@ -60,8 +60,18 @@ _BYBIT_INTERVALS = {
 def is_cuda_available() -> bool:
     """Safely check whether CUDA is available via PyTorch."""
 
+    # Allow forcing CPU mode via environment variables before importing torch
+    if os.environ.get("FORCE_CPU") == "1":
+        return False
+
+    nvd = os.environ.get("NVIDIA_VISIBLE_DEVICES")
+    if nvd is not None and (nvd == "" or nvd.lower() == "none"):
+        return False
+
     try:  # Lazy import to avoid heavy initialization when unused
         import torch  # type: ignore
+        if not torch.backends.cuda.is_built():
+            return False
         return torch.cuda.is_available()
     except Exception as exc:  # pragma: no cover - optional dependency
         logging.getLogger("TradingBot").warning(


### PR DESCRIPTION
## Summary
- honor `FORCE_CPU` and `NVIDIA_VISIBLE_DEVICES` in `is_cuda_available`
- verify CUDA support via `torch.backends.cuda.is_built()`
- document `FORCE_CPU` environment variable in quick-start guide

## Testing
- `pip install -r requirements-cpu.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a0d0ca2ac832db9a4161e999fabb3