### PR TITLE
Use asyncio.to_thread for non-blocking ray.get

### DIFF
--- a/optimizer.py
+++ b/optimizer.py
@@ -234,7 +234,7 @@ class ParameterOptimizer:
                 obj_ref = self.objective(trial, symbol, df)
                 obj_refs.append(obj_ref)
                 trials.append(trial)
-            results = ray.get(obj_refs)
+            results = await asyncio.to_thread(ray.get, obj_refs)
             for t in trials:
                 logger.debug(
                     "Received result for %s trial %s", symbol, t.number


### PR DESCRIPTION
## Summary
- avoid blocking the event loop when gathering Optuna trial results

## Testing
- `pre-commit run --files tests/test_optimizer_ray.py tests/test_optimizer.py`

------
https://chatgpt.com/codex/tasks/task_e_687a10350434832d83cb2896ba6ee1fe