### PR TITLE
Increase shared memory for trade_manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Set `RUNTIME=` if you want to run these CPU images without the NVIDIA runtime.
 Setting `FORCE_CPU=1` disables all CUDA checks, useful when running GPU images on machines without working drivers.
 
 The `trade_manager` container needs extra shared memory. The compose file
-allocates 2GB via `shm_size: '2gb'` to enlarge `/dev/shm`.
+allocates 8GB via `shm_size: '8gb'` to enlarge `/dev/shm`.
 
 The `model_builder` service sets `TF_CPP_MIN_LOG_LEVEL=3` to hide verbose TensorFlow
 GPU warnings. Adjust or remove this variable if you need more detailed logs.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       - ./models:/app/models
       - ./cache:/app/cache
       - ./config.json:/app/config.json
-    shm_size: '2gb'
+    shm_size: '8gb'
     networks:
       - trading_bot_default
   trading_bot:


### PR DESCRIPTION
## Summary
- bump `shm_size` for `trade_manager` service
- document the larger shared memory allocation

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687a120a4efc832d9bc8bde51fc03ea6