### PR TITLE
Add install-test-deps script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-cpu.txt
+          ./scripts/install-test-deps.sh
       - name: Lint
-        run: flake8
+        run: python -m flake8
       - name: Test
         run: pytest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,12 @@ Thank you for your interest in contributing to this project!
 
 ## Development workflow
 
-1. Install dependencies from `requirements-cpu.txt` in a virtual environment.
-2. Run `flake8` and `pytest` before submitting a pull request. These tests are
+1. Install dependencies in a virtual environment using the helper script:
+
+   ```bash
+   ./scripts/install-test-deps.sh
+   ```
+2. Run `python -m flake8` and `pytest` before submitting a pull request. These tests are
    also executed automatically by `pre-commit`.
 
 ## CI troubleshooting

--- a/README.md
+++ b/README.md
@@ -375,10 +375,10 @@ MLFLOW_TRACKING_URI=mlruns python trading_bot.py
 ## Running tests
 
 Running `pytest` requires the packages listed in `requirements-cpu.txt`.
-Install them with:
+Install them with the helper script:
 
 ```bash
-pip install -r requirements-cpu.txt
+./scripts/install-test-deps.sh
 ```
 
 If you skip this step and run `pytest` anyway, common imports like
@@ -389,10 +389,10 @@ For a clean environment you can create a virtualenv and install the
 CPU requirements before running the tests:
 
 ```bash
-python3 -m venv venv
-source venv/bin/activate
-pip install -r requirements-cpu.txt
-pytest
+    python3 -m venv venv
+    source venv/bin/activate
+    ./scripts/install-test-deps.sh
+    pytest
 ```
 
 The `requirements-cpu.txt` file already bundles `pytest` and all other
@@ -402,7 +402,7 @@ Unit tests automatically set the environment variable `TEST_MODE=1`.
 This disables the Telegram logger's background worker thread so tests
 run without spawning extra threads.
 
-As noted above, make sure to run `pip install -r requirements-cpu.txt` before
+As noted above, make sure to run `./scripts/install-test-deps.sh` before
 executing `pytest`; otherwise imports such as `numpy`, `pandas`, `scipy` and
 `requests` will fail.
 
@@ -412,10 +412,10 @@ executing `pytest`; otherwise imports such as `numpy`, `pandas`, `scipy` and
 Пример полного процесса:
 
 ```bash
-python3 -m venv venv
-source venv/bin/activate
-pip install -r requirements-cpu.txt
-pytest
+    python3 -m venv venv
+    source venv/bin/activate
+    ./scripts/install-test-deps.sh
+    pytest
 ```
 
 Если у вас есть GPU и установленный CUDA, можно установить полный список зависимостей из `requirements.txt` и затем запустить те же тесты.
@@ -483,11 +483,11 @@ pre-commit run --all-files
 Linting configuration is stored in `.flake8`. Run the checker manually:
 
 ```bash
-flake8
+python -m flake8
 ```
 
 ## Continuous integration
 
 All pushes and pull requests trigger a GitHub Actions workflow that installs
-dependencies from `requirements-cpu.txt`, runs `flake8`, and executes `pytest`.
+dependencies via `scripts/install-test-deps.sh`, runs `python -m flake8`, and executes `pytest`.
 This ensures style checks and tests run automatically.

--- a/scripts/install-test-deps.sh
+++ b/scripts/install-test-deps.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+set -e
+# Install Python packages needed for running the test suite.
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+python -m pip install -r "$REPO_ROOT/requirements-cpu.txt"


### PR DESCRIPTION
## Summary
- add script to install requirements-cpu.txt
- use the helper script in CI
- document the script in the README
- instruct contributors to use the helper script
- call `pip` through `python -m pip`
- run lint step using `python -m flake8`

## Testing
- `python -m flake8` *(fails: No module named flake8)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_687a1756b0f0832dafd0fdb3d1939907