### PR TITLE
Fix README quick-start pip commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
    python3 -m venv venv
    source venv/bin/activate
    # Вариант с GPU (по умолчанию)
-   pip install -r requirements.txt
+   python -m pip install -r requirements.txt
    # Или CPU‑сборки без CUDA
-   pip install -r requirements-cpu.txt
+   python -m pip install -r requirements-cpu.txt
    ```
    Список `requirements-cpu.txt` содержит версии `torch` и `tensorflow` без поддержки GPU. Его можно использовать для установки зависимостей и запуска тестов на машинах без CUDA.
 - После обновления зависимостей пакет `optuna-integration[botorch]` больше не используется.


### PR DESCRIPTION
## Summary
- update quick-start instructions to use `python -m pip install`

## Testing
- `pytest -k import_order -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687a39a2cc5c832d97eebda95c6d6977