### PR TITLE
Add --full option to install-test-deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,10 +375,12 @@ MLFLOW_TRACKING_URI=mlruns python trading_bot.py
 ## Running tests
 
 Running `pytest` requires the packages listed in `requirements-cpu.txt`.
-Install them with the helper script (which also installs `flake8`):
+Install them with the helper script (which also installs `flake8`).
+Pass `--full` to install the GPU-enabled packages from `requirements.txt`:
 
 ```bash
-./scripts/install-test-deps.sh
+./scripts/install-test-deps.sh         # CPU packages only
+./scripts/install-test-deps.sh --full  # full requirements.txt
 ```
 
 If you skip this step and run `pytest` anyway, common imports like
@@ -418,7 +420,9 @@ executing `pytest`; otherwise imports such as `numpy`, `pandas`, `scipy` and
     pytest
 ```
 
-Если у вас есть GPU и установленный CUDA, можно установить полный список зависимостей из `requirements.txt` и затем запустить те же тесты.
+Если у вас есть GPU и установленный CUDA, можно установить полный список
+зависимостей командой `./scripts/install-test-deps.sh --full` и затем
+запустить те же тесты.
 
 The `requirements.txt` file already includes test-only packages such as
 `pytest`, `optuna` and `tenacity`, so no separate `requirements-dev.txt`

--- a/scripts/install-test-deps.sh
+++ b/scripts/install-test-deps.sh
@@ -2,5 +2,16 @@
 set -e
 # Install Python packages needed for running the test suite.
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-python -m pip install -r "$REPO_ROOT/requirements-cpu.txt"
+
+# Default to the lightweight CPU requirements. Pass --full to install
+# the complete list from requirements.txt (includes GPU packages).
+REQ_FILE="requirements-cpu.txt"
+if [ "$1" = "--full" ]; then
+    REQ_FILE="requirements.txt"
+elif [ -n "$1" ]; then
+    echo "Usage: $0 [--full]" >&2
+    exit 1
+fi
+
+python -m pip install -r "$REPO_ROOT/$REQ_FILE"
 python -m pip install flake8


### PR DESCRIPTION
## Summary
- allow choosing between `requirements-cpu.txt` and full `requirements.txt`
- document the new flag in the README

## Testing
- `python -m flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ta')*

------
https://chatgpt.com/codex/tasks/task_e_687a4621b650832d8b0eeeace9c6dbba