### PR TITLE
Add CPU test setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,12 +377,16 @@ MLFLOW_TRACKING_URI=mlruns python trading_bot.py
 ## Running tests
 
 Running `pytest` requires the packages listed in `requirements-cpu.txt`.
-Install them with the helper script (which also installs `flake8`).
-Pass `--full` to install the GPU-enabled packages from `requirements.txt`:
+Install them using the helper script:
 
 ```bash
-./scripts/install-test-deps.sh         # CPU packages only
-./scripts/install-test-deps.sh --full  # full requirements.txt
+./scripts/setup-tests.sh        # CPU packages only
+```
+
+To install the GPU-enabled packages from `requirements.txt` instead, run:
+
+```bash
+./scripts/install-test-deps.sh --full
 ```
 
 If you skip this step and run `pytest` anyway, common imports like
@@ -395,7 +399,7 @@ CPU requirements before running the tests:
 ```bash
     python3 -m venv venv
     source venv/bin/activate
-    ./scripts/install-test-deps.sh
+    ./scripts/setup-tests.sh
     pytest
 ```
 
@@ -406,7 +410,7 @@ Unit tests automatically set the environment variable `TEST_MODE=1`.
 This disables the Telegram logger's background worker thread so tests
 run without spawning extra threads.
 
-As noted above, make sure to run `./scripts/install-test-deps.sh` before
+As noted above, make sure to run `./scripts/setup-tests.sh` before
 executing `pytest`; otherwise imports such as `numpy`, `pandas`, `scipy` and
 `requests` will fail.
 
@@ -418,13 +422,13 @@ executing `pytest`; otherwise imports such as `numpy`, `pandas`, `scipy` and
 ```bash
     python3 -m venv venv
     source venv/bin/activate
-    ./scripts/install-test-deps.sh
+    ./scripts/setup-tests.sh
     pytest
 ```
 
 Если у вас есть GPU и установленный CUDA, можно установить полный список
 зависимостей командой `./scripts/install-test-deps.sh --full` и затем
-запустить те же тесты.
+  запустить те же тесты.
 
 The `requirements.txt` file already includes test-only packages such as
 `pytest`, `optuna` and `tenacity`, so no separate `requirements-dev.txt`

--- a/scripts/setup-tests.sh
+++ b/scripts/setup-tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+set -e
+# Install only the packages required for running the unit tests on a CPU.
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+python -m pip install -r "$REPO_ROOT/requirements-cpu.txt"


### PR DESCRIPTION
## Summary
- add `scripts/setup-tests.sh` for installing CPU packages for the test suite
- document the new helper script in the README

## Testing
- `python -m flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b7747d70c832d8e21d35085bdb2e2