### PR TITLE
Fix GPU detection to avoid numba crash

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -39,14 +39,16 @@ if os.environ.get("FORCE_CPU") == "1":
     cuda = None  # type: ignore
     GPU_AVAILABLE = False
 else:
-    try:
-        from numba import cuda  # type: ignore
-
-        GPU_AVAILABLE = hasattr(cuda, "is_available") and cuda.is_available()
-    except Exception as e:  # pragma: no cover - numba without cuda support
-        logger.warning("CUDA initialization failed: %s", e)
+    GPU_AVAILABLE = is_cuda_available()
+    if GPU_AVAILABLE:
+        try:
+            from numba import cuda  # type: ignore
+        except Exception as e:  # pragma: no cover - numba without cuda support
+            logger.warning("Numba CUDA import failed: %s", e)
+            cuda = None  # type: ignore
+            GPU_AVAILABLE = False
+    else:
         cuda = None  # type: ignore
-        GPU_AVAILABLE = False
 
 
 def create_exchange() -> BybitSDKAsync:


### PR DESCRIPTION
## Summary
- safely check CUDA before importing numba in `data_handler`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b8047f474832da54b1f47eaa2d43c