### PR TITLE
Set mp spawn start method

### DIFF
--- a/trade_manager.py
+++ b/trade_manager.py
@@ -29,6 +29,10 @@ import shutil
 from dotenv import load_dotenv
 from flask import Flask, request, jsonify
 import threading
+import multiprocessing as mp
+
+if mp.get_start_method(allow_none=True) != "spawn":
+    mp.set_start_method("spawn", force=True)
 
 # Determine computation device once
 


### PR DESCRIPTION
## Summary
- ensure `multiprocessing` uses spawn start method in trade_manager

## Testing
- `pytest -q` *(fails: 21 failed, 48 passed, 23 warnings)*
- `timeout 3 python trade_manager.py` *(fails: ModuleNotFoundError: 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_687b8cf37ce4832dae2b958462965252