### PR TITLE
Add GPU allocation to calc_indicators

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -194,7 +194,7 @@ class IndicatorsCache:
             return None
 
 
-@ray.remote(num_cpus=1)
+@ray.remote(num_cpus=1, num_gpus=1 if GPU_AVAILABLE else 0)
 def calc_indicators(
     df: pd.DataFrame, config: BotConfig, volatility: float, timeframe: str
 ):


### PR DESCRIPTION
## Summary
- allocate GPU for `calc_indicators` when available

## Testing
- `python -m flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b8f7b5708832d88a3a5ad2846e1df