### PR TITLE
Add CUDA library path in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     ports:
       - "8000:8000"
     env_file: .env
+    environment:
+      - LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda/nvvm/lib64
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/ping"]
       interval: 5s
@@ -49,6 +51,8 @@ services:
     ports:
       - "8002:8002"
     env_file: .env
+    environment:
+      - LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda/nvvm/lib64
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8002/ping"]
       interval: 5s


### PR DESCRIPTION
## Summary
- add `LD_LIBRARY_PATH` env var to `data_handler` and `trade_manager` services in `docker-compose.yml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687bc35c0750832db869bdcf5cd5ae7a