### PR TITLE
Fix interactive tzdata install in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,8 @@ RUN pip install --no-cache-dir pip==24.0 setuptools wheel && \
 
 # Этап выполнения
 FROM nvidia/cuda:12.5.1-cudnn-devel-ubuntu22.04
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- set `DEBIAN_FRONTEND=noninteractive` and `TZ=Etc/UTC` in the runtime stage

## Testing
- `./scripts/setup-tests.sh`
- `python -m flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bd28665d4832dbf83b15db276b639