### PR TITLE
Use 2h timeframe

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
     "exchange": "bybit",
-    "timeframe": "1m",
+    "timeframe": "2h",
     "secondary_timeframe": "2h",
     "ws_url": "wss://stream.bybit.com/v5/public/linear",
     "private_ws_url": "wss://stream.bybit.com/v5/private",


### PR DESCRIPTION
## Summary
- switch default timeframe to 2h in `config.json`

## Testing
- `python -m flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c165ee3dc832d8c6d3fb2516a731a