### PR TITLE
Fix LSTM feature alignment

### DIFF
--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -87,6 +87,15 @@ def test_prepare_lstm_features_shape():
     assert isinstance(features, np.ndarray)
     assert features.shape == (len(df), 14)
 
+
+def test_prepare_lstm_features_with_short_indicators():
+    df = make_df()
+    mb = create_model_builder(df)
+    indicators = DummyIndicators(len(df) - 2)
+    features = asyncio.run(mb.prepare_lstm_features("BTCUSDT", indicators))
+    assert isinstance(features, np.ndarray)
+    assert features.shape == (len(df), 14)
+
 @pytest.mark.parametrize("model_type", ["cnn_lstm", "mlp"])
 def test_train_model_remote_returns_state_and_predictions(model_type):
     X = np.random.rand(20, 3, 2).astype(np.float32)


### PR DESCRIPTION
## Summary
- align indicator series to OHLCV index when preparing LSTM and RL features
- add regression test for short indicator arrays

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ce1412a20832d8674ada503a5a3a6