### PR TITLE
Fix utils reload in force_cpu test

### DIFF
--- a/tests/test_force_cpu.py
+++ b/tests/test_force_cpu.py
@@ -1,9 +1,11 @@
 import os
 import importlib
+import sys
 import utils
 
 
-def test_force_cpu():
-    os.environ["FORCE_CPU"] = "1"
+def test_force_cpu(monkeypatch):
+    monkeypatch.setenv("FORCE_CPU", "1")
+    sys.modules["utils"] = utils
     importlib.reload(utils)
     assert utils.is_cuda_available() is False


### PR DESCRIPTION
## Summary
- ensure utils module is reloaded correctly when FORCE_CPU env var is set

## Testing
- `pytest tests/test_force_cpu.py::test_force_cpu -q`
- `pytest -q` *(fails: async timeouts and missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687ce6fb4c54832d82f25b5d0adc0cd2