### PR TITLE
Fix SHAP cache filenames

### DIFF
--- a/model_builder.py
+++ b/model_builder.py
@@ -695,7 +695,9 @@ class ModelBuilder:
                 return
             torch_mods = _get_torch_modules()
             torch = torch_mods['torch']
-            cache_file = os.path.join(self.cache.cache_dir, f"shap_{symbol}.pkl")
+            safe_symbol = symbol.replace('/', '_').replace(':', '_')
+            cache_file = os.path.join(self.cache.cache_dir, f"shap_{safe_symbol}.pkl")
+            os.makedirs(os.path.dirname(cache_file), exist_ok=True)
             last_time = self.shap_cache_times.get(symbol, 0)
             if time.time() - last_time < self.shap_cache_duration:
                 return

--- a/tests/test_shap_cache.py
+++ b/tests/test_shap_cache.py
@@ -1,0 +1,43 @@
+import asyncio
+import types
+import numpy as np
+import pytest
+from config import BotConfig
+import model_builder
+
+class DummyTL:
+    async def send_telegram_message(self, *args, **kwargs):
+        pass
+
+class DummyDH:
+    def __init__(self):
+        self.usdt_pairs = []
+        self.telegram_logger = DummyTL()
+
+class DummyTM:
+    pass
+
+class DummyExplainer:
+    def __init__(self, model, data):
+        pass
+    def shap_values(self, data):
+        return [np.zeros(data.shape)]
+
+
+@pytest.mark.asyncio
+async def test_shap_cache_file_safe_symbol(tmp_path, monkeypatch):
+    cfg = BotConfig(
+        cache_dir=str(tmp_path),
+        model_type="cnn_lstm",
+        nn_framework="pytorch",
+        min_data_length=1,
+        lstm_timesteps=1,
+    )
+    mb = model_builder.ModelBuilder(cfg, DummyDH(), DummyTM())
+    torch = model_builder._get_torch_modules()["torch"]
+    model = torch.nn.Linear(1, 1)
+    X = np.random.rand(5, 1, 1).astype(np.float32)
+    shap_stub = types.SimpleNamespace(GradientExplainer=DummyExplainer)
+    monkeypatch.setattr(model_builder, "shap", shap_stub)
+    await mb.compute_shap_values("BTC/USDT:PERP", model, X)
+    assert (tmp_path / "shap_BTC_USDT_PERP.pkl").exists()


### PR DESCRIPTION
## Summary
- sanitize symbol when generating SHAP cache filename
- add regression test for SHAP cache path when symbol contains special characters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ce913e500832d92fed2d2ab44de60