### PR TITLE
Fix ws_queue timeout handling

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -1227,8 +1227,9 @@ class DataHandler:
                 symbol = topic.split(".")[-1] if isinstance(topic, str) else ""
                 priority = self.symbol_priority.get(symbol, 0)
                 try:
-                    await self.ws_queue.put(
-                        (priority, (symbols, message, timeframe)), timeout=5
+                    await asyncio.wait_for(
+                        self.ws_queue.put((priority, (symbols, message, timeframe))),
+                        timeout=5,
                     )
                 except asyncio.TimeoutError:
                     logger.warning(


### PR DESCRIPTION
## Summary
- fix WebSocket queue put call to use `asyncio.wait_for`

## Testing
- `PYTHONPATH=. pytest tests/test_data_handler.py::test_load_from_disk_buffer_loop -q`

------
https://chatgpt.com/codex/tasks/task_e_687ceaed1624832dac4961d05872b453