### PR TITLE
Fix DummyDataHandler variance

### DIFF
--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -47,8 +47,9 @@ class DummyIndicators:
 class DummyDataHandler:
     def __init__(self, df):
         self.ohlcv = df
-        self.funding_rates = {"BTCUSDT": 0.1}
-        self.open_interest = {"BTCUSDT": 0.2}
+        n = len(df)
+        self.funding_rates = {"BTCUSDT": np.linspace(0.1, 0.2, n)}
+        self.open_interest = {"BTCUSDT": np.linspace(0.2, 0.3, n)}
         self.usdt_pairs = ["BTCUSDT"]
 
 class DummyTradeManager:


### PR DESCRIPTION
## Summary
- fix DummyDataHandler so `funding_rates` and `open_interest` contain
  varying values

## Testing
- `pytest -k 'test_prepare_lstm_features_shape or test_prepare_lstm_features_with_short_indicators' -q` *(fails: ModuleNotFoundError: No module named 'sklearn.preprocessing'; 'sklearn' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_687cee19b22c832da7b57b49af797ca3