### PR TITLE
Fix Flask async routes and training predictions

### DIFF
--- a/model_builder.py
+++ b/model_builder.py
@@ -337,8 +337,8 @@ def _train_model_remote(X, y, batch_size, model_type="cnn_lstm", framework="pyto
                     val_X = val_X.view(val_X.size(0), -1)
                 val_y = val_y.to(device)
                 outputs = model(val_X).squeeze()
-                preds.extend(outputs.cpu().numpy())
-                labels.extend(val_y.cpu().numpy())
+                preds.extend(outputs.cpu().numpy().reshape(-1))
+                labels.extend(val_y.cpu().numpy().reshape(-1))
                 val_loss += criterion(outputs, val_y).item()
         val_loss /= len(val_loader)
         if val_loss + 1e-4 < best_loss:

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -1283,7 +1283,7 @@ else:
 
 
 @api_app.route("/open_position", methods=["POST"])
-async def open_position_route():
+def open_position_route():
     """Open a new trade position."""
     if not _ready_event.is_set() or trade_manager is None:
         return jsonify({"error": "not ready"}), 503
@@ -1302,7 +1302,7 @@ def positions_route():
 
 
 @api_app.route("/start")
-async def start_route():
+def start_route():
     if not _ready_event.is_set() or trade_manager is None:
         return jsonify({"error": "not ready"}), 503
     asyncio.create_task(trade_manager.run())


### PR DESCRIPTION
## Summary
- remove `async` keyword from Flask endpoints in `trade_manager`
- flatten model outputs in `_train_model_remote`

## Testing
- `flake8`
- `pytest tests/test_model_builder.py -k train_model_remote_returns_state_and_predictions -vv`
- `pytest tests/test_trade_manager.py::test_open_position_places_tp_sl_orders -vv`


------
https://chatgpt.com/codex/tasks/task_e_687d08c4c43c832db9dd1b2b78c776da