### PR TITLE
Use single Gunicorn worker for data services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: ${DOCKERFILE:-Dockerfile}
     # Run the full data handler implementation
-    command: gunicorn -w 2 -b 0.0.0.0:8000 --timeout ${GUNICORN_TIMEOUT:-120} data_handler:api_app
+    command: gunicorn -w 1 -b 0.0.0.0:8000 --timeout ${GUNICORN_TIMEOUT:-120} data_handler:api_app
     runtime: ${RUNTIME:-nvidia}
     ports:
       - "8000:8000"
@@ -26,7 +26,7 @@ services:
       context: .
       dockerfile: ${DOCKERFILE:-Dockerfile}
     # Run the full model builder implementation
-    command: gunicorn -w 2 -b 0.0.0.0:8001 --timeout ${GUNICORN_TIMEOUT:-120} model_builder:api_app
+    command: gunicorn -w 1 -b 0.0.0.0:8001 --timeout ${GUNICORN_TIMEOUT:-120} model_builder:api_app
     runtime: ${RUNTIME:-nvidia}
     ports:
       - "8001:8001"


### PR DESCRIPTION
## Summary
- run `data_handler` and `model_builder` with one Gunicorn worker

## Testing
- `docker compose build data_handler model_builder` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e12b98920832d939c04e10b4ea5c6