### PR TITLE
Add open interest dynamics

### DIFF
--- a/model_builder.py
+++ b/model_builder.py
@@ -487,6 +487,7 @@ class ModelBuilder:
         features_df = df[['close', 'open', 'high', 'low', 'volume']].copy()
         features_df['funding'] = self.data_handler.funding_rates.get(symbol, 0.0)
         features_df['open_interest'] = self.data_handler.open_interest.get(symbol, 0.0)
+        features_df['oi_change'] = self.data_handler.open_interest_change.get(symbol, 0.0)
         def _align(series: pd.Series) -> np.ndarray:
             """Return values aligned to ``df.index`` and forward filled."""
             if not isinstance(series, pd.Series):
@@ -733,7 +734,7 @@ class ModelBuilder:
             mean_abs = np.mean(np.abs(values[0]), axis=(0, 1))
             feature_names = [
                 'close', 'open', 'high', 'low', 'volume', 'funding',
-                'open_interest', 'ema30', 'ema100', 'ema200', 'rsi',
+                'open_interest', 'oi_change', 'ema30', 'ema100', 'ema200', 'rsi',
                 'adx', 'macd', 'atr'
             ]
             top_idx = np.argsort(mean_abs)[-3:][::-1]

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -50,6 +50,7 @@ class DummyDataHandler:
         n = len(df)
         self.funding_rates = {"BTCUSDT": np.linspace(0.1, 0.2, n)}
         self.open_interest = {"BTCUSDT": np.linspace(0.2, 0.3, n)}
+        self.open_interest_change = {"BTCUSDT": np.linspace(0.0, 0.1, n)}
         self.usdt_pairs = ["BTCUSDT"]
 
 class DummyTradeManager:
@@ -86,7 +87,7 @@ def test_prepare_lstm_features_shape():
     indicators = DummyIndicators(len(df))
     features = asyncio.run(mb.prepare_lstm_features("BTCUSDT", indicators))
     assert isinstance(features, np.ndarray)
-    assert features.shape == (len(df), 14)
+    assert features.shape == (len(df), 15)
 
 
 def test_prepare_lstm_features_with_short_indicators():
@@ -95,7 +96,7 @@ def test_prepare_lstm_features_with_short_indicators():
     indicators = DummyIndicators(len(df) - 2)
     features = asyncio.run(mb.prepare_lstm_features("BTCUSDT", indicators))
     assert isinstance(features, np.ndarray)
-    assert features.shape == (len(df), 14)
+    assert features.shape == (len(df), 15)
 
 @pytest.mark.parametrize("model_type", ["cnn_lstm", "mlp"])
 def test_train_model_remote_returns_state_and_predictions(model_type):


### PR DESCRIPTION
## Summary
- track open interest changes inside `DataHandler`
- expose new `oi_change` feature in `ModelBuilder`
- include change in SHAP feature names
- adjust tests for the new feature and add a unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e24906774832db02f470c2bf6c156