### PR TITLE
Add RL agent tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import sklearn.model_selection  # preload submodules used in tests
 import sklearn.base
 
 import pytest
+import pandas as pd
 
 # Ensure the project root is available before tests import project modules
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
@@ -92,3 +93,17 @@ def _add_root_and_stub_modules(monkeypatch):
     """Ensure stubs exist for each test."""
     _stub_modules()
     yield
+
+
+@pytest.fixture
+def sample_ohlcv():
+    """Small OHLCV dataframe for simple tests."""
+    return pd.DataFrame(
+        {
+            "close": [1.0, 2.0, 1.0],
+            "open": [1.0, 2.0, 1.0],
+            "high": [1.0, 2.0, 1.0],
+            "low": [1.0, 2.0, 1.0],
+            "volume": [0.0, 0.0, 0.0],
+        }
+    )

--- a/tests/test_rl_agent.py
+++ b/tests/test_rl_agent.py
@@ -1,0 +1,106 @@
+import sys
+import types
+import pandas as pd
+import numpy as np
+import pytest
+
+# Stub stable_baselines3 if missing
+if "stable_baselines3" not in sys.modules:
+    sb3 = types.ModuleType("stable_baselines3")
+
+    class DummyModel:
+        def __init__(self, *a, **kw):
+            pass
+
+        def learn(self, *a, **kw):
+            return self
+
+        def predict(self, obs, deterministic=True):
+            return np.array([1]), None
+
+    sb3.PPO = DummyModel
+    sb3.DQN = DummyModel
+    common = types.ModuleType("stable_baselines3.common")
+    vec_env = types.ModuleType("stable_baselines3.common.vec_env")
+
+    class DummyVecEnv:
+        def __init__(self, env_fns):
+            self.envs = [fn() for fn in env_fns]
+
+    vec_env.DummyVecEnv = DummyVecEnv
+    common.vec_env = vec_env
+    sb3.common = common
+    sys.modules["stable_baselines3"] = sb3
+    sys.modules["stable_baselines3.common"] = common
+    sys.modules["stable_baselines3.common.vec_env"] = vec_env
+
+# Stub gymnasium if missing
+if "gymnasium" not in sys.modules:
+    gym_stub = types.ModuleType("gymnasium")
+
+    class DummyDiscrete:
+        def __init__(self, n):
+            self.n = n
+
+    class DummyBox:
+        def __init__(self, low, high, shape, dtype):
+            self.shape = shape
+
+    gym_stub.Env = object
+    gym_stub.spaces = types.SimpleNamespace(Discrete=DummyDiscrete, Box=DummyBox)
+    sys.modules["gymnasium"] = gym_stub
+
+import importlib
+import model_builder
+importlib.reload(model_builder)
+from config import BotConfig
+from model_builder import RLAgent
+
+
+class DummyModelBuilder:
+    def __init__(self):
+        self.device = "cpu"
+        self.lstm_models = {}
+
+    async def preprocess(self, df, symbol):
+        return df
+
+
+class DummyIndicators:
+    def __init__(self, length, index):
+        base = pd.Series(np.zeros(length), index=index)
+        self.ema30 = base
+        self.ema100 = base
+        self.ema200 = base
+        self.rsi = base
+        self.adx = base
+        self.macd = base
+        self.atr = base
+
+
+class DummyDataHandler:
+    def __init__(self, df, indicators):
+        self.ohlcv = df
+        self.funding_rates = {"BTCUSDT": 0.0}
+        self.open_interest = {"BTCUSDT": 0.0}
+        self.indicators = {"BTCUSDT": indicators}
+        self.usdt_pairs = ["BTCUSDT"]
+
+
+@pytest.mark.asyncio
+async def test_train_symbol_and_predict(sample_ohlcv):
+    idx = pd.MultiIndex.from_product([
+        ["BTCUSDT"], sample_ohlcv.index
+    ], names=["symbol", "timestamp"])
+    df = sample_ohlcv.copy()
+    df.index = idx
+    indicators = DummyIndicators(len(df), df.index.droplevel("symbol"))
+    dh = DummyDataHandler(df, indicators)
+    agent = RLAgent(BotConfig(rl_timesteps=1), dh, DummyModelBuilder())
+    await agent.train_symbol("BTCUSDT")
+    assert "BTCUSDT" in agent.models
+    features = await agent._prepare_features("BTCUSDT", indicators)
+    action = agent.predict(
+        "BTCUSDT", features.iloc[0].to_numpy(dtype=np.float32)
+    )
+    assert action in (None, "buy", "sell")

--- a/tests/test_trading_env.py
+++ b/tests/test_trading_env.py
@@ -1,23 +1,10 @@
-import pandas as pd
-import numpy as np
 import pytest
 from config import BotConfig
 from model_builder import TradingEnv
 
-
-def make_df():
-    return pd.DataFrame({
-        'close': [1.0, 2.0, 1.0],
-        'open': [1.0, 2.0, 1.0],
-        'high': [1.0, 2.0, 1.0],
-        'low': [1.0, 2.0, 1.0],
-        'volume': [0.0, 0.0, 0.0],
-    })
-
-
-def test_drawdown_penalty():
+def test_drawdown_penalty(sample_ohlcv):
     cfg = BotConfig(drawdown_penalty=0.5)
-    env = TradingEnv(make_df(), cfg)
+    env = TradingEnv(sample_ohlcv, cfg)
     env.reset()
     _, r1, _, _ = env.step(1)  # buy -> profit 1
     assert r1 == 1.0
@@ -27,4 +14,15 @@ def test_drawdown_penalty():
     assert pytest.approx(r2) == -1.5
     assert env.balance == 0.0
     assert env.max_balance == 1.0
+
+
+def test_step_rewards(sample_ohlcv):
+    env = TradingEnv(sample_ohlcv, BotConfig())
+    env.reset()
+    _, r1, _, _ = env.step(1)
+    assert r1 == 1.0
+    _, r2, done, _ = env.step(2)
+    assert r2 == 1.0
+    assert done
+    assert env.balance == 2.0
 


### PR DESCRIPTION
## Summary
- extend trading environment tests for reward handling
- add RLAgent training and prediction test with minimal stubs
- provide shared OHLCV fixture

## Testing
- `pytest tests/test_trading_env.py tests/test_rl_agent.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687e3509d040832da1456b32ad64d807