### PR TITLE
Improve indicators cache

### DIFF
--- a/tests/test_indicators_cache.py
+++ b/tests/test_indicators_cache.py
@@ -27,7 +27,8 @@ def make_df(length=30):
         "low": np.linspace(1, 2, length) - 0.1,
         "volume": np.ones(length),
     }
-    return pd.DataFrame(data)
+    idx = pd.date_range("2020-01-01", periods=length, freq="1min")
+    return pd.DataFrame(data, index=idx)
 
 
 def test_interval_from_config():
@@ -47,3 +48,36 @@ def test_volume_profile_respects_interval():
     df = make_df(30)
     ind = IndicatorsCache(df, cfg, 0.1)
     assert ind.volume_profile is None
+
+
+def test_incremental_update():
+    cfg = BotConfig(ema30_period=3, ema100_period=5, ema200_period=7, atr_period_default=3)
+    df = make_df(30)
+    ind = IndicatorsCache(df, cfg, 0.1)
+    prev_ema30 = ind.last_ema30
+    prev_ema100 = ind.last_ema100
+    prev_ema200 = ind.last_ema200
+    prev_atr = ind.last_atr
+    prev_close = ind.last_close
+
+    new = pd.DataFrame({
+        "close": [2.1],
+        "high": [2.2],
+        "low": [2.0],
+        "volume": [1.0],
+    }, index=[df.index[-1] + pd.Timedelta(minutes=1)])
+    ind.update(new)
+
+    alpha30 = 2 / (cfg.ema30_period + 1)
+    alpha100 = 2 / (cfg.ema100_period + 1)
+    alpha200 = 2 / (cfg.ema200_period + 1)
+    tr = max(2.2 - 2.0, abs(2.2 - prev_close), abs(2.0 - prev_close))
+    expected_ema30 = alpha30 * 2.1 + (1 - alpha30) * prev_ema30
+    expected_ema100 = alpha100 * 2.1 + (1 - alpha100) * prev_ema100
+    expected_ema200 = alpha200 * 2.1 + (1 - alpha200) * prev_ema200
+    expected_atr = (prev_atr * (cfg.atr_period_default - 1) + tr) / cfg.atr_period_default
+
+    assert np.isclose(ind.last_ema30, expected_ema30)
+    assert np.isclose(ind.last_ema100, expected_ema100)
+    assert np.isclose(ind.last_ema200, expected_ema200)
+    assert np.isclose(ind.last_atr, expected_atr)


### PR DESCRIPTION
## Summary
- extend IndicatorsCache with incremental EMA/ATR update
- track last computed values for each symbol
- update DataHandler to use incremental updates
- test EMA/ATR incremental calculation

## Testing
- `pytest`
- `python -m flake8`


------
https://chatgpt.com/codex/tasks/task_e_687e7e3025cc832d87ecf8d07431691e