### PR TITLE
Add test for safe_api_call retries

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,34 @@
+import asyncio
+import pytest
+
+import utils
+
+
+class DummyExchange:
+    def __init__(self):
+        self.calls = 0
+        self.last_http_status = 200
+
+    async def fail(self):
+        self.calls += 1
+        return {'retCode': 1}
+
+
+@pytest.mark.asyncio
+async def test_safe_api_call_retries(monkeypatch):
+    exch = DummyExchange()
+
+    sleep_calls = {'n': 0}
+    orig_sleep = asyncio.sleep
+
+    async def fast_sleep(_):
+        sleep_calls['n'] += 1
+        await orig_sleep(0)
+
+    monkeypatch.setattr(utils.asyncio, 'sleep', fast_sleep)
+
+    with pytest.raises(RuntimeError):
+        await utils.safe_api_call(exch, 'fail')
+
+    assert exch.calls == 5
+    assert sleep_calls['n'] == 4


### PR DESCRIPTION
## Summary
- add `tests/test_utils.py` covering `safe_api_call`

## Testing
- `python -m flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687e89d4beac832dbd1b949f2e9b9730