### PR TITLE
Improve ws_min_process_rate handling

### DIFF
--- a/config.json
+++ b/config.json
@@ -67,7 +67,7 @@
     "retrain_interval": 86400,
     "min_liquidity": 1000000,
     "ws_queue_size": 10000,
-    "ws_min_process_rate": 30,
+    "ws_min_process_rate": 1,
     "disk_buffer_size": 10000,
     "prediction_history_size": 100,
     "telegram_queue_size": 100,

--- a/config.py
+++ b/config.py
@@ -107,7 +107,7 @@ class BotConfig:
     retrain_interval: int = _get_default("retrain_interval", 86400)
     min_liquidity: int = _get_default("min_liquidity", 1000000)
     ws_queue_size: int = _get_default("ws_queue_size", 10000)
-    ws_min_process_rate: int = _get_default("ws_min_process_rate", 30)
+    ws_min_process_rate: int = _get_default("ws_min_process_rate", 1)
     disk_buffer_size: int = _get_default("disk_buffer_size", 10000)
     prediction_history_size: int = _get_default("prediction_history_size", 100)
     telegram_queue_size: int = _get_default("telegram_queue_size", 100)

--- a/data_handler.py
+++ b/data_handler.py
@@ -340,7 +340,10 @@ class DataHandler:
         self.cleanup_lock = asyncio.Lock()
         self.ws_rate_timestamps = []
         self.process_rate_timestamps = []
-        self.ws_min_process_rate = config.get("ws_min_process_rate", 30)
+        self.ws_min_process_rate = config.get("ws_min_process_rate", 1)
+        if self.ws_min_process_rate <= 1:
+            tf_seconds = pd.Timedelta(config.timeframe).total_seconds()
+            self.ws_min_process_rate = max(1, int(1800 / tf_seconds))
         self.process_rate_window = 1
         self.cleanup_task = None
         self.ws_queue = asyncio.PriorityQueue(

--- a/tests/test_config_env.py
+++ b/tests/test_config_env.py
@@ -16,3 +16,10 @@ def test_backup_ws_urls_json_env(monkeypatch, tmp_path):
     monkeypatch.setenv("BACKUP_WS_URLS", '["wss://a","wss://b"]')
     cfg = load_config(str(cfg_file))
     assert cfg.backup_ws_urls == ["wss://a", "wss://b"]
+
+
+def test_ws_min_process_rate_default(tmp_path):
+    cfg_file = tmp_path / "c.json"
+    cfg_file.write_text('{"timeframe": "2h"}')
+    cfg = load_config(str(cfg_file))
+    assert cfg.ws_min_process_rate == 1


### PR DESCRIPTION
## Summary
- lower `ws_min_process_rate` default in `config.json` and `BotConfig`
- compute minimum processing rate automatically from timeframe
- test that default is applied and DataHandler derives rate correctly

## Testing
- `pytest tests/test_config_env.py tests/test_data_handler.py::test_dynamic_ws_min_process_rate_short_tf tests/test_data_handler.py::test_dynamic_ws_min_process_rate_long_tf -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ea32e5028832d8d53b18ec3393f9e