### PR TITLE
Launch TradeManager via Flask hook

### DIFF
--- a/trade_manager.py
+++ b/trade_manager.py
@@ -1264,11 +1264,22 @@ def _initialize_trade_manager() -> None:
         raise
 
 
-# Start initialization when the module is imported
+# Load environment variables when the module is imported
 load_dotenv()
 if os.getenv("TEST_MODE") == "1":
     _ready_event.set()
-else:
+
+
+_startup_launched = False
+
+
+@api_app.before_request
+def _start_trade_manager() -> None:
+    """Launch trade manager initialization in a background thread."""
+    global _startup_launched
+    if _startup_launched or os.getenv("TEST_MODE") == "1":
+        return
+    _startup_launched = True
     threading.Thread(target=_initialize_trade_manager, daemon=True).start()
 
 


### PR DESCRIPTION
## Summary
- move thread startup to a Flask hook so it runs only when the API starts

## Testing
- `flake8 trade_manager.py`
- `pytest tests/test_trade_manager.py tests/test_trade_manager_routes.py tests/test_import_order.py tests/test_trade_manager_loops.py`
- `gunicorn` command failed due to missing dependencies

------
https://chatgpt.com/codex/tasks/task_e_687f4df408d8832da0daad7cfc0b0f00