### PR TITLE
Update Ray CPU default

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@
   - `max_symbols` задаёт количество наиболее ликвидных торговых пар, которые бот выберет из доступных.
   - `secondary_timeframe` определяет дополнительный интервал (по умолчанию `2h`). Свечи этого таймфрейма бот запрашивает напрямую у биржи и не агрегирует из основного. См. `DataHandler.load_initial` и `_send_subscriptions`.
   - `max_subscriptions_per_connection` определяет, сколько символов подписывается через одно WebSocket‑соединение.
-   - `telegram_queue_size` ограничивает размер очереди сообщений Telegram.
+  - `ray_num_cpus` задаёт число потоков, которые Ray выделяет под задачи (по умолчанию 32). Убедитесь, что у хоста достаточно ядер или уменьшите значение.
+  - `telegram_queue_size` ограничивает размер очереди сообщений Telegram.
 4. Запустите бота. При локальном запуске без Docker Compose задайте адреса сервисов переменными `DATA_HANDLER_URL`, `MODEL_BUILDER_URL` и `TRADE_MANAGER_URL`:
 ```bash
 DATA_HANDLER_URL=http://localhost:8000 \

--- a/config.json
+++ b/config.json
@@ -55,7 +55,7 @@
     "model_save_path": "/app/models",
     "cache_dir": "/app/cache",
     "log_dir": "/app/logs",
-    "ray_num_cpus": 4,
+    "ray_num_cpus": 32,
     "max_recovery_attempts": 3,
     "n_splits": 5,
     "optimization_interval": 7200,

--- a/config.py
+++ b/config.py
@@ -95,7 +95,7 @@ class BotConfig:
     model_save_path: str = _get_default("model_save_path", "/app/models")
     cache_dir: str = _get_default("cache_dir", "/app/cache")
     log_dir: str = _get_default("log_dir", "/app/logs")
-    ray_num_cpus: int = _get_default("ray_num_cpus", 4)
+    ray_num_cpus: int = _get_default("ray_num_cpus", 32)
     max_recovery_attempts: int = _get_default("max_recovery_attempts", 3)
     n_splits: int = _get_default("n_splits", 5)
     optimization_interval: int = _get_default("optimization_interval", 7200)


### PR DESCRIPTION
## Summary
- default Ray to 32 CPUs in `config.json`
- bump `BotConfig.ray_num_cpus` default to 32
- document Ray CPU requirement in README

## Testing
- `./scripts/setup-tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f85c547ec832d973d6bb8359e1645