### PR TITLE
Set thread limits in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Этап сборки
 FROM nvidia/cuda:12.5.1-cudnn-devel-ubuntu22.04 AS builder
+ENV OMP_NUM_THREADS=1
+ENV MKL_NUM_THREADS=1
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
 
@@ -38,6 +40,8 @@ RUN pip install --no-cache-dir pip==24.0 setuptools wheel && \
 
 # Этап выполнения
 FROM nvidia/cuda:12.5.1-cudnn-devel-ubuntu22.04
+ENV OMP_NUM_THREADS=1
+ENV MKL_NUM_THREADS=1
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
 


### PR DESCRIPTION
## Summary
- set OMP_NUM_THREADS and MKL_NUM_THREADS right after the CUDA base images in Dockerfile

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687f87f026a8832da2cd1204dc202033