### PR TITLE
Extend cache defaults

### DIFF
--- a/config.json
+++ b/config.json
@@ -30,7 +30,7 @@
     "trailing_stop_coeff": 1.0,
     "retrain_threshold": 0.1,
     "retrain_volatility_threshold": 0.02,
-    "forget_window": 86400,
+    "forget_window": 259200,
     "trailing_stop_multiplier": 1.0,
     "tp_multiplier": 2.0,
     "sl_multiplier": 1.0,

--- a/config.py
+++ b/config.py
@@ -68,7 +68,7 @@ class BotConfig:
     retrain_volatility_threshold: float = _get_default(
         "retrain_volatility_threshold", 0.02
     )
-    forget_window: int = _get_default("forget_window", 86400)
+    forget_window: int = _get_default("forget_window", 259200)
     trailing_stop_multiplier: float = _get_default("trailing_stop_multiplier", 1.0)
     tp_multiplier: float = _get_default("tp_multiplier", 2.0)
     sl_multiplier: float = _get_default("sl_multiplier", 1.0)

--- a/utils.py
+++ b/utils.py
@@ -662,11 +662,14 @@ class HistoricalDataCache:
             raise PermissionError(
                 f"Нет прав на запись в директорию кэша: {self.cache_dir}"
             )
-        self.max_cache_size_mb = 512
+        # Allow a larger on-disk cache by default to reduce re-fetches
+        self.max_cache_size_mb = 2048
         self.cache_ttl = 86400 * 7
         self.current_cache_size_mb = self._calculate_cache_size()
-        self.memory_threshold = 0.8
-        self.max_buffer_size_mb = 512
+        # Permit using slightly more memory before triggering cleanup
+        self.memory_threshold = 0.9
+        # Allow disk buffer to grow in proportion to the larger cache size
+        self.max_buffer_size_mb = 2048
 
     def _calculate_cache_size(self):
         total_size = 0


### PR DESCRIPTION
## Summary
- extend forget window to 3 days
- increase HistoricalDataCache size & memory thresholds

## Testing
- `pytest tests/test_cache.py tests/test_config_env.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687f8a7b8b38832db6cd7dd5ec8d4a19