### PR TITLE
Enable tft transformer model

### DIFF
--- a/config.json
+++ b/config.json
@@ -40,7 +40,7 @@
     "min_data_length": 1000,
     "lstm_timesteps": 60,
     "lstm_batch_size": 32,
-    "model_type": "cnn_lstm",
+    "model_type": "tft",
     "nn_framework": "pytorch",
     "ema30_period": 30,
     "ema100_period": 100,

--- a/config.py
+++ b/config.py
@@ -78,7 +78,7 @@ class BotConfig:
     min_data_length: int = _get_default("min_data_length", 1000)
     lstm_timesteps: int = _get_default("lstm_timesteps", 60)
     lstm_batch_size: int = _get_default("lstm_batch_size", 32)
-    model_type: str = _get_default("model_type", "cnn_lstm")
+    model_type: str = _get_default("model_type", "tft")
     nn_framework: str = _get_default("nn_framework", "pytorch")
     ema30_period: int = _get_default("ema30_period", 30)
     ema100_period: int = _get_default("ema100_period", 100)


### PR DESCRIPTION
## Summary
- enable `tft` transformer architecture as default `model_type`
- test saving/loading transformer states
- allow `_train_model_remote` to train transformers in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688083a50980832d9538a59df1914e18