### PR TITLE
Add TFT training test and update fixtures

### DIFF
--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -111,6 +111,15 @@ def test_train_model_remote_returns_state_and_predictions(model_type):
     assert isinstance(labels, list)
 
 
+def test_train_model_remote_tft_predictions():
+    X = np.random.rand(12, 3, 2).astype(np.float32)
+    y = (np.random.rand(12) > 0.5).astype(np.float32)
+    func = getattr(_train_model_remote, "_function", _train_model_remote)
+    state, preds, labels = func(X, y, batch_size=2, model_type="tft")
+    assert isinstance(state, dict)
+    assert len(preds) == len(labels) > 0
+
+
 @pytest.mark.asyncio
 async def test_training_loop_recovery(monkeypatch):
     cfg = BotConfig(cache_dir="/tmp", retrain_interval=0)

--- a/tests/test_rl_agent.py
+++ b/tests/test_rl_agent.py
@@ -61,7 +61,6 @@ class DummyModelBuilder:
     def __init__(self):
         self.device = "cpu"
         self.predictive_models = {}
-        self.lstm_models = self.predictive_models
 
     async def preprocess(self, df, symbol):
         return df

--- a/tests/test_trade_manager_loops.py
+++ b/tests/test_trade_manager_loops.py
@@ -87,7 +87,6 @@ class DummyDataHandler:
 class DummyModelBuilder:
     def __init__(self):
         self.predictive_models = {'BTCUSDT': object()}
-        self.lstm_models = self.predictive_models
     async def retrain_symbol(self, symbol):
         pass
 


### PR DESCRIPTION
## Summary
- extend ModelBuilder tests with new TFT training case
- update DummyModelBuilder fixtures for renamed predictive_models attribute

## Testing
- `flake8`
- `pytest tests/test_model_builder.py -q`
- `pytest tests/test_rl_agent.py -q`
- `pytest tests/test_trade_manager_loops.py::test_monitor_performance_recovery -q`


------
https://chatgpt.com/codex/tasks/task_e_68809fb10b48832d935371dbcb601e92