### PR TITLE
Fix docker shared memory size

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,9 @@ default should work for most setups, but you may call
 ``multiprocessing.set_start_method()`` yourself before launching the service if
 you need a different policy.
 
-The `trade_manager` container needs extra shared memory. The compose file
-allocates 8GB via `shm_size: '8gb'` to enlarge `/dev/shm`.
+The services may build large data sets in memory. Compose allocates
+8GB of shared memory for each container via `shm_size: '8gb'` so Polars
+and other libraries do not run into the default `/dev/shm` limit.
 
 The `model_builder` service sets `TF_CPP_MIN_LOG_LEVEL=3` to hide verbose TensorFlow
 GPU warnings. Adjust or remove this variable if you need more detailed logs.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       timeout: 2s
       retries: 12
       start_period: 5s
+    shm_size: '8gb'
     networks:
       - trading_bot_default
   model_builder:
@@ -39,6 +40,7 @@ services:
       timeout: 2s
       retries: 12
       start_period: 5s
+    shm_size: '8gb'
     networks:
       - trading_bot_default
   trade_manager:


### PR DESCRIPTION
## Summary
- allocate 8GB `/dev/shm` for `data_handler` and `model_builder`
- document that all services get 8GB shared memory

## Testing
- `pip install -r requirements-cpu.txt`
- `python -m flake8` *(fails: many style violations)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881386d6584832d9b669a92c1584602