### PR TITLE
Unify indicator storage

### DIFF
--- a/tests/test_data_handler.py
+++ b/tests/test_data_handler.py
@@ -429,14 +429,11 @@ async def test_feature_callback_invoked(tmp_path):
     df['symbol'] = symbol
     df = df.set_index(['symbol', df.index])
 
-    class DummyInd:
-        def update(self, _):
-            pass
 
-    dh.indicators_cache[f'{symbol}_primary'] = DummyInd()
 
     await dh.synchronize_and_update(symbol, df, 0.0, 0.0, {'imbalance': 0.0, 'timestamp': time.time()})
     await asyncio.sleep(0)
+    assert 'ema30' in dh.ohlcv.columns
     assert called == [symbol]
 
 

--- a/tests/test_trade_manager_loops.py
+++ b/tests/test_trade_manager_loops.py
@@ -64,10 +64,6 @@ class DummyExchange:
     def __init__(self):
         self.orders = []
 
-class DummyIndicators:
-    def __init__(self):
-        self.atr = pd.Series([1.0])
-
 class DummyDataHandler:
     def __init__(self):
         self.exchange = DummyExchange()
@@ -75,8 +71,8 @@ class DummyDataHandler:
         idx = pd.MultiIndex.from_tuples([
             ('BTCUSDT', pd.Timestamp('2020-01-01'))
         ], names=['symbol', 'timestamp'])
-        self.ohlcv = pd.DataFrame({'close': [100]}, index=idx)
-        self.indicators = {'BTCUSDT': DummyIndicators()}
+        self.ohlcv = pd.DataFrame({'close': [100], 'atr': [1.0]}, index=idx)
+        self.indicators = {}
         self.parameter_optimizer = types.SimpleNamespace(optimize=lambda s: {})
 
     async def get_atr(self, symbol: str) -> float:


### PR DESCRIPTION
## Summary
- append indicator columns to OHLCV data in `IndicatorsCache`
- expose these columns in tests and remove reliance on separate indicator objects

## Testing
- `pre-commit run --files data_handler.py tests/test_data_handler.py tests/test_trade_manager.py tests/test_trade_manager_loops.py`

------
https://chatgpt.com/codex/tasks/task_e_6884fc6bcb6c832da03fb199823afbc1