### PR TITLE
Add periodic backtest loop and warnings

### DIFF
--- a/tests/test_backtest_loop.py
+++ b/tests/test_backtest_loop.py
@@ -1,0 +1,76 @@
+import asyncio
+import contextlib
+import logging
+import types
+import os
+import sys
+import pytest
+from config import BotConfig
+
+os.environ["TEST_MODE"] = "1"
+
+class DummyTL:
+    def __init__(self):
+        self.sent = []
+    async def send_telegram_message(self, msg):
+        self.sent.append(msg)
+    @classmethod
+    async def shutdown(cls):
+        pass
+
+class DummyDH:
+    def __init__(self):
+        self.usdt_pairs = ["BTCUSDT"]
+        self.telegram_logger = DummyTL()
+
+class DummyTM:
+    pass
+
+@pytest.mark.asyncio
+async def test_backtest_loop_warns(monkeypatch, caplog):
+    cfg = BotConfig(cache_dir="/tmp", backtest_interval=0, min_sharpe_ratio=0.5)
+    dh = DummyDH()
+    gym_mod = types.ModuleType("gymnasium")
+    gym_mod.Env = object
+    spaces_mod = types.ModuleType("gymnasium.spaces")
+    class DummyDiscrete:
+        def __init__(self, n):
+            self.n = n
+    spaces_mod.Discrete = DummyDiscrete
+    spaces_mod.Box = object
+    gym_mod.spaces = spaces_mod
+    monkeypatch.setitem(sys.modules, "gymnasium", gym_mod)
+    monkeypatch.setitem(sys.modules, "gymnasium.spaces", spaces_mod)
+    import importlib
+    model_builder = importlib.import_module("model_builder")
+    ModelBuilder = model_builder.ModelBuilder
+    monkeypatch.setattr(
+        model_builder,
+        "_get_torch_modules",
+        lambda: {"torch": types.SimpleNamespace(device=lambda *_: "cpu")},
+    )
+    mb = ModelBuilder(cfg, dh, DummyTM())
+
+    calls = {"n": 0}
+    async def fake_backtest_all():
+        calls["n"] += 1
+        return {"BTCUSDT": 0.4}
+    monkeypatch.setattr(mb, "backtest_all", fake_backtest_all)
+
+    caplog.set_level(logging.WARNING)
+
+    orig_sleep = asyncio.sleep
+    async def fast_sleep(_):
+        await orig_sleep(0)
+    monkeypatch.setattr(asyncio, "sleep", fast_sleep)
+
+    task = asyncio.create_task(mb.backtest_loop())
+    with contextlib.suppress(asyncio.TimeoutError):
+        await asyncio.wait_for(task, 0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert calls["n"] >= 1
+    assert any("Sharpe ratio" in r.getMessage() for r in caplog.records)
+    assert dh.telegram_logger.sent

--- a/tests/test_import_order.py
+++ b/tests/test_import_order.py
@@ -25,3 +25,4 @@ def test_telegramlogger_injection_order():
 
     tm = importlib.import_module('trade_manager')
     assert tm.TelegramLogger is StubTL
+    sys.modules.pop('utils', None)

--- a/tests/test_optimizer_gp.py
+++ b/tests/test_optimizer_gp.py
@@ -123,3 +123,7 @@ async def test_holdout_warning_emitted(monkeypatch, caplog):
     caplog.set_level(logging.WARNING)
     await opt.optimize('BTCUSDT')
     assert any('hold-out' in rec.getMessage() for rec in caplog.records)
+
+sys.modules.pop('optuna', None)
+sys.modules.pop('optuna.samplers', None)
+sys.modules.pop('optuna.exceptions', None)

--- a/tests/test_rl_agent.py
+++ b/tests/test_rl_agent.py
@@ -3,6 +3,14 @@ import types
 import pandas as pd
 import numpy as np
 import pytest
+import importlib.util
+import os
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+spec = importlib.util.spec_from_file_location("utils_real", os.path.join(ROOT, "utils.py"))
+utils_real = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(utils_real)
+sys.modules['utils'] = utils_real
 
 # Stub stable_baselines3 if missing
 if "stable_baselines3" not in sys.modules:

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -1358,6 +1358,7 @@ async def create_trade_manager() -> TradeManager:
             dh.feature_callback = mb.precompute_features
             logger.info("ModelBuilder created successfully")
             asyncio.create_task(mb.train())
+            asyncio.create_task(mb.backtest_loop())
             await dh.load_initial()
             asyncio.create_task(dh.subscribe_to_klines(dh.usdt_pairs))
         except Exception as exc:


### PR DESCRIPTION
## Summary
- run backtests periodically in `ModelBuilder`
- warn when Sharpe ratio drops below configured threshold
- launch the new loop from `TradeManager`
- test periodic backtesting logic
- restore optuna modules after GP tests
- load real utils for RL agent tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688505a42234832daad2d6fbaf17ca18