### PR TITLE
Fix trading bot prediction call

### DIFF
--- a/tests/test_integration_services.py
+++ b/tests/test_integration_services.py
@@ -28,7 +28,8 @@ mb_app = Flask('model_builder')
 @mb_app.route('/predict', methods=['POST'])
 def predict():
     data = request.get_json(force=True)
-    price = float(data.get('price', 0))
+    features = data.get('features') or []
+    price = float(features[0]) if isinstance(features, list) and features else 0.0
     signal = 'buy' if price > 0 else None
     return jsonify({'signal': signal})
 

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -96,7 +96,7 @@ def get_prediction(symbol: str, price: float, env: dict) -> str | None:
     try:
         resp = requests.post(
             f"{env['model_builder_url']}/predict",
-            json={"symbol": symbol, "price": price},
+            json={"symbol": symbol, "features": [price]},
             timeout=5,
         )
         if resp.status_code != 200:


### PR DESCRIPTION
## Summary
- send features list to model-builder
- update integration test stub to match new request payload

## Testing
- `pytest tests/test_integration_services.py::test_services_communicate -q`
- `pytest tests/test_integration_services.py::test_service_availability_check -q`
- `pytest tests/test_integration_services.py::test_check_services_success -q`
- `pytest tests/test_integration_services.py::test_check_services_failure -q`
- `pytest tests/test_trading_bot.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688512eb235c832d8e8bda5e5f8da6e0