### PR TITLE
Set multiindex names in DataHandler

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -690,6 +690,7 @@ class DataHandler:
                     ):
                         df["symbol"] = symbol
                         df = df.set_index(["symbol", df.index])
+                        df.index.set_names(["symbol", "timestamp"], inplace=True)
                         await self.synchronize_and_update(
                             symbol,
                             df,

--- a/tests/test_data_handler.py
+++ b/tests/test_data_handler.py
@@ -428,6 +428,7 @@ async def test_feature_callback_invoked(tmp_path):
     df = pd.DataFrame({'open': [1], 'high': [1], 'low': [1], 'close': [1], 'volume': [1]}, index=[ts])
     df['symbol'] = symbol
     df = df.set_index(['symbol', df.index])
+    df.index.set_names(['symbol', 'timestamp'], inplace=True)
 
 
 
@@ -515,6 +516,7 @@ async def test_sync_updates_metrics(monkeypatch):
     df = pd.DataFrame({'open':[1], 'high':[1], 'low':[1], 'close':[1], 'volume':[1]}, index=[ts])
     df['symbol'] = 'BTCUSDT'
     df = df.set_index(['symbol', df.index])
+    df.index.set_names(['symbol', 'timestamp'], inplace=True)
     ob = {
         'bids': [[100, 10], [99, 5]],
         'asks': [[101, 8], [102, 1]],


### PR DESCRIPTION
## Summary
- ensure OHLCV history loaded in `load_initial` has explicit index names
- keep tests consistent with named index levels

## Testing
- `flake8`
- `pytest -k 'data_handler and not polars' -q`
- `pytest tests/test_data_handler_polars.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688649da7194832da0d9af24ba0ef3c1