### PR TITLE
Enable RL open/close actions

### DIFF
--- a/tests/test_rl_agent.py
+++ b/tests/test_rl_agent.py
@@ -111,4 +111,4 @@ async def test_train_symbol_and_predict(sample_ohlcv):
     action = agent.predict(
         "BTCUSDT", features.iloc[0].to_numpy(dtype=np.float32)
     )
-    assert action in (None, "buy", "sell")
+    assert action in {"hold", "open_long", "open_short", "close"}


### PR DESCRIPTION
## Summary
- expand TradingEnv actions and observations
- collect RL features for predictions
- allow RLAgent to output open/close/hold semantics
- enable TradeManager to act on RL actions
- drop RL weight from evaluate_signal
- test RL action overrides and closing behaviour

## Testing
- `pre-commit run --files tests/test_rl_agent.py tests/test_trade_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_688658116344832db9a328f870a581fc