### PR TITLE
Improve append efficiency

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -573,7 +573,10 @@ class IndicatorsCache:
             self.last_close = close
             self.last_high = high
             self.last_low = low
-        self.df = pd.concat([self.df, new_df])
+        # Append the new rows directly rather than using ``pd.concat``
+        self.df = self.df.reindex(self.df.index.union(new_df.index))
+        self.df.loc[new_df.index] = new_df
+        self.df.sort_index(inplace=True)
         self._update_volume_profile()
 
 


### PR DESCRIPTION
## Summary
- avoid `pd.concat` in `IndicatorsCache.update`
- reindex and assign new rows directly then sort

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688664c3f7a8832da53ed5f6399143f3