### PR TITLE
Delete old Telegram webhook

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -850,7 +850,8 @@ class DataHandler:
             history_limit = self.config.get("min_data_length", 200)
 
             mem = psutil.virtual_memory()
-            avail_gb = mem.available / (1024 ** 3)
+            avail_bytes = getattr(mem, "available", 0)
+            avail_gb = avail_bytes / (1024 ** 3)
             batch_size = self.config.get("history_batch_size", 10)
             batch_size = max(1, min(batch_size, int(max(1, avail_gb))))
             logger.info(

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -1486,8 +1486,12 @@ async def create_trade_manager() -> TradeManager:
         if token:
             try:
                 from telegram import Bot
-
                 telegram_bot = Bot(token)
+                try:
+                    telegram_bot.delete_webhook(drop_pending_updates=True)
+                    logger.info("Deleted existing Telegram webhook")
+                except Exception as exc:  # pragma: no cover - delete_webhook errors
+                    logger.exception("Failed to delete Telegram webhook: %s", exc)
             except Exception as exc:  # pragma: no cover - import/runtime errors
                 logger.exception("Failed to create Telegram Bot: %s", exc)
                 raise


### PR DESCRIPTION
## Summary
- clear old Telegram webhooks when starting
- guard against missing `available` in mocked psutil

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688739d86758832d91e646678bd64c10