### PR TITLE
Add HistoricalSimulator with CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,18 @@ Linting configuration is stored in `.flake8`. Run the checker manually:
 python -m flake8
 ```
 
+## Historical simulator
+
+Replay past market data using the built in trading logic:
+
+```bash
+python scripts/run_simulation.py --start 2020-01-01 --end 2020-01-02 --speed 60
+```
+
+The simulator loads candles from the DataHandler cache and steps through them
+rapidly while reusing ``TradeManager`` methods. Trailing stops and other
+position logic behave exactly like in live trading.
+
 ## Continuous integration
 
 All pushes and pull requests trigger a GitHub Actions workflow that installs

--- a/scripts/run_simulation.py
+++ b/scripts/run_simulation.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Command line interface for HistoricalSimulator."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import pandas as pd
+from config import load_config
+from data_handler import DataHandler
+from model_builder import ModelBuilder
+from trade_manager import TradeManager
+from simulation import HistoricalSimulator
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description="Run historical simulation")
+    parser.add_argument("--start", required=True, help="start timestamp YYYY-MM-DD")
+    parser.add_argument("--end", required=True, help="end timestamp YYYY-MM-DD")
+    parser.add_argument("--speed", type=float, default=60.0, help="time acceleration factor")
+    args = parser.parse_args()
+
+    start_ts = pd.to_datetime(args.start, utc=True)
+    end_ts = pd.to_datetime(args.end, utc=True)
+
+    cfg = load_config("config.json")
+    dh = DataHandler(cfg, None, None)
+    await dh.load_initial()
+    mb = ModelBuilder(cfg, dh, None)
+    tm = TradeManager(cfg, dh, mb, None, None)
+    sim = HistoricalSimulator(dh, tm)
+    await sim.run(start_ts, end_ts, args.speed)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/simulation.py
+++ b/simulation.py
@@ -1,0 +1,101 @@
+"""Historical simulation running TradeManager logic."""
+
+from __future__ import annotations
+
+import asyncio
+import pandas as pd
+from typing import Dict
+
+
+class HistoricalSimulator:
+    """Replay historical candles and execute TradeManager methods."""
+
+    def __init__(self, data_handler, trade_manager) -> None:
+        self.data_handler = data_handler
+        self.trade_manager = trade_manager
+        self.history: Dict[str, pd.DataFrame] = {}
+
+    async def load(self, start_ts: pd.Timestamp, end_ts: pd.Timestamp) -> None:
+        """Load cached OHLCV data for all symbols."""
+        timeframe = self.data_handler.config.get("timeframe", "1m")
+        for symbol in self.data_handler.usdt_pairs:
+            df = None
+            if hasattr(self.data_handler, "history"):
+                df = self.data_handler.history
+                if "symbol" in df.index.names:
+                    df = df.xs(symbol, level="symbol", drop_level=False)
+            else:
+                cache = getattr(self.data_handler, "cache", None)
+                if cache:
+                    df = cache.load_cached_data(symbol, timeframe)
+            if df is None:
+                continue
+            idx = df.index.get_level_values("timestamp") if isinstance(df.index, pd.MultiIndex) else df.index
+            df = df[(idx >= start_ts) & (idx <= end_ts)]
+            self.history[symbol] = df
+
+    async def _manage_positions_once(self) -> None:
+        idx_names = getattr(self.trade_manager.positions.index, "names", [])
+        if "symbol" not in idx_names:
+            return
+        symbols = self.trade_manager.positions.index.get_level_values("symbol").unique()
+        for symbol in symbols:
+            ohlcv = self.data_handler.ohlcv
+            if "symbol" in ohlcv.index.names and symbol in ohlcv.index.get_level_values("symbol"):
+                df = ohlcv.xs(symbol, level="symbol", drop_level=False)
+            else:
+                continue
+            if df.empty:
+                continue
+            price = df["close"].iloc[-1]
+            await self.trade_manager.check_trailing_stop(symbol, price)
+            await self.trade_manager.check_stop_loss_take_profit(symbol, price)
+            await self.trade_manager.check_exit_signal(symbol, price)
+
+    async def run(self, start_ts: pd.Timestamp, end_ts: pd.Timestamp, speed: float = 1.0) -> None:
+        await self.load(start_ts, end_ts)
+        if not self.history:
+            return
+        timestamps = sorted({
+            ts
+            for df in self.history.values()
+            for ts in (
+                df.index.get_level_values("timestamp")
+                if isinstance(df.index, pd.MultiIndex)
+                else df.index
+            )
+        })
+        for i, ts in enumerate(timestamps):
+            for symbol, df in self.history.items():
+                if ts in df.index:
+                    row = df.loc[[ts]]
+                    row = row.assign(symbol=symbol)
+                    row.index.name = "timestamp"
+                    row = row.set_index("symbol", append=True).swaplevel(0,1)
+                    await self.data_handler.synchronize_and_update(
+                        symbol,
+                        row,
+                        self.data_handler.funding_rates.get(symbol, 0.0),
+                        self.data_handler.open_interest.get(symbol, 0.0),
+                        {"bids": [], "asks": []},
+                    )
+            for symbol in self.data_handler.usdt_pairs:
+                signal = await self.trade_manager.evaluate_signal(symbol)
+                if signal:
+                    ohlcv = self.data_handler.ohlcv
+                    if "symbol" in ohlcv.index.names and symbol in ohlcv.index.get_level_values("symbol"):
+                        price_df = ohlcv.xs(symbol, level="symbol")
+                        if isinstance(price_df.index, pd.MultiIndex):
+                            mask = price_df.index.get_level_values("timestamp") <= ts
+                        else:
+                            mask = price_df.index <= ts
+                        price = price_df.loc[mask]["close"].iloc[-1]
+                    else:
+                        continue
+                    params = await self.data_handler.parameter_optimizer.optimize(symbol)
+                    await self.trade_manager.open_position(symbol, signal, float(price), params)
+            await self._manage_positions_once()
+            if i < len(timestamps) - 1:
+                dt = (timestamps[i + 1] - ts).total_seconds() / max(speed, 1e-6)
+                if dt > 0:
+                    await asyncio.sleep(dt)

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,0 +1,115 @@
+import asyncio
+import logging
+import sys
+import types
+import pandas as pd
+import pytest
+from config import BotConfig
+
+# Stub heavy dependencies
+if 'torch' not in sys.modules:
+    torch = types.ModuleType('torch')
+    torch.cuda = types.SimpleNamespace(is_available=lambda: False)
+    sys.modules['torch'] = torch
+sk_mod = types.ModuleType('sklearn')
+model_sel = types.ModuleType('sklearn.model_selection')
+model_sel.GridSearchCV = object
+sk_mod.model_selection = model_sel
+base_estimator = types.ModuleType('sklearn.base')
+base_estimator.BaseEstimator = object
+sk_mod.base = base_estimator
+sys.modules.setdefault('sklearn', sk_mod)
+sys.modules.setdefault('sklearn.model_selection', model_sel)
+sys.modules.setdefault('sklearn.base', base_estimator)
+utils = types.ModuleType('utils')
+class DummyTL:
+    def __init__(self, *a, **k):
+        pass
+    async def send_telegram_message(self, *a, **k):
+        pass
+    @classmethod
+    async def shutdown(cls):
+        pass
+utils.TelegramLogger = DummyTL
+utils.logger = logging.getLogger('test')
+async def _cde(*a, **kw):
+    return False
+utils.check_dataframe_empty = _cde
+utils.check_dataframe_empty_async = _cde
+utils.is_cuda_available = lambda: False
+async def _safe_api_call(exchange, method: str, *args, **kwargs):
+    return await getattr(exchange, method)(*args, **kwargs)
+utils.safe_api_call = _safe_api_call
+sys.modules['utils'] = utils
+joblib_mod = types.ModuleType('joblib')
+joblib_mod.dump = lambda *a, **k: None
+joblib_mod.load = lambda *a, **k: {}
+sys.modules.setdefault('joblib', joblib_mod)
+import os
+os.environ['TEST_MODE'] = '1'
+
+sys.modules.pop('trade_manager', None)
+sys.modules.pop('simulation', None)
+from trade_manager import TradeManager
+from simulation import HistoricalSimulator
+
+class DummyExchange:
+    def __init__(self):
+        self.orders = []
+    async def fetch_balance(self):
+        return {'total': {'USDT': 1000}}
+    async def create_order(self, symbol, typ, side, amount, price, params):
+        self.orders.append({'method': 'create_order', 'price': price})
+        return {'id': '1'}
+    async def create_order_with_take_profit_and_stop_loss(self, symbol, typ, side, amount, price, tp, sl, params):
+        self.orders.append({'method': 'create_order_with_tp_sl', 'tp': tp, 'sl': sl})
+        return {'id': '2'}
+
+class DummyDataHandler:
+    def __init__(self):
+        self.exchange = DummyExchange()
+        self.usdt_pairs = ['BTCUSDT']
+        idx = pd.date_range('2020-01-01', periods=3, freq='1min', tz='UTC')
+        df = pd.DataFrame({
+            'open': [100, 101, 101],
+            'high': [100.5, 101.5, 101],
+            'low': [99.5, 100.5, 98],
+            'close': [100, 101, 98],
+            'atr': [1.0, 1.0, 1.0],
+        }, index=idx)
+        df['symbol'] = 'BTCUSDT'
+        self.history = df.set_index('symbol', append=True).swaplevel(0,1)
+        self.history.index.names = ['symbol', 'timestamp']
+        self.ohlcv = self.history.iloc[:1]
+        self.indicators = {'BTCUSDT': types.SimpleNamespace(atr=pd.Series([1.0]*3, index=idx), df=df)}
+        async def _opt(symbol):
+            return {}
+        self.parameter_optimizer = types.SimpleNamespace(optimize=_opt)
+        self.funding_rates = {'BTCUSDT': 0.0}
+        self.open_interest = {'BTCUSDT': 0.0}
+        self.config = BotConfig(cache_dir='/tmp')
+    async def get_atr(self, symbol: str) -> float:
+        return 1.0
+    async def is_data_fresh(self, symbol: str, timeframe: str = 'primary', max_delay: float = 60) -> bool:
+        return True
+    async def synchronize_and_update(self, symbol, df, fr, oi, ob, timeframe='primary'):
+        self.ohlcv = pd.concat([self.ohlcv, df], ignore_index=False).sort_index()
+
+@pytest.mark.asyncio
+async def test_simulator_trailing_stop():
+    dh = DummyDataHandler()
+    cfg = BotConfig(cache_dir='/tmp', trailing_stop_percentage=1.0, trailing_stop_coeff=0.0, trailing_stop_multiplier=1.0)
+    tm = TradeManager(cfg, dh, None, None, None)
+
+    first = {'n': 0}
+    async def fake_eval(symbol):
+        first['n'] += 1
+        return 'buy' if first['n'] == 1 else None
+    tm.evaluate_signal = fake_eval
+
+    sim = HistoricalSimulator(dh, tm)
+    start = dh.history.index.get_level_values('timestamp').min()
+    end = dh.history.index.get_level_values('timestamp').max()
+    await sim.run(start, end, speed=1000)
+    assert tm.positions.empty
+    assert len(dh.exchange.orders) >= 2


### PR DESCRIPTION
## Summary
- add `simulation.py` with `HistoricalSimulator`
- provide CLI script `scripts/run_simulation.py`
- document simulator usage in README
- add unit tests for simulator

## Testing
- `python -m flake8`
- `pytest -q` *(fails to complete: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_688755ddeedc832dab705829a8d06d61