### PR TITLE
Add /ready endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ place market orders on Bybit when you POST to `/open_position` or
 ```
 python services/trade_manager_service.py
 ```
-It also exposes `/positions` and `/ping` routes for status checks.
+It also exposes `/positions`, `/ping` and `/ready` routes for status checks.
 The `/open_position` endpoint accepts either `amount` or `price`. When only
 `price` is sent the service calculates the position size using the
 `TRADE_RISK_USD` environment variable.

--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -81,6 +81,12 @@ def ping():
     return jsonify({'status': 'ok'})
 
 
+@app.route('/ready')
+def ready():
+    """Health check endpoint used by docker-compose."""
+    return jsonify({'status': 'ok'})
+
+
 if __name__ == '__main__':
     port = int(os.environ.get('PORT', '8002'))
     host = os.environ.get('HOST', '0.0.0.0')

--- a/tests/test_service_scripts.py
+++ b/tests/test_service_scripts.py
@@ -148,3 +148,21 @@ def test_trade_manager_service_price_only():
     finally:
         p.terminate()
         p.join()
+
+
+def test_trade_manager_ready_route():
+    p = ctx.Process(target=_run_tm)
+    p.start()
+    try:
+        resp = None
+        for _ in range(50):
+            try:
+                resp = requests.get('http://127.0.0.1:8002/ready', timeout=1)
+                if resp.status_code == 200:
+                    break
+            except Exception:
+                time.sleep(0.1)
+        assert resp is not None and resp.status_code == 200
+    finally:
+        p.terminate()
+        p.join()


### PR DESCRIPTION
## Summary
- expose `/ready` route from trade_manager_service
- clarify README with new readiness endpoint
- test that `/ready` responds with HTTP 200

## Testing
- `pytest tests/test_service_scripts.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6887679bce10832d841e6d2abc51e787