### PR TITLE
Handle missing sklearn in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,9 @@ Unit tests automatically set the environment variable `TEST_MODE=1`.
 This disables the Telegram logger's background worker thread so tests
 run without spawning extra threads.
 
+If `scikit-learn` is not installed, tests marked with `requires_sklearn`
+are skipped automatically. Install the package to run the full suite.
+
 As noted above, make sure to run `./scripts/setup-tests.sh` before
 executing `pytest`; otherwise imports such as `numpy`, `pandas`, `scipy` and
 `requests` will fail.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,28 @@
 import os
 import sys
 import types
-import sklearn  # ensure real scikit-learn loaded before tests may stub it
-import sklearn.model_selection  # preload submodules used in tests
-import sklearn.base
+try:
+    import sklearn  # ensure real scikit-learn loaded before tests may stub it
+    import sklearn.model_selection  # preload submodules used in tests
+    import sklearn.base
+    HAVE_SKLEARN = True
+except ImportError:  # pragma: no cover - optional dependency
+    HAVE_SKLEARN = False
 
 import pytest
 import pandas as pd
+
+# Register a marker for tests requiring scikit-learn
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "requires_sklearn: mark test that needs the scikit-learn package",
+    )
+
+
+def pytest_runtest_setup(item):
+    if not HAVE_SKLEARN and item.get_closest_marker("requires_sklearn"):
+        pytest.skip("scikit-learn not installed")
 
 # Ensure the project root is available before tests import project modules
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -11,6 +11,8 @@ from config import BotConfig
 import asyncio
 from sklearn.preprocessing import StandardScaler
 from sklearn.metrics import brier_score_loss
+
+pytestmark = pytest.mark.requires_sklearn
 from collections import deque
 
 try:  # require functional torch installation for these tests


### PR DESCRIPTION
## Summary
- skip tests requiring scikit-learn if it's not installed
- mark `test_model_builder` as requiring scikit-learn
- document skipping behaviour in README

## Testing
- `python -m flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'scipy')*

------
https://chatgpt.com/codex/tasks/task_e_6887691b2d94832d9e5365db86903a64