### PR TITLE
Improve trade error alerts

### DIFF
--- a/tests/test_trading_bot.py
+++ b/tests/test_trading_bot.py
@@ -70,6 +70,33 @@ def test_send_trade_latency_alert(monkeypatch):
     assert called
 
 
+def test_send_trade_http_error_alert(monkeypatch):
+    called = []
+
+    def fake_post(url, json=None, timeout=None):
+        class Resp:
+            status_code = 500
+
+        return Resp()
+
+    monkeypatch.setattr(trading_bot.requests, 'post', fake_post)
+    monkeypatch.setattr(trading_bot, 'send_telegram_alert', lambda msg: called.append(msg))
+    trading_bot.send_trade('BTCUSDT', 'sell', 1.0, {'trade_manager_url': 'http://tm'})
+    assert called
+
+
+def test_send_trade_exception_alert(monkeypatch):
+    called = []
+
+    def fake_post(url, json=None, timeout=None):
+        raise trading_bot.requests.RequestException('boom')
+
+    monkeypatch.setattr(trading_bot.requests, 'post', fake_post)
+    monkeypatch.setattr(trading_bot, 'send_telegram_alert', lambda msg: called.append(msg))
+    trading_bot.send_trade('BTCUSDT', 'sell', 1.0, {'trade_manager_url': 'http://tm'})
+    assert called
+
+
 @pytest.mark.asyncio
 async def test_reactive_trade_latency_alert(monkeypatch):
     called = []

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -143,8 +143,12 @@ def send_trade(symbol: str, side: str, price: float, env: dict) -> None:
             )
         if resp.status_code != 200:
             logger.error("Trade manager error: HTTP %s", resp.status_code)
+            send_telegram_alert(
+                f"Trade manager responded with HTTP {resp.status_code} for {symbol}"
+            )
     except requests.RequestException as exc:
         logger.error("Trade manager request error: %s", exc)
+        send_telegram_alert(f"Trade manager request failed for {symbol}: {exc}")
 
 
 async def reactive_trade(symbol: str, env: dict | None = None) -> None:


### PR DESCRIPTION
## Summary
- trigger telegram alerts on trade errors
- test `send_trade` alert behaviour for HTTP errors and request exceptions

## Testing
- `pytest -q tests/test_trading_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6887828f1a74832d8451221380af20a2