### PR TITLE
Introduce per-symbol locks for WebSocket updates

### DIFF
--- a/scripts/measure_rate.py
+++ b/scripts/measure_rate.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+import os, sys; sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import asyncio
+import json
+from contextlib import suppress
+import pandas as pd
+from config import BotConfig
+from data_handler import DataHandler
+
+class DummyExchange:
+    pass
+
+async def measure(n=1000, seconds=1.0):
+    cfg = BotConfig(cache_dir='/tmp')
+    dh = DataHandler(cfg, None, None, exchange=DummyExchange())
+    ts = int(pd.Timestamp.now(tz='UTC').timestamp()*1000)
+    msg = json.dumps({
+        'topic': 'kline.1.BTCUSDT',
+        'data': [{
+            'start': ts,
+            'open': 1,
+            'high': 1,
+            'low': 1,
+            'close': 1,
+            'volume': 1
+        }]
+    })
+    for _ in range(n):
+        await dh.ws_queue.put((1, (['BTCUSDT'], msg, 'primary')))
+    task = asyncio.create_task(dh._process_ws_queue())
+    await asyncio.sleep(seconds)
+    task.cancel()
+    with suppress(asyncio.CancelledError):
+        await task
+    rate = len(dh.process_rate_timestamps) / dh.process_rate_window
+    print('rate', rate)
+
+if __name__ == '__main__':
+    asyncio.run(measure())


### PR DESCRIPTION
## Summary
- add `scripts/measure_rate.py` helper to benchmark WebSocket queue throughput
- protect `DataHandler` updates with per-symbol locks instead of global locks

## Testing
- `pytest tests/test_data_handler.py::test_dynamic_ws_min_process_rate_short_tf -q`
- `pytest tests/test_data_handler.py::test_feature_callback_invoked -q`
- `scripts/measure_rate.py`

------
https://chatgpt.com/codex/tasks/task_e_6887c24cdd14832d9fce8a69808d4cc3