### PR TITLE
Ensure Ray shutdown in cleanup routines

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -2347,6 +2347,8 @@ class DataHandler:
                 pass
 
         await TelegramLogger.shutdown()
+        if ray.is_initialized():
+            ray.shutdown()
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_data_handler.py
+++ b/tests/test_data_handler.py
@@ -275,6 +275,16 @@ async def test_stop_handles_close_errors():
     dh.pro_exchange = BadPro()
 
     await dh.stop()  # should not raise
+
+
+@pytest.mark.asyncio
+async def test_stop_shuts_down_ray():
+    import ray
+    ray.init()
+    cfg = BotConfig(cache_dir='/tmp')
+    dh = DataHandler(cfg, None, None, exchange=DummyExchange({'BTCUSDT': 1.0}))
+    await dh.stop()
+    assert not ray.is_initialized()
 @pytest.mark.asyncio
 async def test_load_initial_no_attribute_error(monkeypatch, tmp_path):
     class DummyExchange2:

--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -900,5 +900,16 @@ async def test_execute_top_signals_ranking(monkeypatch):
     assert opened == ["A", "B"]
 
 
+def test_shutdown_shuts_down_ray(monkeypatch):
+    import ray
+    import trade_manager as tm_mod
+    tm_mod.ray = ray
+    ray.init()
+    dh = DummyDataHandler()
+    tm = TradeManager(make_config(), dh, None, None, None)
+    tm.shutdown()
+    assert not ray.is_initialized()
+
+
 sys.modules.pop('utils', None)
 

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -1393,6 +1393,8 @@ class TradeManager:
             except RuntimeError:
                 # event loop already closed
                 pass
+        if ray.is_initialized():
+            ray.shutdown()
 
     async def process_symbol(self, symbol: str):
         while symbol not in self.model_builder.predictive_models:


### PR DESCRIPTION
## Summary
- close Ray when stopping data handler
- close Ray when shutting down trade manager
- stub ray/optuna shutdown in tests
- test Ray shutdown in DataHandler.stop and TradeManager.shutdown

## Testing
- `pytest tests/test_data_handler.py::test_stop_shuts_down_ray tests/test_trade_manager.py::test_shutdown_shuts_down_ray -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c6deadb4832d98a7cc10f2437c12