### PR TITLE
Add periodic funding and open interest updates

### DIFF
--- a/config.json
+++ b/config.json
@@ -57,6 +57,8 @@
     "bollinger_window": 20,
     "ulcer_window": 14,
     "volume_profile_update_interval": 300,
+    "funding_update_interval": 300,
+    "oi_update_interval": 300,
     "model_save_path": "/app/models",
     "cache_dir": "/app/cache",
     "log_dir": "/app/logs",

--- a/config.py
+++ b/config.py
@@ -99,6 +99,8 @@ class BotConfig:
     volume_profile_update_interval: int = _get_default(
         "volume_profile_update_interval", 300
     )
+    funding_update_interval: int = _get_default("funding_update_interval", 300)
+    oi_update_interval: int = _get_default("oi_update_interval", 300)
     model_save_path: str = _get_default("model_save_path", "/app/models")
     cache_dir: str = _get_default("cache_dir", "/app/cache")
     log_dir: str = _get_default("log_dir", "/app/logs")


### PR DESCRIPTION
## Summary
- include funding_update_interval and oi_update_interval in `BotConfig`
- periodically refresh funding rate and open interest in `DataHandler`
- test recovery behaviour for the new loops

## Testing
- `pytest tests/test_data_handler.py::test_funding_rate_loop_recovery tests/test_data_handler.py::test_open_interest_loop_recovery -q`

------
https://chatgpt.com/codex/tasks/task_e_6887ca682c3c832d8ff1c415d7f7ea1d