### PR TITLE
Add optional profiling for DataHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,14 @@ Unit tests automatically set the environment variable `TEST_MODE=1`.
 This disables the Telegram logger's background worker thread so tests
 run without spawning extra threads.
 
+Set `DATA_HANDLER_PROFILE=1` to log how long `DataHandler` methods take.
+Profiling information is printed to the standard log output.
+For example:
+
+```bash
+DATA_HANDLER_PROFILE=1 python trading_bot.py
+```
+
 If `scikit-learn` is not installed, tests marked with `requires_sklearn`
 are skipped automatically. Install the package to run the full suite.
 


### PR DESCRIPTION
## Summary
- add async timing decorator and class instrumenter
- enable profiling via `DATA_HANDLER_PROFILE` env var
- document profiling usage

## Testing
- `flake8`
- `pytest tests/test_force_cpu.py::test_force_cpu -q`


------
https://chatgpt.com/codex/tasks/task_e_6887da37c34c832db59f323964e024da