### PR TITLE
Fix async Telegram webhook deletion

### DIFF
--- a/trade_manager.py
+++ b/trade_manager.py
@@ -1490,7 +1490,7 @@ async def create_trade_manager() -> TradeManager:
                 from telegram import Bot
                 telegram_bot = Bot(token)
                 try:
-                    telegram_bot.delete_webhook(drop_pending_updates=True)
+                    await telegram_bot.delete_webhook(drop_pending_updates=True)
                     logger.info("Deleted existing Telegram webhook")
                 except Exception as exc:  # pragma: no cover - delete_webhook errors
                     logger.exception("Failed to delete Telegram webhook: %s", exc)


### PR DESCRIPTION
## Summary
- await Telegram `delete_webhook` call

## Testing
- `python -m flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests', 'polars', 'ta', ...)*

------
https://chatgpt.com/codex/tasks/task_e_68887070fa58832da7506d2c8d50c4ac