### PR TITLE
Handle empty LSTM features

### DIFF
--- a/model_builder.py
+++ b/model_builder.py
@@ -827,6 +827,10 @@ class ModelBuilder:
         features_df["adx"] = _align(indicators.adx)
         features_df["macd"] = _align(indicators.macd)
         features_df["atr"] = _align(indicators.atr)
+        features_df = features_df.dropna()
+        if features_df.empty:
+            logger.warning("Нет валидных данных для %s", symbol)
+            return np.array([])
         data_np = features_df.to_numpy(dtype=float, copy=True)
         scaler = self.scalers.get(symbol)
         if scaler is None:


### PR DESCRIPTION
## Summary
- clean NaNs before scaling LSTM features
- warn and exit early when no valid data

## Testing
- `pytest -k lstm_features -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_688871e30afc832db359cdccb2682635