### PR TITLE
Warn when simulator loads no cached data

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,6 +661,8 @@ python scripts/run_simulation.py --start 2020-01-01 --end 2020-01-02 --speed 60
 The simulator loads candles from the DataHandler cache and steps through them
 rapidly while reusing ``TradeManager`` methods. Trailing stops and other
 position logic behave exactly like in live trading.
+If no cached candles exist for the chosen period, the simulator logs a warning
+and exits.
 
 ## Continuous integration
 

--- a/simulation.py
+++ b/simulation.py
@@ -63,6 +63,11 @@ class HistoricalSimulator:
     async def run(self, start_ts: pd.Timestamp, end_ts: pd.Timestamp, speed: float = 1.0) -> None:
         await self.load(start_ts, end_ts)
         if not self.history:
+            logger.warning(
+                "No cached OHLCV data found between %s and %s; simulation aborted",
+                start_ts,
+                end_ts,
+            )
             return
         timestamps = sorted({
             ts


### PR DESCRIPTION
## Summary
- warn when HistoricalSimulator loads no history data
- mention the warning in README

## Testing
- `python -m flake8`
- `pytest tests/test_utils.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'optuna')*

------
https://chatgpt.com/codex/tasks/task_e_6888b2e81408832da1b60c00a5cdd47f