### PR TITLE
Update historical simulator docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,6 +658,13 @@ Replay past market data using the built in trading logic:
 python scripts/run_simulation.py --start 2020-01-01 --end 2020-01-02 --speed 60
 ```
 
+If you do not have the full `requirements.txt` installed, set `TEST_MODE=1` so
+the simulator stubs heavy dependencies. Example:
+
+```bash
+TEST_MODE=1 python scripts/run_simulation.py --start ... --end ...
+```
+
 The simulator loads candles from the DataHandler cache and steps through them
 rapidly while reusing ``TradeManager`` methods. Trailing stops and other
 position logic behave exactly like in live trading.


### PR DESCRIPTION
## Summary
- clarify how to run the historical simulator in test mode

## Testing
- `python -m flake8`
- `pytest tests/test_import_order.py::test_telegramlogger_injection_order -q`

------
https://chatgpt.com/codex/tasks/task_e_6889008fa5bc832d9b32f2ec7ef5726b