### PR TITLE
Add flake8 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           ./scripts/install-test-deps.sh
-      - name: Lint
-        run: python -m flake8
+      - name: Run flake8
+        run: flake8 .
       - name: Test
         run: pytest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,10 @@ Thank you for your interest in contributing to this project!
     ```
    (Use `--full` to include GPU packages.) This step is **required** before
    running the test suite—`pytest` expects these packages to be installed.
-2. Run `python -m flake8` and `pytest` before submitting a pull request. These
-   tests are also executed automatically by `pre-commit`.
+2. Run `python -m flake8` and `pytest` before submitting a pull request. The CI
+   workflow runs `flake8` as a dedicated step and will fail if any style errors
+   are reported, so it's best to fix them locally first. These tests are also
+   executed automatically by `pre-commit`.
 
 ## CI troubleshooting
 


### PR DESCRIPTION
## Summary
- run flake8 as a distinct CI step
- document that flake8 will fail the build in CONTRIBUTING

## Testing
- `flake8 .`
- `pre-commit run flake8 --files .github/workflows/ci.yml CONTRIBUTING.md`

------
https://chatgpt.com/codex/tasks/task_e_6889c44414c0832d8442b55b71d11bb2