### PR TITLE
Prefix internal imports with bot

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -13,7 +13,7 @@ try:  # optional dependency
 except Exception:  # pragma: no cover - allow missing polars
     pl = None
 import websockets
-from utils import (
+from bot.utils import (
     BybitSDKAsync,
     logger,
     check_dataframe_empty,
@@ -28,7 +28,7 @@ from utils import (
 from tenacity import retry, wait_exponential
 from typing import List, Dict, TYPE_CHECKING, Any, Callable, Awaitable
 import functools
-from config import BotConfig
+from bot.config import BotConfig
 import ta
 import os
 import joblib

--- a/model_builder.py
+++ b/model_builder.py
@@ -10,10 +10,10 @@ import os
 import time
 import asyncio
 import sys
-from config import BotConfig
+from bot.config import BotConfig
 from collections import deque
 import ray
-from utils import logger, check_dataframe_empty, HistoricalDataCache, is_cuda_available
+from bot.utils import logger, check_dataframe_empty, HistoricalDataCache, is_cuda_available
 from dotenv import load_dotenv
 
 try:  # prefer gymnasium if available

--- a/optimizer.py
+++ b/optimizer.py
@@ -15,12 +15,12 @@ except ImportError:  # pragma: no cover - optional dependency
     torch = None  # type: ignore
 import inspect
 import ray
-from utils import (
+from bot.utils import (
     logger,
     is_cuda_available,
     check_dataframe_empty_async as _check_df_async,
 )
-from config import BotConfig
+from bot.config import BotConfig
 from optuna.samplers import TPESampler
 try:
     from optuna.integration.mlflow import MLflowCallback

--- a/portfolio_backtest.py
+++ b/portfolio_backtest.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
-from utils import logger
+from bot.utils import logger
 
 
 def portfolio_backtest(

--- a/scripts/measure_rate.py
+++ b/scripts/measure_rate.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 from contextlib import suppress
 import pandas as pd
-from config import BotConfig
+from bot.config import BotConfig
 from data_handler import DataHandler
 
 class DummyExchange:

--- a/scripts/run_simulation.py
+++ b/scripts/run_simulation.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import pandas as pd
-from config import load_config
+from bot.config import load_config
 from data_handler import DataHandler
 from model_builder import ModelBuilder
 from trade_manager import TradeManager

--- a/simulation.py
+++ b/simulation.py
@@ -6,7 +6,7 @@ import asyncio
 import pandas as pd
 from typing import Dict
 
-from utils import logger
+from bot.utils import logger
 
 
 class HistoricalSimulator:

--- a/strategy_optimizer.py
+++ b/strategy_optimizer.py
@@ -9,8 +9,8 @@ import pandas as pd
 import optuna
 import ray
 
-from utils import logger
-from config import BotConfig
+from bot.utils import logger
+from bot.config import BotConfig
 from portfolio_backtest import portfolio_backtest
 
 

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -55,14 +55,14 @@ else:
     import ray
 from tenacity import retry, wait_exponential, stop_after_attempt
 import inspect
-from utils import (
+from bot.utils import (
     logger,
     TelegramLogger,
     is_cuda_available,
     check_dataframe_empty_async as _check_df_async,
     safe_api_call,
 )
-from config import BotConfig, load_config
+from bot.config import BotConfig, load_config
 import contextlib
 import types
 
@@ -1537,7 +1537,7 @@ async def create_trade_manager() -> TradeManager:
         trade_manager = TradeManager(cfg, dh, mb, telegram_bot, chat_id)
         logger.info("TradeManager instance created")
         if telegram_bot:
-            from utils import TelegramUpdateListener
+            from bot.utils import TelegramUpdateListener
 
             listener = TelegramUpdateListener(telegram_bot)
 

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -5,7 +5,7 @@ import time
 import requests
 import httpx
 from dotenv import load_dotenv
-from utils import logger
+from bot.utils import logger
 
 
 def send_telegram_alert(message: str) -> None:


### PR DESCRIPTION
## Summary
- prefix local imports with `bot.` throughout the project
- adjust scripts to import `bot.config` as well

## Testing
- `flake8`
- `pytest -q` *(fails: tests/test_data_handler.py::test_load_from_disk_buffer_loop)*

------
https://chatgpt.com/codex/tasks/task_e_6889d9622814832db8f2daebc5f99d8d