### PR TITLE
Fix polars dtype handling in cleanup_old_data

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -1466,16 +1466,17 @@ class DataHandler:
                     async with self.ohlcv_lock:
                         if self.use_polars:
                             if self._ohlcv.height > 0:
-                                threshold = current_time - pd.Timedelta(
-                                    seconds=self.config["forget_window"]
-                                )
-                                if self._ohlcv.dtypes[1] == pl.Object:
+                                threshold = (
+                                    current_time
+                                    - pd.Timedelta(seconds=self.config["forget_window"])
+                                ).to_pydatetime()
+                                if not hasattr(self._ohlcv, "dtypes") or self._ohlcv.dtypes[1] == pl.Object:
                                     self._ohlcv = pl.from_pandas(
                                         self._ohlcv.to_pandas()
                                     )
-                                self._ohlcv = self._ohlcv.filter(
-                                    pl.col("timestamp") >= threshold
-                                )
+                                df_pd = self._ohlcv.to_pandas()
+                                df_pd = df_pd[df_pd["timestamp"] >= threshold]
+                                self._ohlcv = pl.from_pandas(df_pd)
                         elif not self.ohlcv.empty:
                             threshold = current_time - pd.Timedelta(
                                 seconds=self.config["forget_window"]
@@ -1487,16 +1488,17 @@ class DataHandler:
                     async with self.ohlcv_2h_lock:
                         if self.use_polars:
                             if self._ohlcv_2h.height > 0:
-                                threshold = current_time - pd.Timedelta(
-                                    seconds=self.config["forget_window"]
-                                )
-                                if self._ohlcv_2h.dtypes[1] == pl.Object:
+                                threshold = (
+                                    current_time
+                                    - pd.Timedelta(seconds=self.config["forget_window"])
+                                ).to_pydatetime()
+                                if not hasattr(self._ohlcv_2h, "dtypes") or self._ohlcv_2h.dtypes[1] == pl.Object:
                                     self._ohlcv_2h = pl.from_pandas(
                                         self._ohlcv_2h.to_pandas()
                                     )
-                                self._ohlcv_2h = self._ohlcv_2h.filter(
-                                    pl.col("timestamp") >= threshold
-                                )
+                                df2_pd = self._ohlcv_2h.to_pandas()
+                                df2_pd = df2_pd[df2_pd["timestamp"] >= threshold]
+                                self._ohlcv_2h = pl.from_pandas(df2_pd)
                         elif not self.ohlcv_2h.empty:
                             threshold = current_time - pd.Timedelta(
                                 seconds=self.config["forget_window"]


### PR DESCRIPTION
## Summary
- handle absence of `dtypes` before using it when cleaning up polars data
- re-filter polars data using pandas to avoid dtype comparison errors

## Testing
- `flake8`
- `pytest tests/test_data_handler_polars.py::test_cleanup_old_data_polars -q`

------
https://chatgpt.com/codex/tasks/task_e_6889f416d2c8832d96200e94eaab18ec