### PR TITLE
Fix tests hang due to joblib stub

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,10 +171,12 @@ def _stub_modules():
     requests_mod.post = lambda *a, **k: None
     sys.modules.setdefault("requests", requests_mod)
 
-    joblib_mod = types.ModuleType("joblib")
-    joblib_mod.dump = lambda *a, **k: None
-    joblib_mod.load = lambda *a, **k: {}
-    sys.modules.setdefault("joblib", joblib_mod)
+    import importlib.util as _importlib_util
+    if _importlib_util.find_spec("joblib") is None:
+        joblib_mod = types.ModuleType("joblib")
+        joblib_mod.dump = lambda *a, **k: None
+        joblib_mod.load = lambda *a, **k: {}
+        sys.modules.setdefault("joblib", joblib_mod)
 
     dotenv_mod = types.ModuleType("dotenv")
     dotenv_mod.load_dotenv = lambda *a, **k: None


### PR DESCRIPTION
## Summary
- ensure `joblib` stub is only used when the real package is missing

## Testing
- `pytest tests/test_cache.py tests/test_data_handler.py::test_load_from_disk_buffer_loop -q`

------
https://chatgpt.com/codex/tasks/task_e_688a432baef8832d81377551679fa7c0