### PR TITLE
Add ADX window NaN test

### DIFF
--- a/tests/test_indicators_cache.py
+++ b/tests/test_indicators_cache.py
@@ -173,3 +173,10 @@ def test_short_dataframe_no_value_error():
     df = make_df(5)
     ind = IndicatorsCache(df, cfg, 0.1)
     assert ind.adx.isna().all()
+
+
+def test_dataframe_equal_to_adx_window():
+    cfg = BotConfig()
+    df = make_df(cfg.adx_window)
+    ind = IndicatorsCache(df, cfg, 0.1)
+    assert ind.adx.isna().all()


### PR DESCRIPTION
## Summary
- add regression test for ADX when df length equals adx window

## Testing
- `pytest -q tests/test_indicators_cache.py`

------
https://chatgpt.com/codex/tasks/task_e_688a4d9e030c832dadf4221abfcd406d