### PR TITLE
Fix DataHandler subscribe tests

### DIFF
--- a/tests/test_data_handler.py
+++ b/tests/test_data_handler.py
@@ -484,6 +484,8 @@ async def test_subscribe_to_klines_single_timeframe(monkeypatch):
     monkeypatch.setattr(dh, 'load_from_disk_buffer_loop', fake_task)
     monkeypatch.setattr(dh, 'monitor_load', fake_task)
     monkeypatch.setattr(dh, 'cleanup_old_data', fake_task)
+    monkeypatch.setattr(dh, 'funding_rate_loop', fake_task)
+    monkeypatch.setattr(dh, 'open_interest_loop', fake_task)
 
     await dh.subscribe_to_klines(['BTCUSDT'])
     assert call['n'] == 1


### PR DESCRIPTION
## Summary
- stub funding and open interest loops in `test_subscribe_to_klines_single_timeframe`

## Testing
- `flake8 tests/test_data_handler.py`
- `pytest tests/test_data_handler.py::test_subscribe_to_klines_single_timeframe -vv`

------
https://chatgpt.com/codex/tasks/task_e_688a4bdacd24832d9f2c8e4410479538