### PR TITLE
Handle RSI errors gracefully

### DIFF
--- a/tests/test_indicators_cache.py
+++ b/tests/test_indicators_cache.py
@@ -2,6 +2,7 @@ import sys
 import types
 import pandas as pd
 import numpy as np
+import ta
 from bot.config import BotConfig
 
 optimizer_stubbed = False
@@ -180,3 +181,17 @@ def test_dataframe_equal_to_adx_window():
     df = make_df(cfg.adx_window)
     ind = IndicatorsCache(df, cfg, 0.1)
     assert ind.adx.isna().all()
+
+
+def test_rsi_fallback(monkeypatch):
+    cfg = BotConfig()
+    df = make_df(10)
+
+    def fail_rsi(*a, **k):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(ta.momentum, "rsi", fail_rsi)
+    ind = IndicatorsCache(df, cfg, 0.1)
+    assert (ind.rsi == 0).all()
+    assert ind._rsi_avg_gain is None
+    assert ind._rsi_avg_loss is None


### PR DESCRIPTION
## Summary
- guard RSI calculation in `IndicatorsCache` and fall back to zeros
- add test for the fallback behaviour

## Testing
- `pytest tests/test_indicators_cache.py::test_rsi_fallback -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests', async def functions not supported, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688a82d3e4c0832dbd0e092e97f942fd