### PR TITLE
Fix imports to use bot package

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -35,8 +35,8 @@ import joblib
 import psutil
 import ray
 from flask import Flask, jsonify
-from optimizer import ParameterOptimizer
-from strategy_optimizer import StrategyOptimizer
+from bot.optimizer import ParameterOptimizer
+from bot.strategy_optimizer import StrategyOptimizer
 from dotenv import load_dotenv
 
 PROFILE_DATA_HANDLER = os.getenv("DATA_HANDLER_PROFILE") == "1"

--- a/optimizer.py
+++ b/optimizer.py
@@ -49,7 +49,7 @@ def _objective_remote(
 ):
     """Heavy part of objective executed remotely."""
     try:
-        from data_handler import IndicatorsCache
+        from bot.data_handler import IndicatorsCache
 
         train_size = int(0.6 * len(df))
         test_size = int(0.2 * len(df))

--- a/scripts/measure_rate.py
+++ b/scripts/measure_rate.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python3
-import os, sys; sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import json
+import os
+import sys
 from contextlib import suppress
 import pandas as pd
+
+if __package__ is None or __package__ == "":
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
 from bot.config import BotConfig
-from data_handler import DataHandler
+from bot.data_handler import DataHandler
 
 class DummyExchange:
     pass

--- a/scripts/run_simulation.py
+++ b/scripts/run_simulation.py
@@ -6,11 +6,17 @@ from __future__ import annotations
 import argparse
 import asyncio
 import pandas as pd
+
+if __package__ is None or __package__ == "":
+    import os
+    import sys
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
 from bot.config import load_config
-from data_handler import DataHandler
-from model_builder import ModelBuilder
-from trade_manager import TradeManager
-from simulation import HistoricalSimulator
+from bot.data_handler import DataHandler
+from bot.model_builder import ModelBuilder
+from bot.trade_manager import TradeManager
+from bot.simulation import HistoricalSimulator
 
 
 async def main() -> None:

--- a/strategy_optimizer.py
+++ b/strategy_optimizer.py
@@ -11,7 +11,7 @@ import ray
 
 from bot.utils import logger
 from bot.config import BotConfig
-from portfolio_backtest import portfolio_backtest
+from bot.portfolio_backtest import portfolio_backtest
 
 
 @ray.remote

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,15 @@ def _stub_modules():
             pass
     optimizer_mod.ParameterOptimizer = _PO
     sys.modules.setdefault("optimizer", optimizer_mod)
+    sys.modules.setdefault("bot.optimizer", optimizer_mod)
+
+    strategy_mod = types.ModuleType("strategy_optimizer")
+    class _SO:
+        def __init__(self, *a, **k):
+            pass
+    strategy_mod.StrategyOptimizer = _SO
+    sys.modules.setdefault("strategy_optimizer", strategy_mod)
+    sys.modules.setdefault("bot.strategy_optimizer", strategy_mod)
 
     class _RayRemoteFunction:
         def __init__(self, func):

--- a/tests/test_data_handler.py
+++ b/tests/test_data_handler.py
@@ -27,7 +27,7 @@ utils_stub.TelegramLogger = DummyTL
 utils_stub.logger = logging.getLogger('test')
 sys.modules['bot.utils'] = utils_stub
 optimizer_stubbed = False
-if 'optimizer' not in sys.modules:
+if 'optimizer' not in sys.modules and 'bot.optimizer' not in sys.modules:
     optimizer_stubbed = True
     optimizer_stub = types.ModuleType('optimizer')
     class _PO:
@@ -35,6 +35,7 @@ if 'optimizer' not in sys.modules:
             pass
     optimizer_stub.ParameterOptimizer = _PO
     sys.modules['optimizer'] = optimizer_stub
+    sys.modules['bot.optimizer'] = optimizer_stub
 os.environ['TEST_MODE'] = '1'
 
 from bot.data_handler import DataHandler
@@ -42,6 +43,7 @@ from bot import data_handler
 
 if optimizer_stubbed:
     sys.modules.pop('optimizer', None)
+    sys.modules.pop('bot.optimizer', None)
 
 class DummyExchange:
     def __init__(self, volumes):

--- a/tests/test_data_handler_polars.py
+++ b/tests/test_data_handler_polars.py
@@ -27,7 +27,7 @@ sys.modules['bot.utils'] = utils_stub
 
 # Ensure optimizer stub
 optimizer_stubbed = False
-if 'optimizer' not in sys.modules:
+if 'optimizer' not in sys.modules and 'bot.optimizer' not in sys.modules:
     optimizer_stubbed = True
     optimizer_stub = types.ModuleType('optimizer')
     class _PO:
@@ -35,6 +35,7 @@ if 'optimizer' not in sys.modules:
             pass
     optimizer_stub.ParameterOptimizer = _PO
     sys.modules['optimizer'] = optimizer_stub
+    sys.modules['bot.optimizer'] = optimizer_stub
 
 os.environ['TEST_MODE'] = '1'
 
@@ -43,6 +44,7 @@ from bot import data_handler
 
 if optimizer_stubbed:
     sys.modules.pop('optimizer', None)
+    sys.modules.pop('bot.optimizer', None)
 
 class DummyExchange:
     def __init__(self, volumes):

--- a/tests/test_indicators_cache.py
+++ b/tests/test_indicators_cache.py
@@ -6,7 +6,7 @@ import ta
 from bot.config import BotConfig
 
 optimizer_stubbed = False
-if 'optimizer' not in sys.modules:
+if 'optimizer' not in sys.modules and 'bot.optimizer' not in sys.modules:
     optimizer_stubbed = True
     optimizer_stub = types.ModuleType('optimizer')
     class _PO:
@@ -14,9 +14,10 @@ if 'optimizer' not in sys.modules:
             pass
     optimizer_stub.ParameterOptimizer = _PO
     sys.modules['optimizer'] = optimizer_stub
+    sys.modules['bot.optimizer'] = optimizer_stub
 
 strategy_stubbed = False
-if 'strategy_optimizer' not in sys.modules:
+if 'strategy_optimizer' not in sys.modules and 'bot.strategy_optimizer' not in sys.modules:
     strategy_stubbed = True
     strategy_stub = types.ModuleType('strategy_optimizer')
     class _SO:
@@ -24,13 +25,16 @@ if 'strategy_optimizer' not in sys.modules:
             pass
     strategy_stub.StrategyOptimizer = _SO
     sys.modules['strategy_optimizer'] = strategy_stub
+    sys.modules['bot.strategy_optimizer'] = strategy_stub
 
 from bot.data_handler import IndicatorsCache
 
 if optimizer_stubbed:
     sys.modules.pop('optimizer', None)
+    sys.modules.pop('bot.optimizer', None)
 if strategy_stubbed:
     sys.modules.pop('strategy_optimizer', None)
+    sys.modules.pop('bot.strategy_optimizer', None)
 
 
 def make_df(length=30):

--- a/tests/test_indicators_gpu.py
+++ b/tests/test_indicators_gpu.py
@@ -19,7 +19,7 @@ sys.modules.setdefault('ccxt.async_support', ccxt_mod.async_support)
 sys.modules.setdefault('ccxt.pro', ccxt_mod.pro)
 
 optimizer_stubbed = False
-if 'optimizer' not in sys.modules:
+if 'optimizer' not in sys.modules and 'bot.optimizer' not in sys.modules:
     optimizer_stubbed = True
     optimizer_stub = types.ModuleType('optimizer')
     class _PO:
@@ -27,11 +27,13 @@ if 'optimizer' not in sys.modules:
             pass
     optimizer_stub.ParameterOptimizer = _PO
     sys.modules['optimizer'] = optimizer_stub
+    sys.modules['bot.optimizer'] = optimizer_stub
 
 from bot.data_handler import ema_fast, atr_fast  # noqa: E402
 
 if optimizer_stubbed:
     sys.modules.pop('optimizer', None)
+    sys.modules.pop('bot.optimizer', None)
 
 
 def test_ema_fast_matches_ta():

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -44,6 +44,7 @@ sys.modules.setdefault('optuna.exceptions', optuna_exceptions)
 
 
 sys.modules.pop("optimizer", None)
+sys.modules.pop("bot.optimizer", None)
 from bot.optimizer import ParameterOptimizer  # noqa: E402
 
 

--- a/tests/test_optimizer_gp.py
+++ b/tests/test_optimizer_gp.py
@@ -70,6 +70,7 @@ sys.modules['skopt.space'] = skopt_space
 
 # Import optimizer fresh
 sys.modules.pop('optimizer', None)
+sys.modules.pop('bot.optimizer', None)
 from bot.optimizer import ParameterOptimizer  # noqa: E402
 from bot import optimizer
 

--- a/tests/test_optimizer_ray.py
+++ b/tests/test_optimizer_ray.py
@@ -53,6 +53,7 @@ from optuna.exceptions import ExperimentalWarning as _OptunaExperimentalWarning
 builtins.ExperimentalWarning = _OptunaExperimentalWarning
 
 sys.modules.pop('optimizer', None)
+sys.modules.pop('bot.optimizer', None)
 from bot.optimizer import ParameterOptimizer  # noqa: E402
 from bot import optimizer
 

--- a/tests/test_strategy_optimizer.py
+++ b/tests/test_strategy_optimizer.py
@@ -5,6 +5,7 @@ import pytest
 from bot.config import BotConfig
 
 sys.modules.pop('strategy_optimizer', None)
+sys.modules.pop('bot.strategy_optimizer', None)
 from bot.strategy_optimizer import StrategyOptimizer, _portfolio_backtest_remote
 from bot.portfolio_backtest import portfolio_backtest
 

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -1524,8 +1524,8 @@ async def create_trade_manager() -> TradeManager:
             except Exception as exc:  # pragma: no cover - import/runtime errors
                 logger.exception("Failed to create Telegram Bot: %s", exc)
                 raise
-        from data_handler import DataHandler
-        from model_builder import ModelBuilder
+        from bot.data_handler import DataHandler
+        from bot.model_builder import ModelBuilder
 
         logger.info("Creating DataHandler")
         try:


### PR DESCRIPTION
## Summary
- switch modules to use absolute imports like `from bot.optimizer import ParameterOptimizer`
- adjust script entrypoints to work both as modules and as files
- update tests for new import paths

## Testing
- `pytest -q` *(fails: 70 failed, 61 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688a938d6fa8832d92c3c1bf9250cde1