### PR TITLE
Add TEST_MODE stubs and synthetic data

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,12 @@ Unit tests automatically set the environment variable `TEST_MODE=1`.
 This disables the Telegram logger's background worker thread so tests
 run without spawning extra threads.
 
+When `TEST_MODE=1` is exported manually, heavy dependencies like Ray,
+stable-baselines3 and the Bybit SDK are replaced with lightweight stubs.
+`DataHandler` also generates synthetic OHLCV data instead of calling
+external APIs. This mode is useful for running examples on systems
+without the full requirements installed.
+
 Set `DATA_HANDLER_PROFILE=1` to log how long `DataHandler` methods take.
 Profiling information is printed to the standard log output.
 For example:

--- a/strategy_optimizer.py
+++ b/strategy_optimizer.py
@@ -7,7 +7,37 @@ import asyncio
 import numpy as np
 import pandas as pd
 import optuna
-import ray
+import os
+
+if os.getenv("TEST_MODE") == "1":
+    import types
+    import sys
+
+    ray = types.ModuleType("ray")
+
+    class _RayRemoteFunction:
+        def __init__(self, func):
+            self._function = func
+
+        def remote(self, *args, **kwargs):
+            return self._function(*args, **kwargs)
+
+        def options(self, *args, **kwargs):
+            return self
+
+    def _ray_remote(func=None, **_kwargs):
+        if func is None:
+            def wrapper(f):
+                return _RayRemoteFunction(f)
+            return wrapper
+        return _RayRemoteFunction(func)
+
+    ray.remote = _ray_remote
+    ray.get = lambda x: x
+    ray.init = lambda *a, **k: None
+    ray.is_initialized = lambda: False
+else:
+    import ray
 
 from bot.utils import logger
 from bot.config import BotConfig

--- a/utils.py
+++ b/utils.py
@@ -31,6 +31,16 @@ except Exception:  # pragma: no cover - allow missing numba package
         return range(*args)
 
 import httpx
+if os.getenv("TEST_MODE") == "1":
+    import types
+    import sys
+
+    pybit_mod = types.ModuleType("pybit")
+    ut_mod = types.ModuleType("unified_trading")
+    ut_mod.HTTP = object
+    pybit_mod.unified_trading = ut_mod
+    sys.modules.setdefault("pybit", pybit_mod)
+    sys.modules.setdefault("pybit.unified_trading", ut_mod)
 try:
     from telegram.error import RetryAfter, BadRequest, Forbidden
 except Exception:  # pragma: no cover - allow missing telegram package


### PR DESCRIPTION
## Summary
- support TEST_MODE across the codebase
- generate synthetic OHLCV data when testing
- stub heavy modules like ray, RLlib and Catalyst
- document TEST_MODE in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_688bafa75d80832dad7b76fc4fa1d1ca