### PR TITLE
Fix Docker build path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,12 +60,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Копируем виртуальное окружение из этапа сборки
 COPY --from=builder /app/venv /app/venv
 
-# Копируем исходный код
-COPY . .
+# Копируем исходный код в /app/bot
+COPY . /app/bot
 
 # Устанавливаем переменные окружения для виртуального окружения
 ENV VIRTUAL_ENV=/app/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+# Добавляем PYTHONPATH, чтобы модуль bot был доступен
+ENV PYTHONPATH=/app
 
 # Проверяем версии библиотек и доступность CUDA с отладкой
 RUN echo "Checking library versions and CUDA availability..." && \
@@ -81,4 +83,4 @@ RUN echo "Checking library versions and CUDA availability..." && \
     /app/venv/bin/python3.12 -c "import mlflow; print('MLflow Version:', mlflow.__version__)" || echo "MLflow check failed"
 
 # Указываем команду для запуска
-CMD ["/app/venv/bin/python3.12", "trading_bot.py"]
+CMD ["/app/venv/bin/python3.12", "-m", "bot.trading_bot"]


### PR DESCRIPTION
## Summary
- copy bot repo into `/app/bot`
- set `PYTHONPATH` so the bot package resolves
- run module as `bot.trading_bot`

## Testing
- `pytest -k test_import_order -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_688bb4ce2288832da9c00281251afb87