### PR TITLE
Fix Ray shutdown test

### DIFF
--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -912,6 +912,7 @@ def test_shutdown_shuts_down_ray(monkeypatch):
     tm_mod.ray = ray
     trade_manager.ray = ray
     ray.init()
+    monkeypatch.setattr(ray, "is_initialized", lambda: True)
     called = {"done": False}
     orig_shutdown = ray.shutdown
     def fake_shutdown():


### PR DESCRIPTION
## Summary
- ensure TradeManager shutdown test marks Ray initialized

## Testing
- `pytest -k test_shutdown_shuts_down_ray -vv` *(fails: assert False)*

------
https://chatgpt.com/codex/tasks/task_e_688bdd4b6d0c832dbe25ed7c7425c485