### PR TITLE
Bypass retries in safe_api_call during tests

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -32,3 +32,14 @@ async def test_safe_api_call_retries(monkeypatch):
 
     assert exch.calls == 5
     assert sleep_calls['n'] == 4
+
+
+@pytest.mark.asyncio
+async def test_safe_api_call_test_mode(monkeypatch):
+    monkeypatch.setenv("TEST_MODE", "1")
+    exch = DummyExchange()
+
+    result = await utils.safe_api_call(exch, 'fail')
+
+    assert result == {'retCode': 1}
+    assert exch.calls == 1

--- a/utils.py
+++ b/utils.py
@@ -129,6 +129,10 @@ async def handle_rate_limits(exchange) -> None:
 
 async def safe_api_call(exchange, method: str, *args, **kwargs):
     """Call a ccxt method with retry, status and retCode verification."""
+    if os.getenv("TEST_MODE"):
+        # During unit tests we do not want to spend time in the retry loop.
+        return await getattr(exchange, method)(*args, **kwargs)
+
     delay = 1.0
     for attempt in range(5):
         try:


### PR DESCRIPTION
## Summary
- short-circuit `safe_api_call` when running in `TEST_MODE`
- add unit test for new behaviour

## Testing
- `pytest tests/test_utils.py::test_safe_api_call_retries tests/test_utils.py::test_safe_api_call_test_mode -q`
- `flake8 utils.py tests/test_utils.py`
- `pytest -q` *(fails: KeyboardInterrupt, many failures)*

------
https://chatgpt.com/codex/tasks/task_e_688be1d85aac832d98073203824f7b9e