### PR TITLE
Ensure test_safe_api_call_retries removes TEST_MODE

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,6 +16,7 @@ class DummyExchange:
 
 @pytest.mark.asyncio
 async def test_safe_api_call_retries(monkeypatch):
+    monkeypatch.delenv("TEST_MODE", raising=False)
     exch = DummyExchange()
 
     sleep_calls = {'n': 0}


### PR DESCRIPTION
## Summary
- remove TEST_MODE env variable in retry test

## Testing
- `pre-commit run --files tests/test_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_688c8038cac0832da39f433757d2d92d