### PR TITLE
Fix coroutine cleanup in trade manager route test

### DIFF
--- a/tests/test_trade_manager_routes.py
+++ b/tests/test_trade_manager_routes.py
@@ -127,3 +127,5 @@ def test_open_position_route_concurrent(monkeypatch):
             fut.result()
 
     assert len(loop.calls) == 5
+    for _, call_args in loop.calls:
+        call_args[0].close()


### PR DESCRIPTION
## Summary
- prevent unclosed coroutine warnings in `test_trade_manager_routes`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cc507a42c832dbe5ad765854abd9f