### PR TITLE
Fix env management in test_import_order

### DIFF
--- a/tests/test_import_order.py
+++ b/tests/test_import_order.py
@@ -3,8 +3,14 @@ import sys
 import types
 import logging
 import os
+import pytest
 
-os.environ["TEST_MODE"] = "1"
+
+@pytest.fixture(autouse=True)
+def _test_mode_env(monkeypatch):
+    monkeypatch.setenv("TEST_MODE", "1")
+    yield
+    monkeypatch.delenv("TEST_MODE", raising=False)
 
 def test_telegramlogger_injection_order():
     sys.modules.pop('trade_manager', None)


### PR DESCRIPTION
## Summary
- use a fixture to manage `TEST_MODE` in `tests/test_import_order.py`

## Testing
- `pre-commit run --files tests/test_import_order.py`

------
https://chatgpt.com/codex/tasks/task_e_688cee1bdc28832dad47160b5dc41123