### PR TITLE
Refactor service tests to use dynamic ports

### DIFF
--- a/tests/test_service_scripts.py
+++ b/tests/test_service_scripts.py
@@ -2,12 +2,21 @@ import multiprocessing
 import os
 import time
 import types
+import socket
 import requests
 
 ctx = multiprocessing.get_context("spawn")
 
 
-def _run_dh():
+def _get_free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _run_dh(port: int):
     class DummyExchange:
         def fetch_ticker(self, symbol):
             return {'last': 42.0}
@@ -20,21 +29,22 @@ def _run_dh():
     os.environ['STREAM_SYMBOLS'] = ''
     os.environ['HOST'] = '127.0.0.1'
     from bot.services import data_handler_service
-    data_handler_service.app.run(host='127.0.0.1', port=8000)
+    data_handler_service.app.run(host='127.0.0.1', port=port)
 
 
 def test_data_handler_service_price():
-    p = ctx.Process(target=_run_dh)
+    port = _get_free_port()
+    p = ctx.Process(target=_run_dh, args=(port,))
     p.start()
     try:
         for _ in range(50):
             try:
-                resp = requests.get('http://127.0.0.1:8000/ping', timeout=1)
+                resp = requests.get(f'http://127.0.0.1:{port}/ping', timeout=1)
                 if resp.status_code == 200:
                     break
             except Exception:
                 time.sleep(0.1)
-        resp = requests.get('http://127.0.0.1:8000/price/BTCUSDT', timeout=5)
+        resp = requests.get(f'http://127.0.0.1:{port}/price/BTCUSDT', timeout=5)
         assert resp.status_code == 200
         assert resp.json()['price'] == 42.0
     finally:
@@ -42,32 +52,33 @@ def test_data_handler_service_price():
         p.join()
 
 
-def _run_mb(model_dir: str):
+def _run_mb(model_dir: str, port: int):
     os.environ['MODEL_DIR'] = model_dir
     os.environ['HOST'] = '127.0.0.1'
     from bot.services import model_builder_service
-    model_builder_service.app.run(host='127.0.0.1', port=8001)
+    model_builder_service.app.run(host='127.0.0.1', port=port)
 
 
 def test_model_builder_service_train_predict(tmp_path):
-    p = ctx.Process(target=_run_mb, args=(str(tmp_path),))
+    port = _get_free_port()
+    p = ctx.Process(target=_run_mb, args=(str(tmp_path), port))
     p.start()
     try:
         for _ in range(50):
             try:
-                resp = requests.get('http://127.0.0.1:8001/ping', timeout=1)
+                resp = requests.get(f'http://127.0.0.1:{port}/ping', timeout=1)
                 if resp.status_code == 200:
                     break
             except Exception:
                 time.sleep(0.1)
         resp = requests.post(
-            'http://127.0.0.1:8001/train',
+            f'http://127.0.0.1:{port}/train',
             json={'symbol': 'SYM', 'features': [[0], [1]], 'labels': [0, 1]},
             timeout=5,
         )
         assert resp.status_code == 200
         resp = requests.post(
-            'http://127.0.0.1:8001/predict',
+            f'http://127.0.0.1:{port}/predict',
             json={'symbol': 'SYM', 'features': [1]},
             timeout=5,
         )
@@ -78,7 +89,7 @@ def test_model_builder_service_train_predict(tmp_path):
         p.join()
 
 
-def _run_tm():
+def _run_tm(port: int):
     class DummyExchange:
         def create_order(self, symbol, typ, side, amount, params=None):
             return {'id': '1'}
@@ -89,33 +100,34 @@ def _run_tm():
     os.environ['HOST'] = '127.0.0.1'
     os.environ.setdefault('TRADE_RISK_USD', '10')
     from bot.services import trade_manager_service
-    trade_manager_service.app.run(host='127.0.0.1', port=8002)
+    trade_manager_service.app.run(host='127.0.0.1', port=port)
 
 
 def test_trade_manager_service_endpoints():
-    p = ctx.Process(target=_run_tm)
+    port = _get_free_port()
+    p = ctx.Process(target=_run_tm, args=(port,))
     p.start()
     try:
         for _ in range(50):
             try:
-                resp = requests.get('http://127.0.0.1:8002/ping', timeout=1)
+                resp = requests.get(f'http://127.0.0.1:{port}/ping', timeout=1)
                 if resp.status_code == 200:
                     break
             except Exception:
                 time.sleep(0.1)
         resp = requests.post(
-            'http://127.0.0.1:8002/open_position',
+            f'http://127.0.0.1:{port}/open_position',
             json={'symbol': 'BTCUSDT', 'side': 'buy', 'amount': 1},
             timeout=5,
         )
         assert resp.status_code == 200
         resp = requests.post(
-            'http://127.0.0.1:8002/close_position',
+            f'http://127.0.0.1:{port}/close_position',
             json={'symbol': 'BTCUSDT', 'side': 'buy', 'amount': 1},
             timeout=5,
         )
         assert resp.status_code == 200
-        resp = requests.get('http://127.0.0.1:8002/positions', timeout=5)
+        resp = requests.get(f'http://127.0.0.1:{port}/positions', timeout=5)
         assert resp.status_code == 200
         data = resp.json()['positions']
         assert len(data) == 2
@@ -125,23 +137,24 @@ def test_trade_manager_service_endpoints():
 
 
 def test_trade_manager_service_price_only():
-    p = ctx.Process(target=_run_tm)
+    port = _get_free_port()
+    p = ctx.Process(target=_run_tm, args=(port,))
     p.start()
     try:
         for _ in range(50):
             try:
-                resp = requests.get('http://127.0.0.1:8002/ping', timeout=1)
+                resp = requests.get(f'http://127.0.0.1:{port}/ping', timeout=1)
                 if resp.status_code == 200:
                     break
             except Exception:
                 time.sleep(0.1)
         resp = requests.post(
-            'http://127.0.0.1:8002/open_position',
+            f'http://127.0.0.1:{port}/open_position',
             json={'symbol': 'BTCUSDT', 'side': 'buy', 'price': 5},
             timeout=5,
         )
         assert resp.status_code == 200
-        resp = requests.get('http://127.0.0.1:8002/positions', timeout=5)
+        resp = requests.get(f'http://127.0.0.1:{port}/positions', timeout=5)
         assert resp.status_code == 200
         data = resp.json()['positions']
         assert len(data) == 1
@@ -151,13 +164,14 @@ def test_trade_manager_service_price_only():
 
 
 def test_trade_manager_ready_route():
-    p = ctx.Process(target=_run_tm)
+    port = _get_free_port()
+    p = ctx.Process(target=_run_tm, args=(port,))
     p.start()
     try:
         resp = None
         for _ in range(50):
             try:
-                resp = requests.get('http://127.0.0.1:8002/ready', timeout=1)
+                resp = requests.get(f'http://127.0.0.1:{port}/ready', timeout=1)
                 if resp.status_code == 200:
                     break
             except Exception:


### PR DESCRIPTION
## Summary
- choose free ports for service integration tests
- poll service readiness instead of sleeping

## Testing
- `pytest -k 'service_scripts or integration_services' -q`

------
https://chatgpt.com/codex/tasks/task_e_688cf6b5c1f4832d9aeba2f25e484520