### PR TITLE
Ensure binary labels for model service

### DIFF
--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -1,4 +1,9 @@
-"""Reference model builder service using logistic regression."""
+"""Reference model builder service using logistic regression.
+
+The service expects binary labels. The ``/train`` route will return a
+``400`` error if the provided label array does not contain exactly two
+unique classes.
+"""
 
 from flask import Flask, request, jsonify
 import numpy as np
@@ -35,6 +40,9 @@ def train() -> tuple:
         features = features.reshape(-1, 1)
     if len(features) == 0 or len(features) != len(labels):
         return jsonify({'error': 'invalid training data'}), 400
+    # Ensure training labels represent a binary classification problem
+    if len(np.unique(labels)) != 2:
+        return jsonify({'error': 'labels must contain two classes'}), 400
     model = LogisticRegression()
     model.fit(features, labels)
     joblib.dump(model, MODEL_FILE)


### PR DESCRIPTION
## Summary
- add documentation that the `/train` endpoint requires two label classes
- return a 400 error if labels are not binary
- test that the service rejects invalid labels

## Testing
- `pytest tests/test_service_scripts.py::test_model_builder_service_train_predict -q`
- `pytest tests/test_service_scripts.py::test_model_builder_service_requires_binary_labels -q`
- `pytest tests/test_service_scripts.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688d2d9efa34832d9b5a7931d88ac2eb