### PR TITLE
Ensure numeric RSI dtype in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -320,7 +320,8 @@ def _stub_modules():
         avg_loss = loss.rolling(window, min_periods=1).mean()
         rs = avg_gain / avg_loss.replace(0, pd.NA)
         rsi = 100 - (100 / (1 + rs))
-        return rsi.fillna(0) if fillna else rsi
+        rsi = rsi.astype("Float64")
+        return rsi.fillna(0).astype("float64") if fillna else rsi
 
     def _macd_diff(close, window_slow=26, window_fast=12, window_sign=9, fillna=True):
         c = pd.Series(close)


### PR DESCRIPTION
## Summary
- cast stubbed RSI series to numeric `Float64` before filling NAs

## Testing
- `pytest tests/test_indicators_cache.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688ddabcae28832db18d98c8e697777c