### PR TITLE
Ensure RL action scalar extraction before comparisons

### DIFF
--- a/model_builder.py
+++ b/model_builder.py
@@ -1788,6 +1788,7 @@ class RLAgent:
                 )
                 return None
             action, _ = model.predict(obs, deterministic=True)
+        action = action.item()
         action = int(action)
         if action == 1:
             return "open_long"


### PR DESCRIPTION
## Summary
- Ensure RL predictions convert tensor/array actions to native scalars using `item()` before comparison

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688de299f7f8832daa6bd48e48200037