### PR TITLE
Use CUDA torch wheel with matching index

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.26.4
 pandas>=2.2.2
-torch==2.7.1
-torchvision==0.22.1
+torch==2.7.1+cu121
+torchvision==0.22.1+cu121
 ccxt>=4.3.85
 ccxtpro>=0.9.0
 python-telegram-bot>=20.7
@@ -29,6 +29,7 @@ mlflow>=2.12.1
 pytorch-lightning>=2.2.1
 tensorflow>=2.16.1
 catalyst==21.4
+--extra-index-url https://download.pytorch.org/whl/cu121
 pytest>=8.1.1
 pytest-asyncio>=1.0.0
 flask>=3.0.2


### PR DESCRIPTION
## Summary
- switch requirements to CUDA 12.1 torch and torchvision wheels
- add matching extra index for CUDA wheel

## Testing
- `pytest`
- `docker build -t bot-test .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_688e682b64a4832da1b641bdf72e9783