### PR TITLE
Ensure Docker builds use Python 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libffi-dev \
     libblas-dev \
     liblapack-dev \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && python3.12 --version
 
 WORKDIR /app
 
@@ -55,7 +56,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get update && apt-get install -y --no-install-recommends \
     curl \
     python3.12 \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && python3.12 --version
 
 # Копируем виртуальное окружение из этапа сборки
 COPY --from=builder /app/venv /app/venv

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -15,7 +15,8 @@ FROM python:3.12-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && python --version
 
 WORKDIR /app
 
@@ -30,4 +31,4 @@ RUN echo "Checking package versions..." && \
     $VIRTUAL_ENV/bin/python -c "import torch, tensorflow as tf; print('Torch:', torch.__version__, 'TF:', tf.__version__)" && \
     $VIRTUAL_ENV/bin/python -c "import stable_baselines3 as sb3, mlflow, pytorch_lightning as pl; print('SB3:', sb3.__version__, 'MLflow:', mlflow.__version__, 'Lightning:', pl.__version__)"
 
-CMD ["python", "trading_bot.py"]
+CMD ["/app/venv/bin/python3.12", "-m", "bot.trading_bot"]


### PR DESCRIPTION
## Summary
- add explicit Python 3.12 version checks in CUDA-based Docker image
- run trading bot with Python 3.12 in CPU Docker image

## Testing
- `apt-get update`
- `apt-get install -y docker.io`
- `docker build -f Dockerfile.cpu -t bot-cpu-test .` *(fails: Cannot connect to the Docker daemon)*
- `dockerd` *(fails: failed to mount overlay: operation not permitted)*

------
https://chatgpt.com/codex/tasks/task_e_688e87675004832d82306db64e5bcf5d