### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -9,6 +9,9 @@ from flask import Flask, request, jsonify
 import ccxt
 import os
 from dotenv import load_dotenv
+import logging
+
+logging.basicConfig(level=logging.INFO)
 
 load_dotenv()
 
@@ -86,7 +89,8 @@ def close_position() -> tuple:
                 break
         return jsonify({'status': 'ok', 'order_id': order.get('id')})
     except Exception as exc:  # pragma: no cover - network errors
-        return jsonify({'error': str(exc)}), 500
+        logging.exception("Error closing position")
+        return jsonify({'error': 'An internal error has occurred.'}), 500
 
 
 @app.route('/positions')


### PR DESCRIPTION
Potential fix for [https://github.com/averinaleks/bot/security/code-scanning/3](https://github.com/averinaleks/bot/security/code-scanning/3)

To fix the problem, we should avoid returning the raw exception message to the client. Instead, we should log the exception (including the stack trace) on the server for debugging purposes, and return a generic error message to the client. This can be done by importing the `logging` module, configuring it if necessary, and replacing the `return jsonify({'error': str(exc)})` line with a log statement and a generic error response. The change should be made in the `except` block of the `/close_position` route handler in `services/trade_manager_service.py`. If logging is not already set up, we should add a basic configuration at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
