### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -96,7 +96,7 @@ def open_position() -> tuple:
         return jsonify({'status': 'ok', 'order_id': order.get('id')})
     except Exception as exc:  # pragma: no cover - network errors
         app.logger.error('exception creating order: %s', exc)
-        return jsonify({'error': str(exc)}), 500
+        return jsonify({'error': 'An internal error has occurred.'}), 500
 
 
 @app.route('/close_position', methods=['POST'])


### PR DESCRIPTION
Potential fix for [https://github.com/averinaleks/bot/security/code-scanning/2](https://github.com/averinaleks/bot/security/code-scanning/2)

To fix the problem, the code should avoid returning the exception message (`str(exc)`) to the client. Instead, it should log the exception details on the server (using `app.logger.error` or `logging.exception`) and return a generic error message in the JSON response. This change should be made in the `open_position` route handler, specifically in the `except` block on lines 97-99. No changes are needed elsewhere, as the `close_position` endpoint already follows the correct pattern. The fix requires no new imports or method definitions, as logging is already set up.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
