### PR TITLE
Handle price service errors

### DIFF
--- a/services/data_handler_service.py
+++ b/services/data_handler_service.py
@@ -19,9 +19,10 @@ def price(symbol: str):
     try:
         ticker = exchange.fetch_ticker(symbol)
         last = float(ticker.get('last') or 0.0)
+        return jsonify({'price': last})
     except Exception as exc:  # pragma: no cover - network errors
-        last = 0.0
-    return jsonify({'price': last})
+        # Surface exchange errors to clients so callers can react accordingly.
+        return jsonify({'error': str(exc)}), 503
 
 @app.route('/ping')
 def ping():


### PR DESCRIPTION
## Summary
- Return HTTP 503 with error message from price endpoint when exchange access fails
- Detect data handler errors in `fetch_price` and abort trading loop
- Add tests for price service failures and bot error handling

## Testing
- `pytest tests/test_trading_bot.py::test_run_once_invalid_price tests/test_trading_bot.py::test_fetch_price_error tests/test_trading_bot.py::test_run_once_price_error tests/test_service_scripts.py::test_data_handler_service_price tests/test_service_scripts.py::test_data_handler_service_price_error -q`


------
https://chatgpt.com/codex/tasks/task_e_688f4b1a84ec832d8a4e668e5dd6455a