### PR TITLE
Potential fix for code scanning alert no. 357: Information exposure through an exception

### DIFF
--- a/services/data_handler_service.py
+++ b/services/data_handler_service.py
@@ -1,11 +1,15 @@
 """Simple reference data handler service fetching real prices from Bybit."""
 from flask import Flask, jsonify
+import logging
 import ccxt
 import os
 from dotenv import load_dotenv
 
 load_dotenv()
 
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
 app = Flask(__name__)
 
 exchange = ccxt.bybit({
@@ -21,8 +25,9 @@ def price(symbol: str):
         last = float(ticker.get('last') or 0.0)
         return jsonify({'price': last})
     except Exception as exc:  # pragma: no cover - network errors
-        # Surface exchange errors to clients so callers can react accordingly.
-        return jsonify({'error': str(exc)}), 503
+        # Log the exception with traceback for debugging, but do not expose details to clients.
+        logging.exception("Error fetching price for symbol '%s': %s", symbol, exc)
+        return jsonify({'error': 'Failed to fetch price.'}), 503
 
 @app.route('/ping')
 def ping():


### PR DESCRIPTION
Potential fix for [https://github.com/averinaleks/bot/security/code-scanning/357](https://github.com/averinaleks/bot/security/code-scanning/357)

To fix the problem, the code should avoid returning the raw exception message to the client. Instead, it should return a generic error message such as "An internal error has occurred" or "Failed to fetch price." The detailed exception (including the stack trace) should be logged on the server for debugging. This can be achieved by using Python's `logging` module to log the exception with traceback information. The changes should be made only in the `/price/<symbol>` endpoint in `services/data_handler_service.py`. Specifically, update the `except` block to log the exception and return a generic error message. Also, ensure that the `logging` module is imported and configured.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
