### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 # If a job fails with a temporary runner error, rerun the workflow.
 # Self-hosted runners are also supported. When contacting GitHub Support
 # include the correlation ID from the run's raw logs.


### PR DESCRIPTION
Potential fix for [https://github.com/averinaleks/bot/security/code-scanning/1](https://github.com/averinaleks/bot/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` block in the workflow file to restrict the `GITHUB_TOKEN` to the least privilege required. For a typical CI workflow that only checks out code and runs tests, `contents: read` is sufficient. This can be set at the workflow level (applies to all jobs) or at the job level (applies to a specific job). The best way to fix this is to add the following block near the top of the file, after the `name` field and before the `on` field:

```yaml
permissions:
  contents: read
```

This ensures that all jobs in the workflow only have read access to repository contents, unless a job explicitly overrides it. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
