### PR TITLE
Use CUDA PyTorch wheel from global index

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
+--extra-index-url https://download.pytorch.org/whl/cu121
 numpy>=1.26.4
 pandas>=2.2.2
-torch==2.7.1+cpu
+torch==2.7.1+cu121
 torchvision==0.22.1
 ccxt>=4.3.85
 ccxtpro>=0.9.0
@@ -29,7 +30,6 @@ mlflow>=2.12.1
 pytorch-lightning>=2.2.1
 tensorflow>=2.16.1
 catalyst==21.4
---extra-index-url https://download.pytorch.org/whl/cu121
 pytest>=8.1.1
 pytest-asyncio>=1.0.0
 flask>=3.0.2


### PR DESCRIPTION
## Summary
- Move PyTorch extra index to the top of requirements.txt so it applies to all dependencies
- Switch to CUDA 12.1 PyTorch build

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `docker build --target builder -t bot-builder .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*

------
https://chatgpt.com/codex/tasks/task_e_688f5e4a3928832d876f211fe254afad