### PR TITLE
chore: restrict workflow permissions

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -11,6 +11,11 @@
 # https://pypi.org/project/bandit/ is Apache v2.0 licensed, by PyCQA
 
 name: Bandit
+
+permissions:
+  contents: read
+  security-events: write
+
 on:
   push:
     branches: [ "main" ]
@@ -22,11 +27,6 @@ on:
 
 jobs:
   bandit:
-    permissions:
-      contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,10 @@
 #
 name: "CodeQL Advanced"
 
+permissions:
+  contents: read
+  security-events: write
+
 on:
   push:
     branches: [ "main" ]
@@ -28,16 +32,6 @@ jobs:
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
-    permissions:
-      # required for all workflows
-      security-events: write
-
-      # required to fetch internal or private CodeQL packs
-      packages: read
-
-      # only required for workflows in private repositories
-      actions: read
-      contents: read
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- add minimal top-level permissions to CodeQL workflow
- add minimal top-level permissions to Bandit workflow

## Testing
- `pre-commit run --files .github/workflows/codeql.yml .github/workflows/bandit.yml` *(fails: exit code 4)*
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_688f64194f64832dbd73be56a92b95bd