### PR TITLE
fix: respect probability threshold in backtest

### DIFF
--- a/portfolio_backtest.py
+++ b/portfolio_backtest.py
@@ -60,6 +60,8 @@ def portfolio_backtest(
                 ema_slow=ema_slow,
                 atr=atr,
             )
+            if "probability" not in df_reset.columns:
+                df_reset["probability"] = 1.0
             events.append(
                 df_reset[
                     [
@@ -68,6 +70,7 @@ def portfolio_backtest(
                         "close",
                         "high",
                         "low",
+                        "probability",
                         "ema_fast",
                         "ema_slow",
                         "atr",
@@ -90,6 +93,7 @@ def portfolio_backtest(
             high = row["high"]
             low = row["low"]
             atr = row["atr"]
+            probability = row.get("probability", 1.0)
 
             pos = positions.get(symbol)
             if pos is not None:
@@ -110,9 +114,9 @@ def portfolio_backtest(
 
             if symbol not in positions and len(positions) < max_positions and pd.notna(atr):
                 signal = None
-                if row["ema_fast"] > row["ema_slow"] and 1.0 >= base_thr:
+                if row["ema_fast"] > row["ema_slow"] and probability >= base_thr:
                     signal = "buy"
-                elif row["ema_fast"] < row["ema_slow"] and 0.0 <= 1 - base_thr:
+                elif row["ema_fast"] < row["ema_slow"] and (1 - probability) >= base_thr:
                     signal = "sell"
                 if signal:
                     if signal == "buy":

--- a/tests/test_probability_threshold.py
+++ b/tests/test_probability_threshold.py
@@ -1,0 +1,59 @@
+import numpy as np
+import pandas as pd
+
+from bot.portfolio_backtest import portfolio_backtest
+
+
+def make_df(symbol: str, direction: str, prob: float) -> pd.DataFrame:
+    idx = pd.date_range('2020-01-01', periods=30, freq='min')
+    if direction == 'up':
+        close = np.linspace(1, 2, len(idx))
+    else:
+        close = np.linspace(2, 1, len(idx))
+    high = close + 0.1
+    low = close - 0.1
+    df = pd.DataFrame(
+        {
+            'close': close,
+            'open': close,
+            'high': high,
+            'low': low,
+            'volume': np.ones(len(idx)),
+            'probability': np.full(len(idx), prob),
+        },
+        index=idx,
+    )
+    df['symbol'] = symbol
+    return df.set_index(['symbol', df.index])
+
+
+def test_buy_respects_probability_threshold():
+    df_low = {'BTCUSDT': make_df('BTCUSDT', 'up', prob=0.5)}
+    df_high = {'BTCUSDT': make_df('BTCUSDT', 'up', prob=0.7)}
+    params = {
+        'ema30_period': 3,
+        'ema100_period': 5,
+        'tp_multiplier': 1.0,
+        'sl_multiplier': 1.0,
+        'base_probability_threshold': 0.6,
+    }
+    ratio_low = portfolio_backtest(df_low, params, '1m', max_positions=1)
+    ratio_high = portfolio_backtest(df_high, params, '1m', max_positions=1)
+    assert ratio_low == 0.0
+    assert ratio_high > ratio_low
+
+
+def test_sell_respects_probability_threshold():
+    df_low = {'BTCUSDT': make_df('BTCUSDT', 'down', prob=0.9)}
+    df_high = {'BTCUSDT': make_df('BTCUSDT', 'down', prob=0.3)}
+    params = {
+        'ema30_period': 3,
+        'ema100_period': 5,
+        'tp_multiplier': 1.0,
+        'sl_multiplier': 1.0,
+        'base_probability_threshold': 0.6,
+    }
+    ratio_low = portfolio_backtest(df_low, params, '1m', max_positions=1)
+    ratio_high = portfolio_backtest(df_high, params, '1m', max_positions=1)
+    assert ratio_low == 0.0
+    assert ratio_high > ratio_low


### PR DESCRIPTION
## Summary
- honor model probability when generating portfolio backtest signals
- exercise probability-based buy and sell checks in new tests

## Testing
- `pytest tests/test_probability_threshold.py tests/test_strategy_optimizer.py::test_portfolio_backtest_runs -q`


------
https://chatgpt.com/codex/tasks/task_e_688f6ebdbd44832db12eecf44580acdd