### PR TITLE
Use CUDA 12.1 base image for PyTorch compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Этап сборки
-FROM nvidia/cuda:12.5.1-cudnn-devel-ubuntu22.04 AS builder
+FROM nvidia/cuda:12.1.0-cudnn-devel-ubuntu22.04 AS builder
 ENV OMP_NUM_THREADS=1
 ENV MKL_NUM_THREADS=1
 ENV DEBIAN_FRONTEND=noninteractive
@@ -40,7 +40,7 @@ RUN pip install --no-cache-dir pip==24.0 setuptools wheel && \
     find /app/venv -type f -name '*.pyc' -delete
 
 # Этап выполнения
-FROM nvidia/cuda:12.5.1-cudnn-devel-ubuntu22.04
+FROM nvidia/cuda:12.1.0-cudnn-devel-ubuntu22.04
 ENV OMP_NUM_THREADS=1
 ENV MKL_NUM_THREADS=1
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Summary
- Align builder and runtime stages with `nvidia/cuda:12.1.0-cudnn-devel-ubuntu22.04`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `docker build -t trading-bot .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_688f75754788832db8041159f678cfae