### PR TITLE
Update PyTorch CUDA wheel references to cu124

### DIFF
--- a/requirements.out
+++ b/requirements.out
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements.out requirements.txt
 #
--f https://download.pytorch.org/whl/cu121
+-f https://download.pytorch.org/whl/cu124
 
 a2wsgi==1.10.10
     # via -r requirements.txt
@@ -531,7 +531,7 @@ threadpoolctl==3.6.0
     # via
     #   imbalanced-learn
     #   scikit-learn
-torch==2.7.1+cu121
+torch==2.7.1+cu124
     # via
     #   -r requirements.txt
     #   catalyst
@@ -541,7 +541,7 @@ torch==2.7.1+cu121
     #   torchvision
 torchmetrics==1.8.0
     # via pytorch-lightning
-torchvision==0.22.1+cu121
+torchvision==0.22.1+cu124
     # via -r requirements.txt
 tqdm==4.67.1
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
--f https://download.pytorch.org/whl/cu121
+-f https://download.pytorch.org/whl/cu124
 numpy>=1.26.4
 pandas>=2.2.2
-torch==2.7.1+cu121
-torchvision==0.22.1+cu121
+torch==2.7.1+cu124
+torchvision==0.22.1+cu124
 ccxt>=4.3.85
 ccxtpro>=0.9.0
 python-telegram-bot>=20.7


### PR DESCRIPTION
## Summary
- point PyTorch requirements at cu124 download site
- update torch and torchvision to cu124 builds in lockfile

## Testing
- `python -m piptools compile requirements.txt -o requirements.out` *(fails: No matching distribution found for torch==2.7.1+cu124)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_688f78e730dc832da97d512fa6a5fb2a