### PR TITLE
Mark integration tests and split CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,5 +32,27 @@ jobs:
           ./scripts/install-test-deps.sh
       - name: Run flake8
         run: flake8 .
-      - name: Test
-        run: pytest
+      - name: Run unit tests
+        run: pytest -m "not integration"
+
+  integration:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.12'
+      - name: Cache pip
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements-cpu.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          ./scripts/install-test-deps.sh
+      - name: Run integration tests
+        run: pytest -m integration

--- a/tests/test_integration_services.py
+++ b/tests/test_integration_services.py
@@ -98,6 +98,7 @@ def _run_tm(port: int):
     tm_app.run(host=host, port=port)
 
 
+@pytest.mark.integration
 def test_services_communicate():
     from bot import trading_bot  # noqa: E402
     os.environ['HOST'] = '127.0.0.1'
@@ -134,6 +135,7 @@ def test_services_communicate():
             p.join()
 
 
+@pytest.mark.integration
 def test_service_availability_check():
     from bot import trading_bot  # noqa: E402
     os.environ['HOST'] = '127.0.0.1'
@@ -167,6 +169,7 @@ def test_service_availability_check():
             p.join()
 
 
+@pytest.mark.integration
 def test_check_services_success():
     from bot import trading_bot  # noqa: E402
     os.environ['HOST'] = '127.0.0.1'
@@ -202,6 +205,7 @@ def test_check_services_success():
             p.join()
 
 
+@pytest.mark.integration
 def test_check_services_failure():
     from bot import trading_bot  # noqa: E402
     os.environ['HOST'] = '127.0.0.1'
@@ -236,6 +240,7 @@ def test_check_services_failure():
             p.join()
 
 
+@pytest.mark.integration
 def test_check_services_host_only():
     from bot import trading_bot  # noqa: E402
     os.environ['HOST'] = '127.0.0.1'

--- a/tests/test_service_scripts.py
+++ b/tests/test_service_scripts.py
@@ -4,7 +4,7 @@ import time
 import types
 import socket
 import requests
-import multiprocessing
+import pytest
 
 ctx = multiprocessing.get_context("spawn")
 
@@ -33,6 +33,7 @@ def _run_dh(port: int):
     data_handler_service.app.run(host='127.0.0.1', port=port)
 
 
+@pytest.mark.integration
 def test_data_handler_service_price():
     port = _get_free_port()
     p = ctx.Process(target=_run_dh, args=(port,))
@@ -68,6 +69,7 @@ def _run_dh_fail(port: int):
     data_handler_service.app.run(host='127.0.0.1', port=port)
 
 
+@pytest.mark.integration
 def test_data_handler_service_price_error():
     port = _get_free_port()
     p = ctx.Process(target=_run_dh_fail, args=(port,))
@@ -95,6 +97,7 @@ def _run_mb(model_dir: str, port: int):
     model_builder_service.app.run(host='127.0.0.1', port=port)
 
 
+@pytest.mark.integration
 def test_model_builder_service_train_predict(tmp_path):
     port = _get_free_port()
     p = ctx.Process(target=_run_mb, args=(str(tmp_path), port))
@@ -125,6 +128,7 @@ def test_model_builder_service_train_predict(tmp_path):
         p.join()
 
 
+@pytest.mark.integration
 def test_model_builder_service_requires_binary_labels(tmp_path):
     port = _get_free_port()
     p = ctx.Process(target=_run_mb, args=(str(tmp_path), port))
@@ -156,6 +160,7 @@ def _run_mb_fail(model_file: str, port: int):
     model_builder_service.app.run(host='127.0.0.1', port=port)
 
 
+@pytest.mark.integration
 def test_model_builder_service_load_failure(tmp_path):
     port = _get_free_port()
     bad_file = tmp_path / 'model.pkl'
@@ -207,6 +212,7 @@ def _run_tm(port: int, with_tp_sl: bool = True, fail_after_market: bool = False)
     trade_manager_service.app.run(host='127.0.0.1', port=port)
 
 
+@pytest.mark.integration
 def test_trade_manager_service_endpoints():
     port = _get_free_port()
     p = ctx.Process(target=_run_tm, args=(port,))
@@ -244,6 +250,7 @@ def test_trade_manager_service_endpoints():
         p.join()
 
 
+@pytest.mark.integration
 def test_trade_manager_service_price_only():
     port = _get_free_port()
     p = ctx.Process(target=_run_tm, args=(port,))
@@ -271,6 +278,7 @@ def test_trade_manager_service_price_only():
         p.join()
 
 
+@pytest.mark.integration
 def test_trade_manager_service_fallback_orders():
     port = _get_free_port()
     p = ctx.Process(target=_run_tm, args=(port, False))
@@ -298,6 +306,7 @@ def test_trade_manager_service_fallback_orders():
         p.join()
 
 
+@pytest.mark.integration
 def test_trade_manager_service_fallback_failure():
     port = _get_free_port()
     p = ctx.Process(target=_run_tm, args=(port, False, True))
@@ -321,6 +330,7 @@ def test_trade_manager_service_fallback_failure():
         p.join()
 
 
+@pytest.mark.integration
 def test_trade_manager_ready_route():
     port = _get_free_port()
     p = ctx.Process(target=_run_tm, args=(port,))


### PR DESCRIPTION
## Summary
- mark service integration tests with `pytest.mark.integration`
- run unit tests by default in CI
- add separate CI job for integration tests

## Testing
- `pre-commit run --files tests/test_integration_services.py tests/test_service_scripts.py`
- `pytest -m "not integration"`
- `pytest -m integration`


------
https://chatgpt.com/codex/tasks/task_e_688f784aefd4832da563230d4f15c920