### PR TITLE
build: upgrade cuda base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Этап сборки
-FROM nvidia/cuda:12.1.0-cudnn-devel-ubuntu22.04 AS builder
+FROM nvidia/cuda:12.4.0-cudnn-devel-ubuntu22.04 AS builder
 ENV OMP_NUM_THREADS=1
 ENV MKL_NUM_THREADS=1
 ENV DEBIAN_FRONTEND=noninteractive
@@ -40,7 +40,7 @@ RUN pip install --no-cache-dir pip==24.0 setuptools wheel && \
     find /app/venv -type f -name '*.pyc' -delete
 
 # Этап выполнения
-FROM nvidia/cuda:12.1.0-cudnn-devel-ubuntu22.04
+FROM nvidia/cuda:12.4.0-cudnn-devel-ubuntu22.04
 ENV OMP_NUM_THREADS=1
 ENV MKL_NUM_THREADS=1
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Summary
- upgrade runtime and builder base images to CUDA 12.4.0 with cuDNN for Ubuntu 22.04

## Testing
- `docker build -t bot-cuda124 .` *(fails: Cannot connect to the Docker daemon: Docker daemon not running)*
- `pytest -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_688f7a5baa08832d84cb700a82da28e3