### PR TITLE
Use stubbed sleep in trading bot tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import types
 import importlib.abc
 import importlib.util
 import threading
+import time
 try:
     import sklearn  # ensure real scikit-learn loaded before tests may stub it
     import sklearn.model_selection  # preload submodules used in tests
@@ -498,3 +499,18 @@ def sample_ohlcv():
             "volume": [0.0, 0.0, 0.0],
         }
     )
+
+
+@pytest.fixture
+def fast_sleep(monkeypatch):
+    """Replace time.sleep with a stub that records calls without delaying."""
+    calls = {"count": 0, "total": 0.0}
+    real_sleep = time.sleep
+
+    def _sleep(seconds: float):
+        calls["count"] += 1
+        calls["total"] += seconds
+        real_sleep(0)
+
+    monkeypatch.setattr(time, "sleep", _sleep)
+    return calls

--- a/tests/test_trading_bot.py
+++ b/tests/test_trading_bot.py
@@ -54,7 +54,7 @@ def test_load_env_uses_host_when_missing(monkeypatch):
     assert env['trade_manager_url'] == 'http://127.0.0.1:8002'
 
 
-def test_send_trade_latency_alert(monkeypatch):
+def test_send_trade_latency_alert(monkeypatch, fast_sleep):
     called = []
 
     def fake_post(url, json=None, timeout=None):
@@ -98,7 +98,7 @@ def test_send_trade_exception_alert(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_reactive_trade_latency_alert(monkeypatch):
+async def test_reactive_trade_latency_alert(monkeypatch, fast_sleep):
     called = []
 
     class DummyClient:


### PR DESCRIPTION
## Summary
- add `fast_sleep` fixture to stub `time.sleep` with no delay and call tracking
- patch trading bot latency tests to use the new fixture

## Testing
- `pytest tests/test_trading_bot.py -q`
- `pytest tests/test_telegram_logger.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f7c3d1e08832d9e3bdebcc7a6323c