### PR TITLE
refactor: add shared wait helper for service tests

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,35 @@
+import time
+import requests
+
+
+def wait_for_service(
+    url: str,
+    timeout: float = 5.0,
+    *,
+    initial_delay: float = 0.1,
+    max_delay: float = 1.0,
+    backoff: float = 2.0,
+) -> requests.Response:
+    """Poll ``url`` until it responds with HTTP 200 or until ``timeout`` expires.
+
+    The function retries requests with exponential backoff. ``initial_delay`` sets
+    the first sleep interval, which is multiplied by ``backoff`` after each
+    failed attempt up to ``max_delay``. Raises ``AssertionError`` if the service
+    does not become ready within ``timeout`` seconds.
+    """
+    deadline = time.time() + timeout
+    delay = initial_delay
+    while True:
+        try:
+            resp = requests.get(url, timeout=0.2)
+            if resp.status_code == 200:
+                return resp
+        except Exception:
+            pass
+        if time.time() >= deadline:
+            break
+        time.sleep(delay)
+        delay = min(delay * backoff, max_delay)
+    raise AssertionError(
+        f"Service at {url} did not become ready within {timeout} seconds"
+    )

--- a/tests/test_integration_services.py
+++ b/tests/test_integration_services.py
@@ -1,10 +1,11 @@
 import os
-import time
 import requests
 import multiprocessing
 import socket
 from flask import Flask, request, jsonify
 import pytest
+
+from tests.helpers import wait_for_service
 
 # Ensure processes use the spawn start method on all platforms
 multiprocessing.set_start_method("spawn", force=True)
@@ -19,18 +20,6 @@ def _get_free_port() -> int:
     return port
 
 
-def _wait_for_service(url: str, timeout: float = 5.0) -> None:
-    """Poll the given URL until it responds or until ``timeout`` seconds have passed."""
-    start = time.time()
-    while time.time() - start < timeout:
-        try:
-            resp = requests.get(url, timeout=0.2)
-            if resp.status_code == 200:
-                return
-        except Exception:
-            pass
-        time.sleep(0.1)
-    raise AssertionError(f"Service at {url} did not become ready within {timeout} seconds")
 
 
 # Minimal stubs for services to avoid heavy dependencies
@@ -117,7 +106,7 @@ def test_services_communicate():
         f'http://localhost:{mb_port}/ping',
         f'http://localhost:{tm_port}/ready',
     ):
-        _wait_for_service(url)
+        wait_for_service(url)
     os.environ.update({
         'DATA_HANDLER_URL': f'http://localhost:{dh_port}',
         'MODEL_BUILDER_URL': f'http://localhost:{mb_port}',
@@ -154,7 +143,7 @@ def test_service_availability_check():
         f'http://localhost:{mb_port}/ping',
         f'http://localhost:{tm_port}/ready',
     ):
-        _wait_for_service(url)
+        wait_for_service(url)
     try:
         resp = requests.get(f'http://localhost:{dh_port}/ping', timeout=5)
         assert resp.status_code == 200
@@ -188,7 +177,7 @@ def test_check_services_success():
         f'http://localhost:{mb_port}/ping',
         f'http://localhost:{tm_port}/ready',
     ):
-        _wait_for_service(url)
+        wait_for_service(url)
     os.environ.update({
         'DATA_HANDLER_URL': f'http://localhost:{dh_port}',
         'MODEL_BUILDER_URL': f'http://localhost:{mb_port}',
@@ -222,7 +211,7 @@ def test_check_services_failure():
         f'http://localhost:{dh_port}/ping',
         f'http://localhost:{mb_port}/ping',
     ):
-        _wait_for_service(url)
+        wait_for_service(url)
     os.environ.update({
         'DATA_HANDLER_URL': f'http://localhost:{dh_port}',
         'MODEL_BUILDER_URL': f'http://localhost:{mb_port}',
@@ -265,7 +254,7 @@ def test_check_services_host_only():
         f'http://localhost:{mb_port}/ping',
         f'http://localhost:{tm_port}/ready',
     ):
-        _wait_for_service(url)
+        wait_for_service(url)
     os.environ.update({
         'DATA_HANDLER_URL': f'http://localhost:{dh_port}',
         'MODEL_BUILDER_URL': f'http://localhost:{mb_port}',


### PR DESCRIPTION
## Summary
- add `wait_for_service` helper with exponential backoff
- reuse helper in integration and service script tests to remove polling loops
- stub sklearn in service script tests for lighter test setup

## Testing
- `pytest tests/test_integration_services.py tests/test_service_scripts.py -q --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_688f82e3c540832d8f896342f16b2e25