### PR TITLE
ci: split unit and integration test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  unit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -37,7 +37,8 @@ jobs:
 
   integration:
     runs-on: ubuntu-latest
-    needs: build
+    needs: unit
+    continue-on-error: true
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,10 +12,16 @@ Thank you for your interest in contributing to this project!
     ```
    (Use `--full` to include GPU packages.) This step is **required** before
    running the test suite—`pytest` expects these packages to be installed.
-2. Run `python -m flake8` and `pytest` before submitting a pull request. The CI
-   workflow runs `flake8` as a dedicated step and will fail if any style errors
-   are reported, so it's best to fix them locally first. These tests are also
-   executed automatically by `pre-commit`.
+2. Run `python -m flake8` and the test suites before submitting a pull request.
+   The CI workflow runs `flake8` as a dedicated step and will fail if any style
+   errors are reported, so it's best to fix them locally first.
+
+   ```bash
+   pytest -m "not integration"  # unit tests
+   pytest -m integration         # integration tests
+   ```
+
+   These tests are also executed automatically by `pre-commit`.
 
 ## CI troubleshooting
 


### PR DESCRIPTION
## Summary
- run unit tests and linting in `unit` job
- run integration tests in a separate optional job
- document how to run unit and integration tests locally

## Testing
- `python -m flake8`
- `pytest -m "not integration"`
- `pytest -m integration`


------
https://chatgpt.com/codex/tasks/task_e_688f87b89538832d87ab3db3dd5e88eb