### PR TITLE
Align CPU requirements with standard PyTorch

### DIFF
--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -1,6 +1,6 @@
 numpy>=1.26.4
 pandas>=2.2.2
-torch==2.7.1+cpu
+torch==2.7.1
 torchvision==0.22.1
 ccxt>=4.3.85
 ccxtpro>=0.9.0
@@ -29,7 +29,6 @@ mlflow>=2.12.1
 pytorch-lightning>=2.2.1
 tensorflow-cpu>=2.16.1
 catalyst==21.4
---extra-index-url https://download.pytorch.org/whl/cpu
 pytest>=8.1.1
 pytest-asyncio>=1.0.0
 flask>=3.0.2


### PR DESCRIPTION
## Summary
- Switch CPU requirements to use the standard `torch==2.7.1`
- Drop PyTorch CPU extra index from `requirements-cpu.txt`

## Testing
- `sh scripts/install-test-deps.sh` *(installation attempted; cancelled after verifying torch download)*

------
https://chatgpt.com/codex/tasks/task_e_688f93e4ceb0832dbad6671ca6492a2a