### PR TITLE
chore: ensure importlib import in force CPU test

### DIFF
--- a/tests/test_force_cpu.py
+++ b/tests/test_force_cpu.py
@@ -1,5 +1,5 @@
-import os
 import importlib
+import os
 import sys
 from bot import utils
 


### PR DESCRIPTION
## Summary
- reorder imports in force CPU test to include `import importlib` at the top

## Testing
- `pytest tests/test_force_cpu.py`


------
https://chatgpt.com/codex/tasks/task_e_688f9eba0074832d8c98b39709d2eefd