### PR TITLE
fix: ensure importlib imported in RL agent test

### DIFF
--- a/tests/test_rl_agent.py
+++ b/tests/test_rl_agent.py
@@ -1,5 +1,6 @@
 import sys
 import types
+import importlib
 import pandas as pd
 import numpy as np
 import pytest
@@ -58,7 +59,6 @@ if "gymnasium" not in sys.modules:
     gym_stub.spaces = types.SimpleNamespace(Discrete=DummyDiscrete, Box=DummyBox)
     sys.modules["gymnasium"] = gym_stub
 
-import importlib
 from bot import model_builder
 importlib.reload(model_builder)
 from bot.config import BotConfig


### PR DESCRIPTION
## Summary
- import importlib at top of RL agent test for consistent module reload

## Testing
- `pre-commit run --files tests/test_rl_agent.py`
- `pytest tests/test_rl_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_688f9ec83a38832d859cecabbf10eaf2