### PR TITLE
Use monkeypatch to manage TEST_MODE env in tests

### DIFF
--- a/tests/test_trade_manager_routes.py
+++ b/tests/test_trade_manager_routes.py
@@ -20,7 +20,7 @@ async def dummy_coroutine(*_args, **_kwargs):
 
 
 def _setup_module(monkeypatch):
-    os.environ["TEST_MODE"] = "1"
+    monkeypatch.setenv("TEST_MODE", "1")
     import sys
     # stub heavy deps before import
     torch = types.ModuleType("torch")
@@ -70,6 +70,7 @@ def _setup_module(monkeypatch):
     )
     tm.trade_manager = stub
     tm._ready_event.set()
+    monkeypatch.delenv("TEST_MODE", raising=False)
     return tm, loop, stub
 
 


### PR DESCRIPTION
## Summary
- Use monkeypatch.setenv to configure TEST_MODE in trade manager route tests and delete it after setup
- Provide pytest fixture for simulator tests to manage TEST_MODE with monkeypatch

## Testing
- `pytest tests/test_trade_manager_routes.py tests/test_simulation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688f9ea3156c832dbcd312f5819c8aa9