### PR TITLE
test: register integration marker

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ def pytest_configure(config):
         "markers",
         "requires_sklearn: mark test that needs the scikit-learn package",
     )
+    config.addinivalue_line("markers", "integration: mark integration tests")
 
 
 def pytest_runtest_setup(item):


### PR DESCRIPTION
## Summary
- allow pytest to mark integration tests with `@pytest.mark.integration`

## Testing
- `pre-commit run flake8 --files tests/conftest.py`
- `pytest -q`

Attempted to run `pre-commit run --files tests/conftest.py`, but the `pytest` hook failed because no tests were collected for the provided file.

------
https://chatgpt.com/codex/tasks/task_e_688f9f637be0832dbc5ca7026e3f98a5