### PR TITLE
ci: prune docker system before Trivy scan

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -33,14 +33,19 @@ jobs:
         run: |
           docker build -t ghcr.io/your-user/your-bot:${{ github.sha }} .
 
+      - name: Free disk space
+        run: docker system prune -af
+
       - name: Run Trivy vulnerability scanner
+        env:
+          TRIVY_CACHE_DIR: /tmp/trivy-cache
         uses: aquasecurity/trivy-action@7b7aa264d83dc58691451798b4d117d53d21edfe
         with:
-          image-ref: 'ghcr.io/your-user/your-bot:${{ github.sha }}'
-          format: 'template'
+          image-ref: ghcr.io/your-user/your-bot:${{ github.sha }}
+          format: template
           template: '@/contrib/sarif.tpl'
-          output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH'
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@d6c5e1b140009be28958d3837ed3be3fb637d8c0 # v3


### PR DESCRIPTION
## Summary
- reclaim disk space before running Trivy
- configure Trivy to use a dedicated cache directory

## Testing
- `SKIP=pytest pre-commit run --files .github/workflows/trivy.yml`
- `pytest -q`
- `docker system prune -af` *(fails: Cannot connect to the Docker daemon)*
- `TRIVY_CACHE_DIR=/tmp/trivy-cache trivy fs --skip-policy-update .`


------
https://chatgpt.com/codex/tasks/task_e_688f9ef6f8c0832d978444aedc865803