### PR TITLE
Add cleanup for trade_manager in import order test

### DIFF
--- a/tests/test_import_order.py
+++ b/tests/test_import_order.py
@@ -34,3 +34,4 @@ def test_telegramlogger_injection_order():
     assert tm.TelegramLogger is StubTL
     sys.modules.pop('utils', None)
     sys.modules.pop('bot.utils', None)
+    sys.modules.pop("trade_manager", None)


### PR DESCRIPTION
## Summary
- Remove `trade_manager` from `sys.modules` after import order test to restore module state

## Testing
- `pytest tests/test_import_order.py::test_telegramlogger_injection_order -q`


------
https://chatgpt.com/codex/tasks/task_e_688fa15cdd5c832d81a786636cd1b3ba