### PR TITLE
chore: configure semgrep action

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: returntocorp/semgrep-action@fcd5ab7459e8d91cb1777481980d1b18b4fc6735
         with:
           publishToken: ${{ secrets.SEMGREP_APP_TOKEN }}
-          publishDeployment: ${{ secrets.SEMGREP_DEPLOYMENT_ID }}
+          config: "p/ci"
           generateSarif: "1"
 
       # Upload SARIF file generated in previous step


### PR DESCRIPTION
## Summary
- use p/ci ruleset for Semgrep scans
- remove deprecated `publishDeployment` input

## Testing
- `pre-commit run --files .github/workflows/semgrep.yml` *(fails: no tests ran in pytest hook)*
- `pytest tests/test_backtest_loop.py::test_backtest_loop_warns -q`


------
https://chatgpt.com/codex/tasks/task_e_688fc0636324832d95f1c66a15169ea0