### PR TITLE
Allow closing positions by order ID

### DIFF
--- a/tests/test_service_scripts.py
+++ b/tests/test_service_scripts.py
@@ -293,6 +293,7 @@ def test_trade_manager_service_endpoints():
             timeout=5,
         )
         assert resp.status_code == 200
+        order_id = resp.json()['order_id']
         resp = requests.get(f'http://127.0.0.1:{port}/positions', timeout=5)
         assert resp.status_code == 200
         data = resp.json()['positions']
@@ -300,7 +301,7 @@ def test_trade_manager_service_endpoints():
         assert data[0]['trailing_stop'] == 1
         resp = requests.post(
             f'http://127.0.0.1:{port}/close_position',
-            json={'symbol': 'BTCUSDT', 'side': 'buy', 'amount': 1},
+            json={'order_id': order_id, 'side': 'sell'},
             timeout=5,
         )
         assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- Extend `/close_position` to accept `order_id` and optional `close_amount`
- Look up and update positions by `order_id` rather than by symbol/side
- Require clients to specify the closing side instead of automatic flipping
- Update service tests for the new API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fc464f628832d8c8c7bf39e05b07e