### PR TITLE
chore: fail integration job on error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
     name: Integration tests
     runs-on: ubuntu-latest
     needs: unit
-    continue-on-error: true
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5


### PR DESCRIPTION
## Summary
- fail CI integration job on test errors instead of allowing failures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688fce911ee4832da43f6cdb076ab893