### PR TITLE
chore: remove redundant flake8 install

### DIFF
--- a/scripts/install-test-deps.sh
+++ b/scripts/install-test-deps.sh
@@ -14,4 +14,3 @@ elif [ -n "$1" ]; then
 fi
 
 python -m pip install -r "$REPO_ROOT/$REQ_FILE"
-python -m pip install flake8


### PR DESCRIPTION
## Summary
- drop standalone flake8 install from test dependency script

## Testing
- `sh -n scripts/install-test-deps.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fd4d94228832d96d876c720d8c1f0