### PR TITLE
Include price in prediction request and test logging

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -121,7 +121,7 @@ def get_prediction(symbol: str, price: float, env: dict) -> dict | None:
     try:
         resp = requests.post(
             f"{env['model_builder_url']}/predict",
-            json={"symbol": symbol, "features": [price]},
+            json={"symbol": symbol, "price": price, "features": [price]},
             timeout=5,
         )
         if resp.status_code != 200:


### PR DESCRIPTION
## Summary
- send current price as a top-level field in `get_prediction`
- ensure the trading bot logs predictions when the model service responds

## Testing
- `pre-commit run --files trading_bot.py tests/test_trading_bot.py`
- `pytest tests/test_trading_bot.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688fd52c89cc832d8c436a460abc454c