### PR TITLE
Add integration marker for pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    integration: marks tests that require external services or slower integration steps
+


### PR DESCRIPTION
## Summary
- add pytest.ini with integration test marker

## Testing
- `pre-commit run --files pytest.ini` *(fails: not found: /workspace/bot/pytest.ini)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688fd88cc9a8832dbd5ad7f6f5bea23f