### PR TITLE
Unify prediction request schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,10 @@ python services/trade_manager_service.py
 `data_handler_service.py` fetches prices from Bybit using `ccxt` and exposes
 `/price/<symbol>` and `/ohlcv/<symbol>`.
 `model_builder_service.py` trains a small logistic regression when you POST
-features to `/train`.  The service supports multi-class problems via
+features to `/train`.  Predictions are requested via `/predict` using
+`{"features": [...]}` where the first element usually represents the price.
+For backward compatibility a single `price` value is also accepted.  The
+service supports multi-class problems via
 `LogisticRegression(multi_class="auto")` and returns an error if the labels
 contain only a single class.
 `trade_manager_service.py` opens and closes positions on Bybit via

--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -54,7 +54,11 @@ def train() -> tuple:
 @app.route('/predict', methods=['POST'])
 def predict() -> tuple:
     data = request.get_json(force=True)
-    features = np.array(data.get('features', []), dtype=np.float32)
+    features = data.get('features')
+    if features is None:
+        price_val = float(data.get('price', 0.0))
+        features = [price_val]
+    features = np.array(features, dtype=np.float32)
     if features.ndim == 0:
         features = np.array([[features]], dtype=np.float32)
     elif features.ndim == 1:

--- a/tests/test_integration_services.py
+++ b/tests/test_integration_services.py
@@ -40,6 +40,7 @@ mb_app = Flask('model_builder')
 @mb_app.route('/predict', methods=['POST'])
 def predict():
     data = request.get_json(force=True)
+    assert 'features' in data
     features = data.get('features') or []
     price = float(features[0]) if isinstance(features, list) and features else 0.0
     signal = 'buy' if price > 0 else None

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -121,7 +121,7 @@ def get_prediction(symbol: str, price: float, env: dict) -> dict | None:
     try:
         resp = requests.post(
             f"{env['model_builder_url']}/predict",
-            json={"symbol": symbol, "price": price, "features": [price]},
+            json={"symbol": symbol, "features": [price]},
             timeout=5,
         )
         if resp.status_code != 200:


### PR DESCRIPTION
## Summary
- Expand `/predict` handlers to accept `features` arrays with optional `price` fallback
- Call `/predict` using only the `features` schema
- Document unified prediction API and assert it in integration tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689063258afc832d80fdab829da17704