### PR TITLE
feat: support feature vectors

### DIFF
--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -42,7 +42,9 @@ def train() -> tuple:
     labels = np.array(data.get('labels', []), dtype=np.float32)
     if features.ndim == 1:
         features = features.reshape(-1, 1)
-    if len(features) == 0 or len(features) != len(labels):
+    else:
+        features = features.reshape(len(features), -1)
+    if features.size == 0 or len(features) != len(labels):
         return jsonify({'error': 'invalid training data'}), 400
     # Ensure training labels contain at least two classes
     if len(np.unique(labels)) < 2:
@@ -67,6 +69,8 @@ def predict() -> tuple:
     if features.ndim == 0:
         features = np.array([[features]], dtype=np.float32)
     elif features.ndim == 1:
+        features = features.reshape(1, -1)
+    else:
         features = features.reshape(1, -1)
     if _model is None:
         price = float(features[0, 0]) if features.size else 0.0

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -3,6 +3,7 @@
 import os
 import time
 from collections import deque
+import statistics
 
 import httpx
 import requests
@@ -144,7 +145,7 @@ def build_feature_vector(price: float) -> list[float]:
         volume = _PRICE_HISTORY[-1] - _PRICE_HISTORY[-2]
     else:
         volume = 0.0
-    sma = sum(_PRICE_HISTORY) / len(_PRICE_HISTORY)
+    sma = statistics.fmean(_PRICE_HISTORY)
     return [price, volume, sma]
 
 


### PR DESCRIPTION
## Summary
- build and send a basic [price, volume, sma] feature vector from trading bot
- update model builder service to reshape feature arrays and validate labels
- allow training utilities to consume multi-feature inputs

## Testing
- `pre-commit run flake8 --files trading_bot.py services/model_builder_service.py model_builder.py`
- `pytest tests/test_service_scripts.py::test_model_builder_service_train_predict -q`

------
https://chatgpt.com/codex/tasks/task_e_6890704ff1fc832d80c7e8020e3ddafc