### PR TITLE
test: improve service process handling

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,4 +1,9 @@
 import time
+import random
+import socket
+import multiprocessing
+from contextlib import contextmanager
+
 import requests
 
 
@@ -14,22 +19,66 @@ def wait_for_service(
 
     The function retries requests with exponential backoff. ``initial_delay`` sets
     the first sleep interval, which is multiplied by ``backoff`` after each
-    failed attempt up to ``max_delay``. Raises ``AssertionError`` if the service
+    failed attempt up to ``max_delay``. Raises ``RuntimeError`` if the service
     does not become ready within ``timeout`` seconds.
     """
     deadline = time.time() + timeout
     delay = initial_delay
+    last_exc: Exception | None = None
     while True:
         try:
             resp = requests.get(url, timeout=0.2)
             if resp.status_code == 200:
                 return resp
-        except Exception:
-            pass
+        except Exception as exc:  # pragma: no cover
+            last_exc = exc
         if time.time() >= deadline:
             break
         time.sleep(delay)
         delay = min(delay * backoff, max_delay)
-    raise AssertionError(
+    raise RuntimeError(
         f"Service at {url} did not become ready within {timeout} seconds"
-    )
+    ) from last_exc
+
+
+def get_free_port(retries: int = 10, low: int = 20000, high: int = 50000) -> int:
+    """Return an available port on localhost.
+
+    Ports are chosen randomly from the range ``low``-``high``. The function
+    retries to mitigate bind conflicts when tests run in parallel.
+    """
+    for _ in range(retries):
+        port = random.randint(low, high)
+        with socket.socket() as s:
+            try:
+                s.bind(("127.0.0.1", port))
+            except OSError:
+                continue
+            return port
+    raise RuntimeError("Could not allocate free port")
+
+
+ctx = multiprocessing.get_context("spawn")
+
+
+@contextmanager
+def service_process(
+    proc: multiprocessing.Process,
+    *,
+    url: str,
+    start_timeout: float = 5.0,
+    join_timeout: float = 0.2,
+):
+    """Start a service ``proc`` and ensure cleanup.
+
+    ``wait_for_service`` verifies availability of ``url`` within ``start_timeout``.
+    On exit, the process is terminated and joined with ``join_timeout`` to prevent
+    hanging tests.
+    """
+    proc.start()
+    try:
+        resp = wait_for_service(url, timeout=start_timeout)
+        yield resp
+    finally:
+        proc.terminate()
+        proc.join(join_timeout)


### PR DESCRIPTION
## Summary
- add `service_process` context manager with startup timeout and cleanup
- refine `wait_for_service` error handling and add randomized `get_free_port`
- refactor tests to use new helpers and reduce port conflicts

## Testing
- `pytest tests/test_service_scripts.py::test_data_handler_service_price -q`
- `pytest tests/test_integration_services.py::test_services_communicate -q`
- `pytest tests/test_service_scripts.py::test_trade_manager_service_endpoints -q`


------
https://chatgpt.com/codex/tasks/task_e_6890aacb5b78832d86d98b63338006ad