### PR TITLE
Refine service error handling

### DIFF
--- a/services/data_handler_service.py
+++ b/services/data_handler_service.py
@@ -33,13 +33,17 @@ def price(symbol: str):
     except CCXT_BASE_ERROR as exc:
         logging.exception("Exchange error fetching price for '%s': %s", symbol, exc)
         return jsonify({'error': 'exchange error fetching price'}), 502
-    except Exception as exc:  # pragma: no cover - unexpected
-        logging.exception("Unexpected error fetching price for '%s': %s", symbol, exc)
-        return jsonify({'error': 'Failed to fetch price.'}), 503
 
 @app.route('/ping')
 def ping():
     return jsonify({'status': 'ok'})
+
+
+@app.errorhandler(Exception)
+def handle_unexpected_error(exc: Exception) -> tuple:
+    """Log unexpected errors and return a 500 response."""
+    logging.exception("Unhandled error: %s", exc)
+    return jsonify({'error': 'internal server error'}), 500
 
 if __name__ == '__main__':
     port = int(os.environ.get('PORT', '8000'))

--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -148,9 +148,6 @@ def open_position() -> tuple:
     except CCXT_BASE_ERROR as exc:
         app.logger.exception('exchange error creating order: %s', exc)
         return jsonify({'error': 'exchange error creating order'}), 502
-    except Exception as exc:  # pragma: no cover - unexpected
-        app.logger.exception('unexpected error creating order: %s', exc)
-        return jsonify({'error': 'An internal error has occurred.'}), 500
 
 
 @app.route('/close_position', methods=['POST'])
@@ -202,9 +199,6 @@ def close_position() -> tuple:
     except CCXT_BASE_ERROR as exc:
         app.logger.exception('exchange error closing position: %s', exc)
         return jsonify({'error': 'exchange error closing position'}), 502
-    except Exception as exc:  # pragma: no cover - unexpected
-        app.logger.exception('unexpected error closing position: %s', exc)
-        return jsonify({'error': 'An internal error has occurred.'}), 500
 
 
 @app.route('/positions')
@@ -221,6 +215,13 @@ def ping():
 def ready():
     """Health check endpoint used by docker-compose."""
     return jsonify({'status': 'ok'})
+
+
+@app.errorhandler(Exception)
+def handle_unexpected_error(exc: Exception) -> tuple:
+    """Log unexpected errors and return a 500 response."""
+    app.logger.exception('unhandled error: %s', exc)
+    return jsonify({'error': 'internal server error'}), 500
 
 
 if __name__ == '__main__':

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -26,7 +26,7 @@ def send_telegram_alert(message: str) -> None:
     url = f"https://api.telegram.org/bot{token}/sendMessage"
     try:
         requests.post(url, data={"chat_id": chat_id, "text": message}, timeout=5)
-    except Exception as exc:  # pragma: no cover - network errors
+    except requests.RequestException as exc:  # pragma: no cover - network errors
         logger.error("Failed to send Telegram alert: %s", exc)
 
 # Threshold for slow trade confirmations


### PR DESCRIPTION
## Summary
- streamline Bybit price service error handling with ccxt-specific exceptions and global fallback
- improve trade manager responses by removing broad catch-all blocks and logging unexpected errors
- tighten Telegram alert sending to catch only HTTP request failures

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890af5a1eec832db85f03c405b9e323