### PR TITLE
Handle configuration load errors explicitly

### DIFF
--- a/config.py
+++ b/config.py
@@ -6,11 +6,15 @@ This module defines the :class:`BotConfig` dataclass along with helpers to
 load configuration values from ``config.json`` and environment variables.
 """
 
+import ast
 import json
+import logging
 import os
 from dataclasses import dataclass, field, fields, asdict
 from typing import Any, Dict, List, get_type_hints
-import ast
+
+
+logger = logging.getLogger(__name__)
 
 # Load defaults from config.json
 CONFIG_PATH = os.getenv(
@@ -19,7 +23,8 @@ CONFIG_PATH = os.getenv(
 try:
     with open(CONFIG_PATH, "r") as f:
         DEFAULTS = json.load(f)
-except Exception:
+except (OSError, json.JSONDecodeError) as exc:
+    logger.warning("Failed to load %s: %s", CONFIG_PATH, exc)
     DEFAULTS = {}
 
 


### PR DESCRIPTION
## Summary
- log when config JSON fails to load
- catch specific OSError/JSONDecodeError instead of blanket Exception

## Testing
- `pre-commit run --files config.py tests/test_utils.py`
- `pytest tests/test_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6890ba3c08ec832db611a5a7080cc3b1