### PR TITLE
Add locking for concurrent position access

### DIFF
--- a/simulation.py
+++ b/simulation.py
@@ -43,10 +43,13 @@ class HistoricalSimulator:
             self.history[symbol] = df
 
     async def _manage_positions_once(self) -> None:
-        idx_names = getattr(self.trade_manager.positions.index, "names", [])
-        if "symbol" not in idx_names:
-            return
-        symbols = self.trade_manager.positions.index.get_level_values("symbol").unique()
+        async with self.trade_manager.position_lock:
+            idx_names = getattr(self.trade_manager.positions.index, "names", [])
+            if "symbol" not in idx_names:
+                return
+            symbols = self.trade_manager.positions.index.get_level_values(
+                "symbol"
+            ).unique()
         for symbol in symbols:
             ohlcv = self.data_handler.ohlcv
             if "symbol" in ohlcv.index.names and symbol in ohlcv.index.get_level_values("symbol"):


### PR DESCRIPTION
## Summary
- guard manage_positions and other methods with position lock
- snapshot open positions when gathering signals and processing symbols
- protect simulation position management with trade_manager lock

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68910a6fa014832d84976d44485c9ea1