### PR TITLE
Mount config file in service containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,11 @@ services:
       timeout: 2s
       retries: 12
       start_period: 5s
+    volumes:
+      - ./logs:/app/logs
+      - ./models:/app/models
+      - ./cache:/app/cache
+      - ./config.json:/app/config.json
     shm_size: '8gb'
     networks:
       - trading_bot_default
@@ -42,6 +47,11 @@ services:
       timeout: 2s
       retries: 12
       start_period: 5s
+    volumes:
+      - ./logs:/app/logs
+      - ./models:/app/models
+      - ./cache:/app/cache
+      - ./config.json:/app/config.json
     shm_size: '8gb'
     networks:
       - trading_bot_default


### PR DESCRIPTION
## Summary
- mount config, logs, models and cache volumes in data_handler and model_builder services

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68911d0ee20c832dbcb3594a4b4684e9