### PR TITLE
Load environment before config

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -13,6 +13,7 @@ from tenacity import retry, stop_after_attempt, wait_exponential
 from bot.config import BotConfig
 from bot.utils import logger
 
+load_dotenv()
 
 CFG = BotConfig()
 
@@ -389,8 +390,6 @@ def run_once() -> None:
 
 def main():
     """Run the trading bot until interrupted."""
-    # Load environment variables from a .env file when running as a script
-    load_dotenv()
     try:
         check_services()
         while True:


### PR DESCRIPTION
## Summary
- initialize environment variables from `.env` immediately after imports
- instantiate `BotConfig` after loading environment
- drop redundant `load_dotenv` in `main`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68911d28f814832da9bdd890c03f4e47