### PR TITLE
Use temporary cache directories

### DIFF
--- a/scripts/measure_rate.py
+++ b/scripts/measure_rate.py
@@ -5,6 +5,7 @@ import os
 import sys
 from contextlib import suppress
 import pandas as pd
+import tempfile
 
 if __package__ is None or __package__ == "":
     sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
@@ -16,13 +17,14 @@ class DummyExchange:
     pass
 
 async def measure(n=1000, seconds=1.0):
-    cfg = BotConfig(cache_dir='/tmp')
-    dh = DataHandler(cfg, None, None, exchange=DummyExchange())
-    ts = int(pd.Timestamp.now(tz='UTC').timestamp()*1000)
-    msg = json.dumps({
-        'topic': 'kline.1.BTCUSDT',
-        'data': [{
-            'start': ts,
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cfg = BotConfig(cache_dir=tmpdir)
+        dh = DataHandler(cfg, None, None, exchange=DummyExchange())
+        ts = int(pd.Timestamp.now(tz='UTC').timestamp()*1000)
+        msg = json.dumps({
+            'topic': 'kline.1.BTCUSDT',
+            'data': [{
+                'start': ts,
             'open': 1,
             'high': 1,
             'low': 1,
@@ -30,15 +32,15 @@ async def measure(n=1000, seconds=1.0):
             'volume': 1
         }]
     })
-    for _ in range(n):
-        await dh.ws_queue.put((1, (['BTCUSDT'], msg, 'primary')))
-    task = asyncio.create_task(dh._process_ws_queue())
-    await asyncio.sleep(seconds)
-    task.cancel()
-    with suppress(asyncio.CancelledError):
-        await task
-    rate = len(dh.process_rate_timestamps) / dh.process_rate_window
-    print('rate', rate)
+        for _ in range(n):
+            await dh.ws_queue.put((1, (['BTCUSDT'], msg, 'primary')))
+        task = asyncio.create_task(dh._process_ws_queue())
+        await asyncio.sleep(seconds)
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+        rate = len(dh.process_rate_timestamps) / dh.process_rate_window
+        print('rate', rate)
 
 if __name__ == '__main__':
     asyncio.run(measure())

--- a/tests/test_backtest_loop.py
+++ b/tests/test_backtest_loop.py
@@ -25,9 +25,9 @@ class DummyTM:
     pass
 
 @pytest.mark.asyncio
-async def test_backtest_loop_warns(monkeypatch, caplog):
+async def test_backtest_loop_warns(monkeypatch, caplog, tmp_path):
     monkeypatch.setenv("TEST_MODE", "1")
-    cfg = BotConfig(cache_dir="/tmp", backtest_interval=0, min_sharpe_ratio=0.5)
+    cfg = BotConfig(cache_dir=str(tmp_path), backtest_interval=0, min_sharpe_ratio=0.5)
     dh = DummyDH()
     gym_mod = types.ModuleType("gymnasium")
     gym_mod.Env = object

--- a/tests/test_data_handler_polars.py
+++ b/tests/test_data_handler_polars.py
@@ -74,8 +74,8 @@ async def test_synchronize_and_update_polars(tmp_path):
     assert 'ema30' in dh.indicators[symbol].df.columns
 
 @pytest.mark.asyncio
-async def test_cleanup_old_data_polars(monkeypatch):
-    cfg = BotConfig(cache_dir='/tmp', data_cleanup_interval=0, forget_window=1, use_polars=True)
+async def test_cleanup_old_data_polars(monkeypatch, tmp_path):
+    cfg = BotConfig(cache_dir=str(tmp_path), data_cleanup_interval=0, forget_window=1, use_polars=True)
     dh = DataHandler(cfg, None, None, exchange=DummyExchange({'BTCUSDT': 1.0}))
     now = pd.Timestamp.now(tz='UTC')
     old_ts = now - pd.Timedelta(seconds=5)

--- a/tests/test_model_builder_cache.py
+++ b/tests/test_model_builder_cache.py
@@ -67,11 +67,11 @@ def make_df(n=5):
     return df
 
 @pytest.mark.asyncio
-async def test_precompute_features_caches(monkeypatch):
+async def test_precompute_features_caches(monkeypatch, tmp_path):
     from bot.model_builder import ModelBuilder
     df = make_df()
     dh = DummyDH(df)
-    cfg = BotConfig(cache_dir="/tmp", lstm_timesteps=2, min_data_length=len(df), nn_framework="tensorflow")
+    cfg = BotConfig(cache_dir=str(tmp_path), lstm_timesteps=2, min_data_length=len(df), nn_framework="tensorflow")
     mb = ModelBuilder(cfg, dh, DummyTM())
     ind = DummyIndicators(len(df))
     dh.indicators["BTCUSDT"] = ind

--- a/tests/test_trade_manager_loops.py
+++ b/tests/test_trade_manager_loops.py
@@ -6,6 +6,7 @@ import types
 import os
 import pandas as pd
 import pytest
+import tempfile
 from bot.config import BotConfig
 
 # Stub heavy dependencies before importing the trade manager
@@ -103,7 +104,7 @@ class DummyModelBuilder:
 
 def make_config():
     return BotConfig(
-        cache_dir='/tmp',
+        cache_dir=tempfile.mkdtemp(),
         check_interval=1,
         performance_window=1,
         order_retry_delay=0,


### PR DESCRIPTION
## Summary
- replace hardcoded `/tmp` cache paths with per-run temporary directories
- update tests to use pytest `tmp_path` or `tempfile` for cache dirs

## Testing
- `pre-commit run --files scripts/measure_rate.py tests/test_backtest_loop.py tests/test_data_handler.py tests/test_data_handler_polars.py tests/test_model_builder.py tests/test_model_builder_cache.py tests/test_simulation.py tests/test_trade_manager.py tests/test_trade_manager_loops.py`
- `pytest tests/test_simulation.py tests/test_data_handler.py tests/test_backtest_loop.py tests/test_model_builder.py tests/test_model_builder_cache.py tests/test_trade_manager.py tests/test_trade_manager_loops.py tests/test_data_handler_polars.py`


------
https://chatgpt.com/codex/tasks/task_e_68912801ae34832d91eeadbcb9c52c65