### PR TITLE
Abort startup if no liquid USDT pairs

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -1070,6 +1070,8 @@ class DataHandler:
         try:
             markets = await safe_api_call(self.exchange, "load_markets")
             self.usdt_pairs = await self.select_liquid_pairs(markets)
+            if not self.usdt_pairs:
+                raise RuntimeError("No liquid USDT pairs found")
             logger.info(
                 "Найдено %s USDT-пар с высокой ликвидностью",
                 len(self.usdt_pairs),

--- a/scripts/run_simulation.py
+++ b/scripts/run_simulation.py
@@ -17,6 +17,7 @@ from bot.data_handler import DataHandler
 from bot.model_builder import ModelBuilder
 from bot.trade_manager import TradeManager
 from bot.simulation import HistoricalSimulator
+from bot.utils import logger
 
 
 async def main() -> None:
@@ -31,7 +32,11 @@ async def main() -> None:
 
     cfg = load_config("config.json")
     dh = DataHandler(cfg, None, None)
-    await dh.load_initial()
+    try:
+        await dh.load_initial()
+    except RuntimeError as exc:
+        logger.error("Failed to load initial data: %s", exc)
+        return
     mb = ModelBuilder(cfg, dh, None)
     tm = TradeManager(cfg, dh, mb, None, None)
     sim = HistoricalSimulator(dh, tm)

--- a/tests/test_data_handler.py
+++ b/tests/test_data_handler.py
@@ -410,6 +410,24 @@ async def test_load_initial_no_attribute_error(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_load_initial_raises_when_no_pairs(monkeypatch, tmp_path):
+    class DummyExchange:
+        async def load_markets(self):
+            return {}
+
+    cfg = BotConfig(cache_dir=str(tmp_path))
+    dh = DataHandler(cfg, None, None, exchange=DummyExchange())
+
+    async def fake_select(markets):
+        return []
+
+    monkeypatch.setattr(dh, 'select_liquid_pairs', fake_select)
+
+    with pytest.raises(RuntimeError, match="No liquid USDT pairs"):
+        await dh.load_initial()
+
+
+@pytest.mark.asyncio
 async def test_fetch_ohlcv_single_empty_not_cached(tmp_path, monkeypatch):
     monkeypatch.delenv("TEST_MODE", raising=False)
     class Ex:

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -1620,7 +1620,7 @@ POSITIONS = []
 trade_manager: TradeManager | None = None
 
 
-async def create_trade_manager() -> TradeManager:
+async def create_trade_manager() -> TradeManager | None:
     """Instantiate the TradeManager using config.json."""
     global trade_manager
     if trade_manager is None:
@@ -1674,6 +1674,10 @@ async def create_trade_manager() -> TradeManager:
             asyncio.create_task(mb.backtest_loop())
             await dh.load_initial()
             asyncio.create_task(dh.subscribe_to_klines(dh.usdt_pairs))
+        except RuntimeError as exc:
+            logger.error("Initial data load failed: %s", exc)
+            await dh.stop()
+            return None
         except Exception as exc:
             logger.exception("Failed to create ModelBuilder: %s", exc)
             raise


### PR DESCRIPTION
## Summary
- raise `RuntimeError` when no liquid USDT pairs are found
- abort TradeManager and simulation startup if initial data load fails
- add regression test for empty USDT pair list

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689126fe3f68832db7378769863e0612