### PR TITLE
ci: fail bandit on findings

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -34,15 +34,15 @@ jobs:
         uses: shundor/python-bandit-scan@ab1d87dfccc5a0ffab88be3aaac6ffe35c10d6cd
         with: # optional arguments
           # exit with 0, even with results found
-          exit_zero: true # optional, default is DEFAULT
+          exit_zero: false # fail when issues are found
           # Github token of the repository (automatically created by Github)
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information.
           # File or directory to run bandit on
           # path: # optional, default is .
           # Report only issues of a given severity level or higher. Can be LOW, MEDIUM or HIGH. Default is UNDEFINED (everything)
-          # level: # optional, default is UNDEFINED
+          level: MEDIUM
           # Report only issues of a given confidence level or higher. Can be LOW, MEDIUM or HIGH. Default is UNDEFINED (everything)
-          # confidence: # optional, default is UNDEFINED
+          confidence: MEDIUM
           # comma-separated list of paths (glob patterns supported) to exclude from scan (note that these are in addition to the excluded paths provided in the config file) (default: .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg)
           # excluded_paths: # optional, default is DEFAULT
           # comma-separated list of test IDs to skip


### PR DESCRIPTION
## Summary
- configure Bandit workflow to fail when issues are detected
- enforce medium severity and confidence thresholds for scanning

## Testing
- `SKIP=pytest pre-commit run --files .github/workflows/bandit.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689126f6a70c832da303781b2755dded