### PR TITLE
chore: configure pytest pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,5 @@ repos:
         name: pytest
         entry: pytest
         language: system
+        pass_filenames: false
+        stages: [commit]


### PR DESCRIPTION
## Summary
- configure local pytest hook to ignore filenames and run during commits

## Testing
- `pre-commit autoupdate`
- `pre-commit run --files .pre-commit-config.yaml`


------
https://chatgpt.com/codex/tasks/task_e_6891c603df1c832da09bdedb33ed0505