### PR TITLE
feat: make tensorflow check optional

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,9 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 # Добавляем PYTHONPATH, чтобы модуль bot был доступен
 ENV PYTHONPATH=/app
 
+# Optionally enable TensorFlow checks during build
+ARG ENABLE_TF=0
+
 # Проверяем версии библиотек и доступность CUDA с отладкой
 RUN echo "Checking library versions and CUDA availability..." && \
     /app/venv/bin/python3.12 -c "import ccxt; print('CCXT Version:', ccxt.__version__)" || echo "CCXT check failed" && \
@@ -79,7 +82,7 @@ RUN echo "Checking library versions and CUDA availability..." && \
     /app/venv/bin/python3.12 -c "import optuna; print('Optuna Version:', optuna.__version__)" || echo "Optuna check failed" && \
     /app/venv/bin/python3.12 -c "import shap; print('SHAP Version:', shap.__version__)" || echo "SHAP check failed" && \
     /app/venv/bin/python3.12 -c "import numba; print('Numba Version:', numba.__version__)" || echo "Numba check failed" && \
-    /app/venv/bin/python3.12 -c "import tensorflow as tf; print('TF Version:', tf.__version__)" || echo "TensorFlow check failed" && \
+    if [ "$ENABLE_TF" = "1" ]; then /app/venv/bin/python3.12 -c "import tensorflow as tf; print('TF Version:', tf.__version__)" || echo "TensorFlow check failed"; else echo "TensorFlow check skipped"; fi && \
     /app/venv/bin/python3.12 -c "import stable_baselines3 as sb3; print('SB3 Version:', sb3.__version__)" || echo "SB3 check failed" && \
     /app/venv/bin/python3.12 -c "import pytorch_lightning as pl; print('Lightning Version:', pl.__version__)" || echo "Lightning check failed" && \
     /app/venv/bin/python3.12 -c "import mlflow; print('MLflow Version:', mlflow.__version__)" || echo "MLflow check failed"

--- a/README.md
+++ b/README.md
@@ -209,6 +209,16 @@ GPU warnings. Set the environment variable to `2` or `3` **before importing
 TensorFlow** if you want to suppress extra CUDA messages entirely. Adjust or
 remove this variable if you need more detailed logs.
 
+The Docker image also skips importing TensorFlow during its build-time library
+check unless explicitly enabled. Set `ENABLE_TF=1` as a build argument when
+you require TensorFlow features:
+
+```bash
+docker build --build-arg ENABLE_TF=1 -t trading-bot .
+```
+
+Omit the argument to skip the import and avoid the associated warnings.
+
 When both TensorFlow and PyTorch start in the same container you might see
 messages like `Unable to register cuDNN factory` or `computation placer already
 registered`. These lines appear while each framework loads CUDA plugins and


### PR DESCRIPTION
## Summary
- make TensorFlow version check optional with ENABLE_TF build arg
- document how to enable TensorFlow check during build

## Testing
- `pytest`
- `docker build --build-arg ENABLE_TF=0 -t bot-test .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_6891c606cda8832d8268c0add7c49557