### PR TITLE
Add fixed stop loss price after breakeven

### DIFF
--- a/tests/test_trade_manager_loops.py
+++ b/tests/test_trade_manager_loops.py
@@ -153,6 +153,7 @@ async def test_manage_positions_recovery(monkeypatch):
         'entry_price': [100],
         'tp_multiplier': [2],
         'sl_multiplier': [1],
+        'stop_loss_price': [99],
         'highest_price': [100],
         'lowest_price': [0],
         'breakeven_triggered': [False],


### PR DESCRIPTION
## Summary
- Track an explicit `stop_loss_price` for each position instead of zeroing `sl_multiplier` when moving to breakeven
- Use stored stop price in stop-loss/TP checks once breakeven is triggered
- Test that breakeven sets stop loss to entry and that fixed price is honored

## Testing
- `pre-commit run --files trade_manager.py tests/test_trade_manager.py tests/test_trade_manager_loops.py`
- `pytest tests/test_trade_manager.py tests/test_trade_manager_loops.py`


------
https://chatgpt.com/codex/tasks/task_e_6891d0057cec832dbbadcc318fa93c73