### PR TITLE
Use non-executable formats for TradeManager state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## Unreleased
+- Store TradeManager state in non-executable formats: positions saved as Parquet and returns as JSON.

--- a/README.md
+++ b/README.md
@@ -689,6 +689,14 @@ Linting configuration is stored in `.flake8`. Run the checker manually:
 python -m flake8
 ```
 
+## State persistence
+
+`TradeManager` now saves its open positions as a Parquet file and per-symbol
+returns as JSON inside the directory specified by `cache_dir`. The files are
+named `trade_manager_state.parquet` and `trade_manager_returns.json`
+respectively. These non-executable formats replace the previous pickle-based
+storage.
+
 ## Historical simulator
 
 Replay past market data using the built in trading logic:


### PR DESCRIPTION
## Summary
- switch TradeManager's saved state to Parquet and JSON instead of pickle
- document new state formats in README and CHANGELOG

## Testing
- `bandit -r trade_manager.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891d534b360832d8d62d71c63fb3023