### PR TITLE
Pin zlib in Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,14 @@ ENV TZ=Etc/UTC
 
 # Установка необходимых пакетов для сборки
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    zlib1g=1:1.3* \
+    zlib1g-dev=1:1.3* \
     tzdata \
     software-properties-common \
     && add-apt-repository -y ppa:deadsnakes/ppa \
     && apt-get update && apt-get install -y --no-install-recommends \
+    zlib1g=1:1.3* \
+    zlib1g-dev=1:1.3* \
     python3.12 \
     python3.12-dev \
     python3.12-venv \
@@ -50,10 +54,14 @@ WORKDIR /app
 
 # Установка минимальных пакетов для выполнения
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    zlib1g=1:1.3* \
+    zlib1g-dev=1:1.3* \
     tzdata \
     software-properties-common \
     && add-apt-repository -y ppa:deadsnakes/ppa \
     && apt-get update && apt-get install -y --no-install-recommends \
+    zlib1g=1:1.3* \
+    zlib1g-dev=1:1.3* \
     curl \
     python3.12 \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,6 +1,11 @@
 # syntax=docker/dockerfile:1
 FROM python:3.12-slim
 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    zlib1g=1:1.3* \
+    zlib1g-dev=1:1.3* \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 # Install only linting tools

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,5 +1,10 @@
 FROM python:3.12-slim AS builder
 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    zlib1g=1:1.3* \
+    zlib1g-dev=1:1.3* \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY requirements-cpu.txt .
@@ -14,6 +19,8 @@ RUN python -m venv $VIRTUAL_ENV && \
 FROM python:3.12-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    zlib1g=1:1.3* \
+    zlib1g-dev=1:1.3* \
     curl \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && python --version


### PR DESCRIPTION
## Summary
- pin zlib1g and zlib1g-dev to 1.3 series in builder and runtime stages
- apply same zlib pin for CPU and CI Dockerfiles

## Testing
- `pytest`
- `docker build -f Dockerfile.ci -t bot-ci .` *(fails: Cannot connect to the Docker daemon)*


------
https://chatgpt.com/codex/tasks/task_e_6891d53c21c0832d86ba04a7ece21183