### PR TITLE
fix: unpin zlib packages in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,14 @@ ENV TZ=Etc/UTC
 
 # Установка необходимых пакетов для сборки
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    zlib1g=1:1.3* \
-    zlib1g-dev=1:1.3* \
+    zlib1g \
+    zlib1g-dev \
     tzdata \
     software-properties-common \
     && add-apt-repository -y ppa:deadsnakes/ppa \
     && apt-get update && apt-get install -y --no-install-recommends \
-    zlib1g=1:1.3* \
-    zlib1g-dev=1:1.3* \
+    zlib1g \
+    zlib1g-dev \
     python3.12 \
     python3.12-dev \
     python3.12-venv \
@@ -54,14 +54,14 @@ WORKDIR /app
 
 # Установка минимальных пакетов для выполнения
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    zlib1g=1:1.3* \
-    zlib1g-dev=1:1.3* \
+    zlib1g \
+    zlib1g-dev \
     tzdata \
     software-properties-common \
     && add-apt-repository -y ppa:deadsnakes/ppa \
     && apt-get update && apt-get install -y --no-install-recommends \
-    zlib1g=1:1.3* \
-    zlib1g-dev=1:1.3* \
+    zlib1g \
+    zlib1g-dev \
     curl \
     python3.12 \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -2,8 +2,8 @@
 FROM python:3.12-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    zlib1g=1:1.3* \
-    zlib1g-dev=1:1.3* \
+    zlib1g \
+    zlib1g-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,8 +1,8 @@
 FROM python:3.12-slim AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    zlib1g=1:1.3* \
-    zlib1g-dev=1:1.3* \
+    zlib1g \
+    zlib1g-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -19,8 +19,8 @@ RUN python -m venv $VIRTUAL_ENV && \
 FROM python:3.12-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    zlib1g=1:1.3* \
-    zlib1g-dev=1:1.3* \
+    zlib1g \
+    zlib1g-dev \
     curl \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && python --version


### PR DESCRIPTION
## Summary
- remove Debian Bookworm-incompatible version pins for zlib1g and zlib1g-dev in Dockerfile, Dockerfile.ci and Dockerfile.cpu

## Testing
- `pytest -q`
- Attempted `podman build -f Dockerfile.ci` (failed: operation not permitted)

------
https://chatgpt.com/codex/tasks/task_e_6891e0330224832d91e4f2dd498383be