### PR TITLE
build: patch zlib to 1.3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Этап сборки
 FROM nvidia/cuda:12.6.2-cudnn-devel-ubuntu22.04 AS builder
+ARG ZLIB_VERSION=1.3.1
 ENV OMP_NUM_THREADS=1
 ENV MKL_NUM_THREADS=1
 ENV DEBIAN_FRONTEND=noninteractive
@@ -7,15 +8,14 @@ ENV TZ=Etc/UTC
 
 # Установка необходимых пакетов для сборки и обновление linux-libc-dev
 RUN apt-get update && apt-get upgrade -y linux-libc-dev && apt-get install -y --no-install-recommends \
-    zlib1g \
-    zlib1g-dev \
     tzdata \
     software-properties-common \
     linux-libc-dev \
+    build-essential \
+    curl \
     && add-apt-repository -y ppa:deadsnakes/ppa \
     && apt-get update && apt-get upgrade -y linux-libc-dev && apt-get install -y --no-install-recommends \
-    zlib1g \
-    zlib1g-dev \
+    curl \
     python3.12 \
     python3.12-dev \
     python3.12-venv \
@@ -26,7 +26,12 @@ RUN apt-get update && apt-get upgrade -y linux-libc-dev && apt-get install -y --
     libblas-dev \
     liblapack-dev \
     linux-libc-dev \
+    && curl -L https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
+    && tar -xf zlib.tar.gz \
+    && cd zlib-${ZLIB_VERSION} && ./configure --prefix=/usr && make -j"$(nproc)" && make install && cd .. \
+    && rm -rf zlib.tar.gz zlib-${ZLIB_VERSION} \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && ldconfig \
     && python3.12 --version
 
 WORKDIR /app
@@ -47,6 +52,7 @@ RUN pip install --no-cache-dir pip==24.0 setuptools wheel && \
 
 # Этап выполнения
 FROM nvidia/cuda:12.6.2-cudnn-devel-ubuntu22.04
+ARG ZLIB_VERSION=1.3.1
 ENV OMP_NUM_THREADS=1
 ENV MKL_NUM_THREADS=1
 ENV DEBIAN_FRONTEND=noninteractive
@@ -56,19 +62,21 @@ WORKDIR /app
 
 # Установка минимальных пакетов для выполнения и обновление linux-libc-dev
 RUN apt-get update && apt-get upgrade -y linux-libc-dev && apt-get install -y --no-install-recommends \
-    zlib1g \
-    zlib1g-dev \
     tzdata \
     software-properties-common \
     linux-libc-dev \
+    curl \
     && add-apt-repository -y ppa:deadsnakes/ppa \
     && apt-get update && apt-get upgrade -y linux-libc-dev && apt-get install -y --no-install-recommends \
-    zlib1g \
-    zlib1g-dev \
     curl \
     python3.12 \
     linux-libc-dev \
+    && curl -L https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
+    && tar -xf zlib.tar.gz \
+    && cd zlib-${ZLIB_VERSION} && ./configure --prefix=/usr && make -j"$(nproc)" && make install && cd .. \
+    && rm -rf zlib.tar.gz zlib-${ZLIB_VERSION} \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && ldconfig \
     && python3.12 --version
 
 # Копируем виртуальное окружение из этапа сборки

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,11 +1,18 @@
 # syntax=docker/dockerfile:1
 FROM python:3.12.4-slim
+ARG ZLIB_VERSION=1.3.1
 
 RUN apt-get update && apt-get upgrade -y linux-libc-dev && apt-get install -y --no-install-recommends \
-    zlib1g \
-    zlib1g-dev \
     linux-libc-dev \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+    build-essential \
+    curl \
+    && curl -L https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
+    && tar -xf zlib.tar.gz \
+    && cd zlib-${ZLIB_VERSION} && ./configure --prefix=/usr && make -j"$(nproc)" && make install && cd .. \
+    && rm -rf zlib.tar.gz zlib-${ZLIB_VERSION} \
+    && apt-get purge -y --auto-remove build-essential curl \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && ldconfig
 
 WORKDIR /app
 

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,10 +1,16 @@
 FROM python:3.12.4-slim AS builder
+ARG ZLIB_VERSION=1.3.1
 
 RUN apt-get update && apt-get upgrade -y linux-libc-dev && apt-get install -y --no-install-recommends \
-    zlib1g \
-    zlib1g-dev \
     linux-libc-dev \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+    build-essential \
+    curl \
+    && curl -L https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
+    && tar -xf zlib.tar.gz \
+    && cd zlib-${ZLIB_VERSION} && ./configure --prefix=/usr && make -j"$(nproc)" && make install && cd .. \
+    && rm -rf zlib.tar.gz zlib-${ZLIB_VERSION} \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && ldconfig
 
 WORKDIR /app
 
@@ -18,13 +24,17 @@ RUN python -m venv $VIRTUAL_ENV && \
     find $VIRTUAL_ENV -type f -name '*.pyc' -delete
 
 FROM python:3.12.4-slim
+ARG ZLIB_VERSION=1.3.1
 
 RUN apt-get update && apt-get upgrade -y linux-libc-dev && apt-get install -y --no-install-recommends \
-    zlib1g \
-    zlib1g-dev \
     curl \
     linux-libc-dev \
+    && curl -L https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
+    && tar -xf zlib.tar.gz \
+    && cd zlib-${ZLIB_VERSION} && ./configure --prefix=/usr && make -j"$(nproc)" && make install && cd .. \
+    && rm -rf zlib.tar.gz zlib-${ZLIB_VERSION} \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && ldconfig \
     && python --version
 
 WORKDIR /app


### PR DESCRIPTION
## Summary
- compile zlib 1.3.1 from source in Docker builds to address MiniZip overflow

## Testing
- `pre-commit run --files Dockerfile Dockerfile.ci Dockerfile.cpu`
- `trivy fs --scanners vuln .`


------
https://chatgpt.com/codex/tasks/task_e_6891fb436ac8832db44bdebba0cb96b5