### PR TITLE
Remove numpy fallback

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -18,15 +18,7 @@ except Exception:  # noqa: W0703 - allow missing pandas
     pd.Index = list
     pd.MultiIndex = types.SimpleNamespace(from_arrays=lambda *a, **k: [])
 
-try:  # pragma: no cover - optional dependency
-    import numpy as np  # type: ignore
-except Exception:  # noqa: W0703 - allow missing numpy
-    np = types.ModuleType("numpy")
-    np.ndarray = list
-    np.array = lambda *a, **k: a[0]
-    np.random = types.SimpleNamespace(randn=lambda *a, **k: [0] * (a[0] if a else 0))
-    np.cumsum = lambda x: x
-    np.abs = abs
+import numpy as np  # type: ignore
 
 try:  # optional dependency
     import polars as pl  # type: ignore

--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -1,4 +1,4 @@
-numpy>=1.26.4
+numpy>=1.26.4  # core numeric library
 pandas>=2.2.2
 torch==2.7.1
 torchvision==0.22.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.26.4
+numpy>=1.26.4  # core numeric library
 pandas>=2.2.2
 torch==2.7.1
 torchvision==0.22.1

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -20,12 +20,7 @@ except Exception:  # noqa: W0703 - allow missing pandas
     pd.Series = list
     pd.MultiIndex = types.SimpleNamespace(from_arrays=lambda *a, **k: [])
 
-try:  # pragma: no cover - optional dependency
-    import numpy as np  # type: ignore
-except Exception:  # noqa: W0703 - allow missing numpy
-    np = types.ModuleType("numpy")
-    np.ndarray = list
-    np.array = lambda *a, **k: a[0]
+import numpy as np  # type: ignore
 
 if os.getenv("TEST_MODE") == "1":
     ray = types.ModuleType("ray")


### PR DESCRIPTION
## Summary
- drop numpy fallbacks from data handler and trade manager
- mark numpy as a required dependency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68921205002c832d9f6876112f3a7adc