### PR TITLE
feat: support configurable balance key

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -110,4 +110,5 @@ dataclass.  Default values are shown for reference.
 | transformer_weight | 0.5 | Ensemble weight for transformer model. |
 | ema_weight | 0.2 | Ensemble weight for EMA strategy. |
 | early_stopping_patience | 3 | Epochs with no improvement before early stop. |
+| balance_key | – | Balance key for equity; defaults to symbol quote currency. |
 

--- a/config.py
+++ b/config.py
@@ -11,7 +11,7 @@ import json
 import logging
 import os
 from dataclasses import dataclass, field, fields, asdict
-from typing import Any, Dict, List, get_type_hints
+from typing import Any, Dict, List, get_type_hints, Optional
 
 
 logger = logging.getLogger(__name__)
@@ -149,6 +149,7 @@ class BotConfig:
     transformer_weight: float = _get_default("transformer_weight", 0.5)
     ema_weight: float = _get_default("ema_weight", 0.2)
     early_stopping_patience: int = _get_default("early_stopping_patience", 3)
+    balance_key: Optional[str] = _get_default("balance_key", None)
 
     def __getitem__(self, key: str) -> Any:
         return getattr(self, key)

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -476,7 +476,11 @@ class TradeManager:
                 )
                 return 0.0
             account = await safe_api_call(self.exchange, "fetch_balance")
-            equity = float(account["total"].get("USDT", 0))
+            balance_key = self.config.get("balance_key")
+            if not balance_key:
+                sym = symbol.split(":", 1)[0]
+                balance_key = sym.split("/")[1] if "/" in sym else "USDT"
+            equity = float(account.get("total", {}).get(balance_key, 0))
             if equity <= 0:
                 logger.warning("Insufficient balance for %s", symbol)
                 await self.telegram_logger.send_telegram_message(


### PR DESCRIPTION
## Summary
- allow selecting balance currency via `balance_key` config or symbol quote
- document `balance_key` option in configuration reference

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68922dcc549c832db545477160ae9178