### PR TITLE
Verify trailing stop positions before processing

### DIFF
--- a/simulation.py
+++ b/simulation.py
@@ -59,9 +59,13 @@ class HistoricalSimulator:
             if df.empty:
                 continue
             price = df["close"].iloc[-1]
-            await self.trade_manager.check_trailing_stop(symbol, price)
-            await self.trade_manager.check_stop_loss_take_profit(symbol, price)
-            await self.trade_manager.check_exit_signal(symbol, price)
+            idx_names = getattr(self.trade_manager.positions.index, "names", [])
+            if "symbol" in idx_names and symbol in self.trade_manager.positions.index.get_level_values("symbol"):
+                await self.trade_manager.check_trailing_stop(symbol, price)
+            if "symbol" in idx_names and symbol in self.trade_manager.positions.index.get_level_values("symbol"):
+                await self.trade_manager.check_stop_loss_take_profit(symbol, price)
+            if "symbol" in idx_names and symbol in self.trade_manager.positions.index.get_level_values("symbol"):
+                await self.trade_manager.check_exit_signal(symbol, price)
 
     async def run(self, start_ts: pd.Timestamp, end_ts: pd.Timestamp, speed: float = 1.0) -> None:
         await self.load(start_ts, end_ts)


### PR DESCRIPTION
## Summary
- use debug-level logging for missing position or ATR data in `check_trailing_stop`
- verify a symbol is still in active positions before performing trailing-stop or exit checks

## Testing
- `pre-commit run --files trade_manager.py simulation.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689232bf5408832dbf6a93a225b8e7f3