### PR TITLE
Pin setuptools version in Dockerfiles and requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN python3.12 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # Устанавливаем зависимости
-RUN pip install --no-cache-dir pip==24.0 setuptools wheel && \
+RUN pip install --no-cache-dir pip==24.0 setuptools==78.1.1 wheel && \
     pip install --no-cache-dir -r requirements.txt && \
     find /app/venv -type d -name '__pycache__' -exec rm -rf {} + && \
     find /app/venv -type f -name '*.pyc' -delete

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -18,7 +18,7 @@ COPY requirements-cpu.txt .
 
 ENV VIRTUAL_ENV=/app/venv
 RUN python -m venv $VIRTUAL_ENV && \
-    $VIRTUAL_ENV/bin/pip install --no-cache-dir pip==24.0 setuptools wheel && \
+    $VIRTUAL_ENV/bin/pip install --no-cache-dir pip==24.0 setuptools==78.1.1 wheel && \
     $VIRTUAL_ENV/bin/pip install --no-cache-dir -r requirements-cpu.txt && \
     find $VIRTUAL_ENV -type d -name '__pycache__' -exec rm -rf {} + && \
     find $VIRTUAL_ENV -type f -name '*.pyc' -delete

--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -1,3 +1,4 @@
+setuptools>=78.1.1
 numpy>=1.26.4  # core numeric library
 pandas>=2.2.2
 torch==2.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+setuptools>=78.1.1
 numpy>=1.26.4  # core numeric library
 pandas>=2.2.2
 torch==2.7.1


### PR DESCRIPTION
## Summary
- Pin setuptools to 78.1.1 in Dockerfile and Dockerfile.cpu installation steps
- Add setuptools>=78.1.1 to both requirements files for downstream environments

## Testing
- `pre-commit run --files Dockerfile Dockerfile.cpu requirements.txt requirements-cpu.txt` *(fails: pytest hook interrupted)*
- `pytest -q`
- Attempted `docker build -f Dockerfile.cpu -t bot-cpu-test .` *(fails: Cannot connect to Docker daemon; daemon fails to start due to permission errors)*


------
https://chatgpt.com/codex/tasks/task_e_689239d4b878832daca4a2803691b8a0