### PR TITLE
Use spawn context without global start method

### DIFF
--- a/tests/test_integration_services.py
+++ b/tests/test_integration_services.py
@@ -1,6 +1,7 @@
 import os
 import requests
 import multiprocessing
+import sys
 import signal
 from contextlib import ExitStack
 from flask import Flask, request, jsonify
@@ -8,8 +9,8 @@ import pytest
 
 from tests.helpers import get_free_port, service_process
 
-# Ensure processes use the spawn start method on all platforms
-multiprocessing.set_start_method("spawn", force=True)
+if sys.platform == "win32":
+    multiprocessing.set_start_method("spawn", force=True)
 ctx = multiprocessing.get_context("spawn")
 
 


### PR DESCRIPTION
## Summary
- remove global multiprocessing.set_start_method call from integration test
- rely on spawn context for process creation and set start method only on Windows

## Testing
- `python -m pytest tests/test_integration_services.py`

------
https://chatgpt.com/codex/tasks/task_e_68923b18d4ec832d9ff71e02162fbc27