### PR TITLE
chore(ci): build Dockerfile.ci from ubuntu base with Python 3.12

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,16 +1,25 @@
 # syntax=docker/dockerfile:1
-FROM python:3.12.4-slim
+FROM ubuntu:22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
 ARG ZLIB_VERSION=1.3.1
 
-RUN apt-get update && apt-get upgrade -y linux-libc-dev && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+    software-properties-common \
     linux-libc-dev \
     build-essential \
     curl \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        python3.12 \
+        python3.12-dev \
+        python3.12-distutils \
+    && curl -sS https://bootstrap.pypa.io/get-pip.py | python3.12 \
     && curl -L https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
     && tar -xf zlib.tar.gz \
     && cd zlib-${ZLIB_VERSION} && ./configure --prefix=/usr && make -j"$(nproc)" && make install && cd .. \
     && rm -rf zlib.tar.gz zlib-${ZLIB_VERSION} \
-    && apt-get purge -y --auto-remove build-essential curl \
+    && apt-get purge -y --auto-remove build-essential curl software-properties-common \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && ldconfig
 


### PR DESCRIPTION
## Summary
- base Dockerfile.ci on ubuntu 22.04 and install Python 3.12 via deadsnakes

## Testing
- `pre-commit run --files Dockerfile.ci` *(fails: tests/test_integration_services.py::test_services_communicate)*

------
https://chatgpt.com/codex/tasks/task_e_68923b03b8c8832d8f05e21dd00c7594