### PR TITLE
Use patch utilities for environment variables in tests

### DIFF
--- a/tests/test_integration_services.py
+++ b/tests/test_integration_services.py
@@ -91,9 +91,9 @@ def _run_tm(port: int):
 
 
 @pytest.mark.integration
-def test_services_communicate():
+def test_services_communicate(monkeypatch):
     from bot import trading_bot  # noqa: E402
-    os.environ['HOST'] = '127.0.0.1'
+    monkeypatch.setenv('HOST', '127.0.0.1')
     dh_port = get_free_port()
     mb_port = get_free_port()
     tm_port = get_free_port()
@@ -107,11 +107,9 @@ def test_services_communicate():
         stack.enter_context(
             service_process(ctx.Process(target=_run_tm, args=(tm_port,)), url=f'http://localhost:{tm_port}/ready')
         )
-        os.environ.update({
-            'DATA_HANDLER_URL': f'http://localhost:{dh_port}',
-            'MODEL_BUILDER_URL': f'http://localhost:{mb_port}',
-            'TRADE_MANAGER_URL': f'http://localhost:{tm_port}',
-        })
+        monkeypatch.setenv('DATA_HANDLER_URL', f'http://localhost:{dh_port}')
+        monkeypatch.setenv('MODEL_BUILDER_URL', f'http://localhost:{mb_port}')
+        monkeypatch.setenv('TRADE_MANAGER_URL', f'http://localhost:{tm_port}')
         trading_bot.run_once()
         resp = requests.get(f'http://localhost:{tm_port}/positions', timeout=5)
         data = resp.json()
@@ -119,9 +117,9 @@ def test_services_communicate():
 
 
 @pytest.mark.integration
-def test_service_availability_check():
+def test_service_availability_check(monkeypatch):
     from bot import trading_bot  # noqa: E402
-    os.environ['HOST'] = '127.0.0.1'
+    monkeypatch.setenv('HOST', '127.0.0.1')
     dh_port = get_free_port()
     mb_port = get_free_port()
     tm_port = get_free_port()
@@ -144,9 +142,9 @@ def test_service_availability_check():
 
 
 @pytest.mark.integration
-def test_check_services_success():
+def test_check_services_success(monkeypatch):
     from bot import trading_bot  # noqa: E402
-    os.environ['HOST'] = '127.0.0.1'
+    monkeypatch.setenv('HOST', '127.0.0.1')
     dh_port = get_free_port()
     mb_port = get_free_port()
     tm_port = get_free_port()
@@ -160,20 +158,18 @@ def test_check_services_success():
         stack.enter_context(
             service_process(ctx.Process(target=_run_tm, args=(tm_port,)), url=f'http://localhost:{tm_port}/ready')
         )
-        os.environ.update({
-            'DATA_HANDLER_URL': f'http://localhost:{dh_port}',
-            'MODEL_BUILDER_URL': f'http://localhost:{mb_port}',
-            'TRADE_MANAGER_URL': f'http://localhost:{tm_port}',
-            'SERVICE_CHECK_RETRIES': '2',
-            'SERVICE_CHECK_DELAY': '0.1',
-        })
+        monkeypatch.setenv('DATA_HANDLER_URL', f'http://localhost:{dh_port}')
+        monkeypatch.setenv('MODEL_BUILDER_URL', f'http://localhost:{mb_port}')
+        monkeypatch.setenv('TRADE_MANAGER_URL', f'http://localhost:{tm_port}')
+        monkeypatch.setenv('SERVICE_CHECK_RETRIES', '2')
+        monkeypatch.setenv('SERVICE_CHECK_DELAY', '0.1')
         trading_bot.check_services()
 
 
 @pytest.mark.integration
-def test_check_services_failure():
+def test_check_services_failure(monkeypatch):
     from bot import trading_bot  # noqa: E402
-    os.environ['HOST'] = '127.0.0.1'
+    monkeypatch.setenv('HOST', '127.0.0.1')
     dh_port = get_free_port()
     mb_port = get_free_port()
     tm_port = get_free_port()
@@ -184,27 +180,23 @@ def test_check_services_failure():
         stack.enter_context(
             service_process(ctx.Process(target=_run_mb, args=(mb_port,)), url=f'http://localhost:{mb_port}/ping')
         )
-        os.environ.update({
-            'DATA_HANDLER_URL': f'http://localhost:{dh_port}',
-            'MODEL_BUILDER_URL': f'http://localhost:{mb_port}',
-            'TRADE_MANAGER_URL': f'http://localhost:{tm_port}',
-            'SERVICE_CHECK_RETRIES': '2',
-            'SERVICE_CHECK_DELAY': '0.1',
-        })
+        monkeypatch.setenv('DATA_HANDLER_URL', f'http://localhost:{dh_port}')
+        monkeypatch.setenv('MODEL_BUILDER_URL', f'http://localhost:{mb_port}')
+        monkeypatch.setenv('TRADE_MANAGER_URL', f'http://localhost:{tm_port}')
+        monkeypatch.setenv('SERVICE_CHECK_RETRIES', '2')
+        monkeypatch.setenv('SERVICE_CHECK_DELAY', '0.1')
         with pytest.raises(SystemExit):
             trading_bot.check_services()
 
 
 @pytest.mark.integration
-def test_check_services_host_only():
+def test_check_services_host_only(monkeypatch):
     from bot import trading_bot  # noqa: E402
-    os.environ['HOST'] = '127.0.0.1'
+    monkeypatch.setenv('HOST', '127.0.0.1')
     for var in ('DATA_HANDLER_URL', 'MODEL_BUILDER_URL', 'TRADE_MANAGER_URL'):
-        os.environ.pop(var, None)
-    os.environ.update({
-        'SERVICE_CHECK_RETRIES': '2',
-        'SERVICE_CHECK_DELAY': '0.1',
-    })
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv('SERVICE_CHECK_RETRIES', '2')
+    monkeypatch.setenv('SERVICE_CHECK_DELAY', '0.1')
     dh_port = get_free_port()
     mb_port = get_free_port()
     tm_port = get_free_port()
@@ -218,9 +210,7 @@ def test_check_services_host_only():
         stack.enter_context(
             service_process(ctx.Process(target=_run_tm, args=(tm_port,)), url=f'http://localhost:{tm_port}/ready')
         )
-        os.environ.update({
-            'DATA_HANDLER_URL': f'http://localhost:{dh_port}',
-            'MODEL_BUILDER_URL': f'http://localhost:{mb_port}',
-            'TRADE_MANAGER_URL': f'http://localhost:{tm_port}',
-        })
+        monkeypatch.setenv('DATA_HANDLER_URL', f'http://localhost:{dh_port}')
+        monkeypatch.setenv('MODEL_BUILDER_URL', f'http://localhost:{mb_port}')
+        monkeypatch.setenv('TRADE_MANAGER_URL', f'http://localhost:{tm_port}')
         trading_bot.check_services()

--- a/tests/test_service_scripts.py
+++ b/tests/test_service_scripts.py
@@ -3,6 +3,7 @@ import os
 import types
 import requests
 import pytest
+from unittest.mock import patch
 
 from tests.helpers import get_free_port, service_process
 
@@ -21,10 +22,9 @@ def _run_dh(port: int):
     ccxt.bybit = lambda *a, **kw: DummyExchange()
     import sys
     sys.modules['ccxt'] = ccxt
-    os.environ['STREAM_SYMBOLS'] = ''
-    os.environ['HOST'] = '127.0.0.1'
-    from bot.services import data_handler_service
-    data_handler_service.app.run(host='127.0.0.1', port=port)
+    with patch.dict(os.environ, {'STREAM_SYMBOLS': '', 'HOST': '127.0.0.1'}):
+        from bot.services import data_handler_service
+        data_handler_service.app.run(host='127.0.0.1', port=port)
 
 
 @pytest.mark.integration
@@ -46,10 +46,9 @@ def _run_dh_fail(port: int):
     ccxt.bybit = lambda *a, **kw: DummyExchange()
     import sys
     sys.modules['ccxt'] = ccxt
-    os.environ['STREAM_SYMBOLS'] = ''
-    os.environ['HOST'] = '127.0.0.1'
-    from bot.services import data_handler_service
-    data_handler_service.app.run(host='127.0.0.1', port=port)
+    with patch.dict(os.environ, {'STREAM_SYMBOLS': '', 'HOST': '127.0.0.1'}):
+        from bot.services import data_handler_service
+        data_handler_service.app.run(host='127.0.0.1', port=port)
 
 
 @pytest.mark.integration
@@ -90,10 +89,9 @@ def _run_mb(model_dir: str, port: int):
     sys.modules['sklearn'] = sklearn
     sys.modules['sklearn.linear_model'] = linear_model
 
-    os.environ['MODEL_DIR'] = model_dir
-    os.environ['HOST'] = '127.0.0.1'
-    from bot.services import model_builder_service
-    model_builder_service.app.run(host='127.0.0.1', port=port)
+    with patch.dict(os.environ, {'MODEL_DIR': model_dir, 'HOST': '127.0.0.1'}):
+        from bot.services import model_builder_service
+        model_builder_service.app.run(host='127.0.0.1', port=port)
 
 
 @pytest.mark.integration
@@ -177,11 +175,10 @@ def _run_mb_fail(model_file: str, port: int):
     sys.modules['sklearn'] = sklearn
     sys.modules['sklearn.linear_model'] = linear_model
 
-    os.environ['MODEL_FILE'] = model_file
-    os.environ['HOST'] = '127.0.0.1'
-    from bot.services import model_builder_service
-    model_builder_service._load_model()
-    model_builder_service.app.run(host='127.0.0.1', port=port)
+    with patch.dict(os.environ, {'MODEL_FILE': model_file, 'HOST': '127.0.0.1'}):
+        from bot.services import model_builder_service
+        model_builder_service._load_model()
+        model_builder_service.app.run(host='127.0.0.1', port=port)
 
 
 @pytest.mark.integration
@@ -237,11 +234,14 @@ def _run_tm(
     ccxt.bybit = lambda *a, **kw: DummyExchange()
     import sys
     sys.modules['ccxt'] = ccxt
-    os.environ['HOST'] = '127.0.0.1'
-    os.environ['TRADE_MANAGER_TOKEN'] = 'test-token'
-    os.environ.setdefault('TRADE_RISK_USD', '10')
-    from bot.services import trade_manager_service
-    trade_manager_service.app.run(host='127.0.0.1', port=port)
+    env = {
+        'HOST': '127.0.0.1',
+        'TRADE_MANAGER_TOKEN': 'test-token',
+        'TRADE_RISK_USD': os.environ.get('TRADE_RISK_USD', '10'),
+    }
+    with patch.dict(os.environ, env):
+        from bot.services import trade_manager_service
+        trade_manager_service.app.run(host='127.0.0.1', port=port)
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
- switch integration tests to `monkeypatch` for setting environment variables
- use `unittest.mock.patch.dict` in service script helpers for temporary env vars

## Testing
- `pytest tests/test_integration_services.py tests/test_service_scripts.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68923b0e2a88832d9b1fe7639cefc48a