### PR TITLE
feat: build cpu image from ubuntu

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,10 +1,13 @@
-FROM python:3.12.4-slim AS builder
+FROM ubuntu:22.04 AS builder
 ARG ZLIB_VERSION=1.3.1
 
 RUN apt-get update && apt-get upgrade -y linux-libc-dev && apt-get install -y --no-install-recommends \
+    software-properties-common \
     linux-libc-dev \
     build-essential \
     curl \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get update && apt-get install -y --no-install-recommends python3.12 python3.12-venv python3.12-dev \
     && curl -L https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
     && tar -xf zlib.tar.gz \
     && cd zlib-${ZLIB_VERSION} && ./configure --prefix=/usr && make -j"$(nproc)" && make install && cd .. \
@@ -17,25 +20,28 @@ WORKDIR /app
 COPY requirements-cpu.txt .
 
 ENV VIRTUAL_ENV=/app/venv
-RUN python -m venv $VIRTUAL_ENV && \
+RUN python3.12 -m venv $VIRTUAL_ENV && \
     $VIRTUAL_ENV/bin/pip install --no-cache-dir pip==24.0 setuptools==78.1.1 wheel && \
     $VIRTUAL_ENV/bin/pip install --no-cache-dir -r requirements-cpu.txt && \
     find $VIRTUAL_ENV -type d -name '__pycache__' -exec rm -rf {} + && \
     find $VIRTUAL_ENV -type f -name '*.pyc' -delete
 
-FROM python:3.12.4-slim
+FROM ubuntu:22.04
 ARG ZLIB_VERSION=1.3.1
 
 RUN apt-get update && apt-get upgrade -y linux-libc-dev && apt-get install -y --no-install-recommends \
+    software-properties-common \
     curl \
     linux-libc-dev \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get update && apt-get install -y --no-install-recommends python3.12 python3.12-venv python3.12-dev \
     && curl -L https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
     && tar -xf zlib.tar.gz \
     && cd zlib-${ZLIB_VERSION} && ./configure --prefix=/usr && make -j"$(nproc)" && make install && cd .. \
     && rm -rf zlib.tar.gz zlib-${ZLIB_VERSION} \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && ldconfig \
-    && python --version
+    && python3.12 --version
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- build CPU Docker image from ubuntu 22.04 instead of python slim image
- install Python 3.12 manually from deadsnakes PPA and reuse existing dependency setup

## Testing
- `pytest` *(fails: SyntaxError in data_handler.py)*

------
https://chatgpt.com/codex/tasks/task_e_68923b0c2860832dadd7c4f0249c1bd7