### PR TITLE
Handle optional cupy dependency gracefully

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -7,6 +7,7 @@ import json
 import time
 import os
 import types
+import threading
 
 
 try:  # pragma: no cover - optional dependency
@@ -179,8 +180,13 @@ def _init_cuda() -> None:
         if GPU_AVAILABLE:
             try:
                 import cupy as cupy_mod  # type: ignore
-
-
+            except ImportError as exc:
+                logger.warning("cupy import failed: %s", exc)
+                cp = np  # type: ignore
+                GPU_AVAILABLE = False
+            else:
+                cp = cupy_mod  # type: ignore
+        else:
             cp = np  # type: ignore
 
         GPU_INITIALIZED = True


### PR DESCRIPTION
## Summary
- handle optional cupy import with fallback to numpy
- ensure GPU initialization respects cupy availability

## Testing
- `python -m py_compile data_handler.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68923fde23dc832d9f0fef83ebcd92ed