### PR TITLE
chore: install gnupg in ci image

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -5,6 +5,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG ZLIB_VERSION=1.3.1
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+    gnupg \
     software-properties-common \
     linux-libc-dev \
     build-essential \
@@ -19,7 +20,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     && tar -xf zlib.tar.gz \
     && cd zlib-${ZLIB_VERSION} && ./configure --prefix=/usr && make -j"$(nproc)" && make install && cd .. \
     && rm -rf zlib.tar.gz zlib-${ZLIB_VERSION} \
-    && apt-get purge -y --auto-remove build-essential curl software-properties-common \
+    && apt-get purge -y --auto-remove build-essential curl gnupg software-properties-common \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && ldconfig
 


### PR DESCRIPTION
## Summary
- install gnupg in Dockerfile.ci to provide gpg-agent
- purge gnupg after building to keep the image slim

## Testing
- `pytest` (fails: SyntaxError in data_handler)
- `buildah bud -f Dockerfile.ci -t ghcr.io/averinaleks/bot:test .` (fails: unable to apply cgroup configuration)


------
https://chatgpt.com/codex/tasks/task_e_68923fe6a860832d89bb5c26c37e1a56