### PR TITLE
Handle cupy import failure during CUDA init

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -8,6 +8,7 @@ import time
 import os
 import types
 
+import logging
 import threading
 
 
@@ -176,15 +177,17 @@ def _init_cuda() -> None:
             cp = np  # type: ignore
             GPU_INITIALIZED = True
             return
-
         GPU_AVAILABLE = is_cuda_available()
         if GPU_AVAILABLE:
             try:
                 import cupy as cupy_mod  # type: ignore
-
+                cp = cupy_mod
+            except ImportError as exc:
+                logging.getLogger("TradingBot").warning("cupy import failed: %s", exc)
+                GPU_AVAILABLE = False
+                cp = np  # type: ignore
         else:
             cp = np  # type: ignore
-
         GPU_INITIALIZED = True
 
 


### PR DESCRIPTION
## Summary
- ensure `_init_cuda` gracefully falls back to NumPy when `cupy` is unavailable
- import `logging` to support warning output during CUDA setup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892463c50bc832d8935b224d11fc21f