### PR TITLE
chore: streamline Python setup in CI Dockerfile

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -14,8 +14,8 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     && apt-get update && apt-get install -y --no-install-recommends \
         python3.12 \
         python3.12-dev \
-        python3.12-distutils \
-    && curl -sS https://bootstrap.pypa.io/get-pip.py | python3.12 \
+        python3.12-venv \
+    && python3.12 -m ensurepip --upgrade \
     && curl -L https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
     && tar -xf zlib.tar.gz \
     && cd zlib-${ZLIB_VERSION} && ./configure --prefix=/usr && make -j"$(nproc)" && make install && cd .. \
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
 WORKDIR /app
 
 # Install only linting tools
-RUN pip install --no-cache-dir flake8
+RUN python3.12 -m pip install --no-cache-dir flake8
 
 # Copy files required for static analysis
 COPY .pre-commit-config.yaml .flake8 .pylintrc requirements.txt requirements-cpu.txt ./


### PR DESCRIPTION
## Summary
- remove deprecated python3.12-distutils from CI image
- rely on ensurepip and python3.12-venv for pip setup
- install flake8 using `python3.12 -m pip`

## Testing
- `pre-commit run --files Dockerfile.ci` *(fails: SyntaxError in data_handler.py)*
- `docker build -f Dockerfile.ci -t bot-ci .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68924632f144832daf4c2e277419ceda