### PR TITLE
Handle missing cupy gracefully

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -7,6 +7,7 @@ import json
 import time
 import os
 import types
+import logging
 
 import threading
 
@@ -181,7 +182,11 @@ def _init_cuda() -> None:
         if GPU_AVAILABLE:
             try:
                 import cupy as cupy_mod  # type: ignore
-
+                cp = cupy_mod  # type: ignore
+            except ImportError as exc:
+                logging.getLogger("TradingBot").warning("cupy import failed: %s", exc)
+                GPU_AVAILABLE = False
+                cp = np  # type: ignore
         else:
             cp = np  # type: ignore
 


### PR DESCRIPTION
## Summary
- handle missing cupy module with proper fallback to NumPy and warning
- import logging for GPU initialization

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689246415cdc832d843185b2c3a02292