### PR TITLE
Guard indicator tests when ta is unavailable

### DIFF
--- a/tests/test_indicators_cache.py
+++ b/tests/test_indicators_cache.py
@@ -2,7 +2,8 @@ import sys
 import types
 import pandas as pd
 import numpy as np
-import ta
+import pytest
+ta = pytest.importorskip("ta")
 from bot.config import BotConfig
 
 optimizer_stubbed = False

--- a/tests/test_indicators_gpu.py
+++ b/tests/test_indicators_gpu.py
@@ -2,7 +2,8 @@ import os
 import sys
 import numpy as np
 import pandas as pd
-import ta
+import pytest
+ta = pytest.importorskip("ta")
 import types
 from bot import utils
 


### PR DESCRIPTION
## Summary
- Skip indicator tests if the optional `ta` library is not installed
- Add `pytest` import and use `pytest.importorskip` in indicator test modules

## Testing
- `STUB_TA=0 pytest tests/test_indicators_gpu.py tests/test_indicators_cache.py`
- `STUB_TA=0 pre-commit run --files tests/test_indicators_gpu.py tests/test_indicators_cache.py` *(fails: SyntaxError in data_handler.py)*

------
https://chatgpt.com/codex/tasks/task_e_6892463376b4832dac99d39c87f95001