### PR TITLE
Fix GPU initialization import guard

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -183,7 +183,8 @@ def _init_cuda() -> None:
         if GPU_AVAILABLE:
             try:
                 import cupy as cupy_mod  # type: ignore
-
+                cp = cupy_mod  # type: ignore
+            except Exception:  # pragma: no cover - import guard
                 GPU_AVAILABLE = False
                 cp = np  # type: ignore
         else:


### PR DESCRIPTION
## Summary
- handle optional CuPy import in `_init_cuda`

## Testing
- `flake8 .`
- `pytest` *(fails: AttributeError: module 'requests' has no attribute 'Response')*


------
https://chatgpt.com/codex/tasks/task_e_68924d4e1658832da78ff8149a712ecd