### PR TITLE
Default data handler service host to loopback

### DIFF
--- a/services/data_handler_service.py
+++ b/services/data_handler_service.py
@@ -47,5 +47,5 @@ def handle_unexpected_error(exc: Exception) -> tuple:
 
 if __name__ == '__main__':
     port = int(os.environ.get('PORT', '8000'))
-    host = os.environ.get('HOST', '0.0.0.0')
+    host = os.environ.get('HOST', '127.0.0.1')
     app.run(host=host, port=port)


### PR DESCRIPTION
## Summary
- default data handler service HOST to `127.0.0.1`

## Testing
- `bandit -r services/data_handler_service.py`
- `HOST=0.0.0.0 PORT=8001 python services/data_handler_service.py` *(terminated after startup)*

------
https://chatgpt.com/codex/tasks/task_e_6892523832fc832db5f6cfeae3bfbef4