### PR TITLE
Default ModelBuilder to localhost

### DIFF
--- a/model_builder.py
+++ b/model_builder.py
@@ -1901,9 +1901,8 @@ if __name__ == "__main__":
     load_dotenv()
     _load_model()
     port = int(os.environ.get("PORT", "8001"))
-    host = os.environ.get("HOST")
-    if not host:
-        host = "127.0.0.1"
+    host = os.environ.get("HOST", "127.0.0.1")
+    if "HOST" not in os.environ:
         logger.info("HOST not set, defaulting to %s", host)
     elif host != "127.0.0.1":
         logger.warning("Using non-local host %s; ensure this is intended", host)


### PR DESCRIPTION
## Summary
- default ModelBuilder service to localhost unless HOST is set

## Testing
- `pytest -q`
- `pip-audit`

------
https://chatgpt.com/codex/tasks/task_e_689252387478832db5b0ac2c92f22a9f