### PR TITLE
Default DataHandler host to localhost

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -2781,6 +2781,8 @@ def ping():
 if __name__ == "__main__":
     load_dotenv()
     port = int(os.environ.get("PORT", "8000"))
-    host = os.environ.get("HOST", "0.0.0.0")
+    # Bind to localhost by default to avoid exposing the service on all network
+    # interfaces, which could allow unintended remote access.
+    host = os.environ.get("HOST", "127.0.0.1")
     logger.info("Starting DataHandler service on %s:%s", host, port)
     api_app.run(host=host, port=port)


### PR DESCRIPTION
## Summary
- use localhost as default host for data handler to avoid exposing service

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689269f36a98832dab4290f05430a2e1