### PR TITLE
Define host variable for data handler service

### DIFF
--- a/services/data_handler_service.py
+++ b/services/data_handler_service.py
@@ -47,4 +47,11 @@ def handle_unexpected_error(exc: Exception) -> tuple:
 
 if __name__ == '__main__':
     port = int(os.environ.get('PORT', '8000'))
+    host = os.environ.get('HOST', '127.0.0.1')
+    if host != '127.0.0.1':
+        logging.warning(
+            'Using non-local host %s; ensure this exposure is intended', host
+        )
+    else:
+        logging.info('HOST not set, defaulting to %s', host)
     app.run(host=host, port=port)


### PR DESCRIPTION
## Summary
- ensure data handler service reads HOST env var and warns when using non-local host

## Testing
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_68926caa3750832db370509b7ac6ac75