### PR TITLE
Define host before use in data handler service

### DIFF
--- a/services/data_handler_service.py
+++ b/services/data_handler_service.py
@@ -46,8 +46,8 @@ def handle_unexpected_error(exc: Exception) -> tuple:
     return jsonify({'error': 'internal server error'}), 500
 
 if __name__ == '__main__':
-    port = int(os.environ.get('PORT', '8000'))
     host = os.environ.get('HOST', '127.0.0.1')
+    port = int(os.environ.get('PORT', '8000'))
     if host != '127.0.0.1':
         logging.warning(
             'Using non-local host %s; ensure this exposure is intended', host


### PR DESCRIPTION
## Summary
- ensure host is defined from environment before any references in `services/data_handler_service.py`

## Testing
- `flake8 services/data_handler_service.py`


------
https://chatgpt.com/codex/tasks/task_e_6892713bdc84832da9618b705cd171de