### PR TITLE
Batch volume data fetches to cap task concurrency

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -12,6 +12,7 @@ dataclass.  Default values are shown for reference.
 | ws_url | wss://stream.bybit.com/v5/public/linear | Public WebSocket endpoint. |
 | backup_ws_urls | ['wss://stream.bybit.com/v5/public/linear'] | Fallback WebSocket endpoints. |
 | max_concurrent_requests | 10 | Limit for simultaneous HTTP requests. |
+| max_volume_batch | 50 | Markets processed per volume fetch batch. |
 | history_batch_size | 10 | Number of candles fetched per history request. |
 | max_symbols | 50 | Maximum symbols to track. |
 | max_subscriptions_per_connection | 15 | WebSocket subscriptions allowed per connection. |

--- a/config.json
+++ b/config.json
@@ -8,6 +8,7 @@
     ],
     "max_concurrent_requests": 10,
     "history_batch_size": 10,
+    "max_volume_batch": 50,
     "history_retention": 200,
     "max_symbols": 50,
     "max_subscriptions_per_connection": 15,

--- a/config.py
+++ b/config.py
@@ -44,6 +44,7 @@ class BotConfig:
         )
     )
     max_concurrent_requests: int = _get_default("max_concurrent_requests", 10)
+    max_volume_batch: int = _get_default("max_volume_batch", 50)
     history_batch_size: int = _get_default("history_batch_size", 10)
     max_symbols: int = _get_default("max_symbols", 50)
     max_subscriptions_per_connection: int = _get_default(


### PR DESCRIPTION
## Summary
- batch symbol volume requests in `select_liquid_pairs` to avoid unbounded task creation
- add `max_volume_batch` configuration option and document it

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892fbc5403c832d9c46383d4a8ce768