### PR TITLE
Move multiprocessing start method setup into explicit initialization

### DIFF
--- a/trade_manager.py
+++ b/trade_manager.py
@@ -95,8 +95,10 @@ if os.getenv("TEST_MODE") == "1" and not hasattr(Flask, "asgi_app"):
 import threading
 import multiprocessing as mp
 
-if mp.get_start_method(allow_none=True) != "spawn":
-    mp.set_start_method("spawn", force=True)
+def setup_multiprocessing() -> None:
+    """Ensure multiprocessing uses the 'spawn' start method."""
+    if mp.get_start_method(allow_none=True) != "spawn":
+        mp.set_start_method("spawn", force=True)
 
 # Determine computation device once
 
@@ -1928,6 +1930,7 @@ def ready() -> tuple:
 
 
 if __name__ == "__main__":
+    setup_multiprocessing()
     load_dotenv()
     port = int(os.environ.get("PORT", "8002"))
     host = os.environ.get("HOST", "127.0.0.1")


### PR DESCRIPTION
## Summary
- add `setup_multiprocessing` helper to configure multiprocessing with spawn start method
- invoke multiprocessing setup inside module's `__main__` entrypoint

## Testing
- `TEST_MODE=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893050cae04832d8ba5e1e17c0adf2b