### PR TITLE
refactor: handle awaitable ema conditions

### DIFF
--- a/trade_manager.py
+++ b/trade_manager.py
@@ -1485,12 +1485,18 @@ class TradeManager:
 
             ema_signal = None
             check = self.evaluate_ema_condition(symbol, "buy")
-            ema_buy = await check if inspect.iscoroutine(check) else check
+            if inspect.isawaitable(check):
+                ema_buy = await check
+            else:
+                ema_buy = check
             if ema_buy:
                 ema_signal = "buy"
             else:
                 check = self.evaluate_ema_condition(symbol, "sell")
-                ema_sell = await check if inspect.iscoroutine(check) else check
+                if inspect.isawaitable(check):
+                    ema_sell = await check
+                else:
+                    ema_sell = check
                 if ema_sell:
                     ema_signal = "sell"
 


### PR DESCRIPTION
## Summary
- replace ternary await with explicit `inspect.isawaitable` checks for EMA buy/sell logic
- add tests covering synchronous and asynchronous EMA condition evaluation

## Testing
- `pytest tests/test_trade_manager.py::test_evaluate_signal_uses_cached_features tests/test_trade_manager.py::test_evaluate_signal_handles_sync_async_ema -q`


------
https://chatgpt.com/codex/tasks/task_e_6893121801ec832dbc25336a8b429703