### PR TITLE
Include GPU configuration in Ray initialization

### DIFF
--- a/tests/test_data_handler.py
+++ b/tests/test_data_handler.py
@@ -406,8 +406,10 @@ async def test_stop_handles_close_errors(cfg_factory):
 @pytest.mark.asyncio
 async def test_stop_shuts_down_ray(cfg_factory):
     import ray
-    ray.init()
     cfg = cfg_factory()
+    ray.init(
+        num_cpus=cfg["ray_num_cpus"], num_gpus=1, ignore_reinit_error=True
+    )
     dh = DataHandler(cfg, None, None, exchange=DummyExchange({'BTCUSDT': 1.0}))
     await dh.stop()
     assert not ray.is_initialized()

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -1750,9 +1750,15 @@ async def create_trade_manager() -> TradeManager | None:
             )
             raise
         if not ray.is_initialized():
-            logger.info("Initializing Ray with num_cpus=%s", cfg["ray_num_cpus"])
+            logger.info(
+                "Initializing Ray with num_cpus=%s, num_gpus=1", cfg["ray_num_cpus"]
+            )
             try:
-                ray.init(num_cpus=cfg["ray_num_cpus"], ignore_reinit_error=True)
+                ray.init(
+                    num_cpus=cfg["ray_num_cpus"],
+                    num_gpus=1,
+                    ignore_reinit_error=True,
+                )
                 logger.info("Ray initialized successfully")
             except RuntimeError as exc:
                 logger.exception(


### PR DESCRIPTION
## Summary
- configure TradeManager to initialize Ray with GPU support and `ignore_reinit_error`
- update test to use new Ray initialization signature

## Testing
- `pytest tests/test_data_handler.py::test_stop_shuts_down_ray -q`


------
https://chatgpt.com/codex/tasks/task_e_689317f845e0832dbee3a4455a77045a