### PR TITLE
Avoid stubbing httpx when real package exists

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,11 +53,18 @@ def _stub_modules():
     sys.modules.setdefault("pybit", pybit_mod)
     sys.modules.setdefault("pybit.unified_trading", ut_mod)
 
-    httpx_mod = types.ModuleType("httpx")
-    class HTTPError(Exception):
-        pass
-    httpx_mod.HTTPError = HTTPError
-    sys.modules.setdefault("httpx", httpx_mod)
+    try:  # use real httpx when available so integration tests can perform HTTP calls
+        import httpx as real_httpx
+        if getattr(real_httpx, "AsyncClient", None):
+            sys.modules.setdefault("httpx", real_httpx)
+        else:
+            raise ImportError
+    except Exception:  # pragma: no cover - optional dependency
+        httpx_mod = types.ModuleType("httpx")
+        class HTTPError(Exception):
+            pass
+        httpx_mod.HTTPError = HTTPError
+        sys.modules.setdefault("httpx", httpx_mod)
     telegram_error_mod = types.ModuleType("telegram.error")
     telegram_error_mod.RetryAfter = Exception
     sys.modules.setdefault("telegram", types.ModuleType("telegram"))


### PR DESCRIPTION
## Summary
- only stub `httpx` when the real package with `AsyncClient` isn't available

## Testing
- `pytest -m integration`

------
https://chatgpt.com/codex/tasks/task_e_689336119a14832d95f63c3394b7dd6a