### PR TITLE
Specify gptoss network name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,6 +159,7 @@ networks:
   trading_bot_default:
     driver: bridge
   gptoss_net:
+    name: gptoss_net
     driver: bridge
 
 volumes:


### PR DESCRIPTION
## Summary
- explicitly name the `gptoss_net` network in `docker-compose.yml`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689338e7e808832da6585f8056a1ef5b