### PR TITLE
Enable GPU for gptoss service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - gptoss_workspace:/workspace
     environment:
       - TRANSFORMERS_CACHE=/workspace
+    gpus: all
     networks:
       - gptoss_net
   data_handler:


### PR DESCRIPTION
## Summary
- configure gptoss service to request GPU resources using `gpus: all`

## Testing
- `pre-commit run --files docker-compose.yml`


------
https://chatgpt.com/codex/tasks/task_e_68933edd6c80832d820a95066dd6d4ee