### PR TITLE
Potential fix for code scanning alert no. 755: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -1,4 +1,6 @@
 name: GPT-OSS Code Review
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/averinaleks/bot/security/code-scanning/755](https://github.com/averinaleks/bot/security/code-scanning/755)

To fix the problem, you should add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. In this case, since the workflow only checks out code and runs a Docker command, it only needs read access to repository contents. The best way to do this is to add a `permissions: contents: read` block at the top level of the workflow file, just below the `name` field and before the `on` field. This will apply the permission restriction to all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
