### PR TITLE
Fix empty environment in gptoss_check service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,6 +158,7 @@ services:
     volumes:
       - .:/workspace
     environment:
+      PYTHONUNBUFFERED: "1"
     depends_on:
       gptoss:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- add PYTHONUNBUFFERED to gptoss_check service so environment section is valid

## Testing
- `docker compose config`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893534805e0832d872109f51f3d1beb