### PR TITLE
fix gptoss check by logging into ghcr

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -14,7 +14,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Запустить gptoss review в Docker
-        run: |
-          docker compose run gptoss_check
+      - name: Run gptoss review in Docker
+        run: docker compose run gptoss_check


### PR DESCRIPTION
## Summary
- log into ghcr.io before running gptoss check

## Testing
- `pre-commit run --files .github/workflows/gptoss_review.yml` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6893584a3088832dae99400b32437ece