### PR TITLE
chore: use latest gpt-oss image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 # Set DOCKERFILE=Dockerfile.cpu to build a CPU-only image
 services:
   gptoss:
-    image: ghcr.io/openai/gpt-oss:20b
+    image: ghcr.io/openai/gpt-oss:latest
     ports:
       - "8000:8000"
     volumes:
@@ -154,7 +154,7 @@ services:
         soft: 65536
         hard: 65536
   gptoss_check:
-    image: ghcr.io/openai/gpt-oss:20b
+    image: ghcr.io/openai/gpt-oss:latest
     command: python3 gptoss_check/check_code.py
     working_dir: /workspace
     volumes:


### PR DESCRIPTION
## Summary
- use `ghcr.io/openai/gpt-oss:latest` for gptoss and gptoss_check services

## Testing
- `pytest`
- `docker compose run gptoss_check` *(fails: docker: 'compose' is not a docker command)*
- `docker-compose run gptoss_check` *(fails: Unsupported config option for services.gptoss: 'gpus')*

------
https://chatgpt.com/codex/tasks/task_e_68935b2bf3b0832d883f25f9ce75d6a1