### PR TITLE
Remove obsolete version field from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 # Set DOCKERFILE=Dockerfile.cpu to build a CPU-only image
 services:
   gptoss:


### PR DESCRIPTION
## Summary
- remove outdated `version` field from `docker-compose.yml`
- verify config generation works with `docker compose config`

## Testing
- `docker compose config`

------
https://chatgpt.com/codex/tasks/task_e_689365c97ff8832db47569122933f2af