### PR TITLE
Use gpt-oss 20b image in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # Set DOCKERFILE=Dockerfile.cpu to build a CPU-only image
 services:
   gptoss:
-    image: ghcr.io/openai/gpt-oss:latest
+    image: ghcr.io/openai/gpt-oss:20b
     ports:
       - "8003:8000"
     volumes:
@@ -153,7 +153,7 @@ services:
         soft: 65536
         hard: 65536
   gptoss_check:
-    image: ghcr.io/openai/gpt-oss:latest
+    image: ghcr.io/openai/gpt-oss:20b
     command: python3 gptoss_check/check_code.py
     working_dir: /workspace
     volumes:


### PR DESCRIPTION
## Summary
- use ghcr.io/openai/gpt-oss:20b for gptoss and gptoss_check services

## Testing
- `pytest -q | tail -n 20`
- `docker compose pull gptoss gptoss_check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689386420ab4832db6d4de89e385762f