### PR TITLE
Potential fix for code scanning alert no. 757: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,4 +1,6 @@
 name: Build and Push Docker image
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/averinaleks/bot/security/code-scanning/757](https://github.com/averinaleks/bot/security/code-scanning/757)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since this workflow only checks out code and pushes to Docker Hub (using Docker Hub credentials, not the `GITHUB_TOKEN`), it does not require any write permissions to the repository. The minimal required permission is `contents: read`. This block should be added at the top level of the workflow (just after the `name:` line and before `on:`), so it applies to all jobs in the workflow. No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
