### PR TITLE
Use GitHub source for zlib in CI Dockerfile

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
         python3.12-dev \
         python3.12-venv \
     && python3.12 -m ensurepip --upgrade \
-    && curl -L https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
+    && curl -fsSL https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
     && tar -xf zlib.tar.gz \
     && cd zlib-${ZLIB_VERSION} && ./configure --prefix=/usr && make -j"$(nproc)" && make install && cd .. \
     && rm -rf zlib.tar.gz zlib-${ZLIB_VERSION} \


### PR DESCRIPTION
## Summary
- Download zlib from GitHub releases in CI image and fail fast on HTTP errors

## Testing
- `pre-commit run --files Dockerfile.ci`
- `docker build -f Dockerfile.ci -t ci-test .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_6893ad4bcc9c832d8a15fac658e10ba7