### PR TITLE
fix: correct mpmath requirement

### DIFF
--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -237,7 +237,7 @@ mlflow-skinny>=3.2.0
     # via mlflow
 mlflow-tracing>=3.2.0
     # via mlflow
-mpmath>=.3.0
+mpmath>=1.3.0
     # via sympy
 msgpack>=1.1.1
     # via ray


### PR DESCRIPTION
## Summary
- fix typo in CPU requirements for mpmath dependency

## Testing
- `python -m pip install --dry-run -r requirements-cpu.txt`
- `python -m pre_commit run --files requirements-cpu.txt` *(fails: AttributeError: module 'requests' has no attribute 'Response')*


------
https://chatgpt.com/codex/tasks/task_e_689499cfddc4832daeed722c4e6e3c5b