### PR TITLE
Log unexpected GPT response structure

### DIFF
--- a/gpt_client.py
+++ b/gpt_client.py
@@ -25,5 +25,10 @@ def query_gpt(prompt: str) -> str:
         return ""
     try:
         return data["completions"][0]["text"]
-    except (KeyError, IndexError, TypeError):
+    except (KeyError, IndexError, TypeError) as exc:
+        logger.warning(
+            "Unexpected response structure from GPT OSS API: %s | data: %r",
+            exc,
+            data,
+        )
         return ""


### PR DESCRIPTION
## Summary
- warn when GPT OSS API returns unexpected structure
- return empty string after logging to maintain safe fallback

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689499a7e8d8832d9bb41f7250e00caa