### PR TITLE
Fix GPT client endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,9 @@
       отсутствуют. В этом случае Telegram уведомления отправляться не будут.
     - `TRADE_RISK_USD` — величина риска в долларах для расчёта размера позиции,
       если `/open_position` получает только `price`.
-    - `GPT_OSS_API` — адрес сервиса [GPT OSS](https://github.com/jina-ai/gpt-oss),
-      к которому обращается функция `query_gpt` для анализа кода. Например:
+    - `GPT_OSS_API` — базовый адрес сервиса [GPT OSS](https://github.com/jina-ai/gpt-oss)
+      (без суффикса `/completions`), к которому обращается функция
+      `query_gpt` для анализа кода. Например:
 
       ```python
       from bot.gpt_client import query_gpt

--- a/gpt_client.py
+++ b/gpt_client.py
@@ -11,7 +11,8 @@ def query_gpt(prompt: str) -> str:
     The API endpoint is read from the ``GPT_OSS_API`` environment variable.
     If it is not set, ``http://localhost:8003`` is used.
     """
-    url = os.getenv("GPT_OSS_API", "http://localhost:8003")
+    api_url = os.getenv("GPT_OSS_API", "http://localhost:8003")
+    url = api_url.rstrip("/") + "/completions"
     try:
         response = requests.post(url, json={"prompt": prompt}, timeout=5)
         response.raise_for_status()
@@ -24,7 +25,7 @@ def query_gpt(prompt: str) -> str:
         logger.exception("Invalid JSON response from GPT OSS API: %s", exc)
         return ""
     try:
-        return data["completions"][0]["text"]
+        return data["choices"][0]["text"]
     except (KeyError, IndexError, TypeError) as exc:
         logger.warning(
             "Unexpected response structure from GPT OSS API: %s | data: %r",


### PR DESCRIPTION
## Summary
- Correct GPT OSS endpoint by appending `/completions`
- Parse GPT OSS responses via `choices[0].text`
- Clarify GPT_OSS_API documentation

## Testing
- `pytest tests/test_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6894ab7a6238832dbff28bd245e93ac9