### PR TITLE
refactor: make run_once async

### DIFF
--- a/tests/test_integration_services.py
+++ b/tests/test_integration_services.py
@@ -1,4 +1,3 @@
-import asyncio
 import os
 import requests
 import multiprocessing
@@ -6,6 +5,7 @@ import sys
 import signal
 from contextlib import ExitStack
 from flask import Flask, request, jsonify
+import asyncio
 import pytest
 
 from tests.helpers import get_free_port, service_process
@@ -111,7 +111,7 @@ def test_services_communicate(monkeypatch):
         monkeypatch.setenv('DATA_HANDLER_URL', f'http://localhost:{dh_port}')
         monkeypatch.setenv('MODEL_BUILDER_URL', f'http://localhost:{mb_port}')
         monkeypatch.setenv('TRADE_MANAGER_URL', f'http://localhost:{tm_port}')
-        trading_bot.run_once()
+        asyncio.run(trading_bot.run_once_async())
         resp = requests.get(f'http://localhost:{tm_port}/positions', timeout=5)
         data = resp.json()
         assert data['positions'], 'position was not created'

--- a/tests/test_trading_bot.py
+++ b/tests/test_trading_bot.py
@@ -282,7 +282,7 @@ def test_run_once_invalid_price(monkeypatch):
         "trade_manager_url": "http://tm",
     })
 
-    trading_bot.run_once()
+    asyncio.run(trading_bot.run_once_async())
     assert not sent
 
 
@@ -347,7 +347,7 @@ def test_run_once_price_error(monkeypatch):
         "trade_manager_url": "http://tm",
     })
 
-    trading_bot.run_once()
+    asyncio.run(trading_bot.run_once_async())
     assert not called["pred"]
 
 
@@ -376,7 +376,7 @@ def test_run_once_forwards_prediction_params(monkeypatch):
         },
     )
 
-    trading_bot.run_once()
+    asyncio.run(trading_bot.run_once_async())
     assert sent == {"tp": 110, "sl": 90, "trailing_stop": 1}
 
 
@@ -408,7 +408,7 @@ def test_run_once_env_fallback(monkeypatch):
     monkeypatch.setenv("SL", "5")
     monkeypatch.setenv("TRAILING_STOP", "2")
 
-    trading_bot.run_once()
+    asyncio.run(trading_bot.run_once_async())
     assert sent == {"tp": 10.0, "sl": 5.0, "trailing_stop": 2.0}
 
 
@@ -443,7 +443,7 @@ def test_run_once_config_fallback(monkeypatch):
     monkeypatch.setattr(trading_bot.CFG, "sl_multiplier", 0.9, raising=False)
     monkeypatch.setattr(trading_bot.CFG, "trailing_stop_multiplier", 0.05, raising=False)
 
-    trading_bot.run_once()
+    asyncio.run(trading_bot.run_once_async())
     assert sent == {
         "tp": pytest.approx(110.0),
         "sl": pytest.approx(90.0),
@@ -483,7 +483,7 @@ def test_run_once_ignores_invalid_env(monkeypatch):
     monkeypatch.setattr(trading_bot.CFG, "sl_multiplier", 0.9, raising=False)
     monkeypatch.setattr(trading_bot.CFG, "trailing_stop_multiplier", 0.05, raising=False)
 
-    trading_bot.run_once()
+    asyncio.run(trading_bot.run_once_async())
     assert sent == {
         "tp": pytest.approx(110.0),
         "sl": pytest.approx(90.0),
@@ -518,6 +518,6 @@ def test_run_once_logs_prediction(monkeypatch, caplog):
     )
 
     with caplog.at_level("INFO"):
-        trading_bot.run_once()
+        asyncio.run(trading_bot.run_once_async())
 
     assert "Prediction: buy" in caplog.messages


### PR DESCRIPTION
## Summary
- refactor run_once into async run_once_async and await prediction fetches
- run main logic inside a single asyncio loop with main_async
- update tests for new async entry point

## Testing
- `SKIP=pytest pre-commit run --files trading_bot.py tests/test_trading_bot.py tests/test_integration_services.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894c3b9f048832da01555927f27874f