### PR TITLE
Add async trade sending

### DIFF
--- a/tests/test_data_handler.py
+++ b/tests/test_data_handler.py
@@ -619,7 +619,7 @@ async def test_trade_callback_invoked(monkeypatch, tmp_path):
         async def get(self, url, timeout=None):
             records.append(("get", url))
             return types.SimpleNamespace(status_code=200, json=lambda: {"price": 1.0})
-        async def post(self, url, json=None, timeout=None):
+        async def post(self, url, json=None, timeout=None, headers=None):
             records.append(("post", url, json))
             if url.endswith("/predict"):
                 return types.SimpleNamespace(status_code=200, json=lambda: {"signal": "buy"})


### PR DESCRIPTION
## Summary
- add `send_trade_async` using `httpx.AsyncClient`
- use async trade sending in `reactive_trade` and `run_once`
- adjust tests for new async interfaces

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894c3be6280832d933ad74a90f28671