### PR TITLE
Fix nested event loop in run_once_async

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -503,16 +503,14 @@ async def run_once_async() -> None:
         )
         tp, sl, trailing_stop = _resolve_trade_params(tp, sl, trailing_stop, price)
         logger.info("Sending trade: %s %s @ %s", SYMBOL, signal, price)
-        asyncio.run(
-            send_trade_async(
-                SYMBOL,
-                signal,
-                price,
-                env,
-                tp=tp,
-                sl=sl,
-                trailing_stop=trailing_stop,
-            )
+        await send_trade_async(
+            SYMBOL,
+            signal,
+            price,
+            env,
+            tp=tp,
+            sl=sl,
+            trailing_stop=trailing_stop,
         )
 
 


### PR DESCRIPTION
## Summary
- Avoid calling `asyncio.run` inside `run_once_async`
- Await `send_trade_async` directly to prevent event loop errors

## Testing
- `pytest tests/test_trading_bot.py::test_run_once_forwards_prediction_params tests/test_trading_bot.py::test_run_once_env_fallback tests/test_trading_bot.py::test_run_once_config_fallback tests/test_trading_bot.py::test_run_once_ignores_invalid_env tests/test_trading_bot.py::test_run_once_logs_prediction -q`
- `pytest -m "not integration" -q` *(fails: assert not dh.ws_queue.empty, AttributeError: type object 'mem' has no attribute 'available', assert False)*

------
https://chatgpt.com/codex/tasks/task_e_6895b7a60e50832db6bd93439915772a