### PR TITLE
Use latest GPT-OSS image in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # Set DOCKERFILE=Dockerfile.cpu to build a CPU-only image
 services:
   gptoss:
-    image: ghcr.io/openai/gpt-oss:20b
+    image: ghcr.io/openai/gpt-oss:latest
     ports:
       - "8003:8000"
     volumes:
@@ -153,7 +153,7 @@ services:
         soft: 65536
         hard: 65536
   gptoss_check:
-    image: ghcr.io/openai/gpt-oss:20b
+    image: ghcr.io/openai/gpt-oss:latest
     command: python3 gptoss_check/check_code.py
     working_dir: /workspace
     volumes:


### PR DESCRIPTION
## Summary
- update gptoss and gptoss_check services to pull `ghcr.io/openai/gpt-oss:latest`

## Testing
- `SKIP=pytest pre-commit run --files docker-compose.yml`
- `docker pull ghcr.io/openai/gpt-oss:latest` *(fails: command not found)*
- `docker-compose pull gptoss` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895ce979540832d929ac494a210fbe7