### PR TITLE
Use repository-relative paths in GPT OSS code check

### DIFF
--- a/gptoss_check/check_code.py
+++ b/gptoss_check/check_code.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import requests
 
 
@@ -33,8 +34,8 @@ def send_telegram(msg: str) -> None:
 files = ("main.py", "strategy.py", "utils.py")
 
 for filename in files:
-    path = f"/repo/{filename}"
-    if os.path.exists(path):
+    path = Path(__file__).resolve().parent.parent / filename
+    if path.exists():
         with open(path, encoding="utf-8") as f:
             code = f.read()
 


### PR DESCRIPTION
## Summary
- Resolve check_code file paths relative to the repository instead of `/repo`
- Add `pathlib.Path` import for portable path handling

## Testing
- `python - <<'PY'
import os
class DummyResponse:
    def __init__(self):
        self.status_code = 200
    def raise_for_status(self):
        pass
    def json(self):
        return {'choices':[{'text':'dummy'}]}
import requests
requests.post = lambda *args, **kwargs: DummyResponse()
os.environ['GPT_OSS_API'] = 'http://localhost'
from gptoss_check import check_code
PY`
- `pytest -q` *(fails: DataLoader worker (pid 5517) exited unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_6895d1838680832dbf82cbe921c528e2