### PR TITLE
docs: add GHCR token secret requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,13 @@ pip-compile requirements-cpu.in        # updates requirements-cpu.txt
 
 Commit both the `.in` and generated `.txt` files when updating.
 
+## Repository secrets
+
+Some GitHub Actions workflows pull container images from GitHub Container Registry
+(GHCR). These workflows expect a secret named `TOKEN` that provides a personal
+access token with the `read:packages` scope so the runner can authenticate and
+download images from GHCR.
+
 ## CI troubleshooting
 
 GitHub Actions occasionally fails to start a runner or download dependencies, reporting a temporary error. In most cases simply rerunning the workflow resolves the problem. If failures persist you can set up a [self-hosted runner](https://docs.github.com/actions/hosting-your-own-runners) to avoid queueing delays and network issues. For stubborn issues contact [GitHub Support](https://support.github.com/). Include the **correlation ID** from the failed run's `View raw logs` page so they can investigate.


### PR DESCRIPTION
## Summary
- document GHCR `TOKEN` secret requirement for workflows

## Testing
- `pre-commit run --files CONTRIBUTING.md`
- `pytest` *(fails: tests/test_model_builder.py::test_train_model_remote_tft_predictions - RuntimeError: DataLoader worker (pid(s) ...)*)

------
https://chatgpt.com/codex/tasks/task_e_6895d207b6f0832da5a65b613f1089d3