### PR TITLE
Start GPT-OSS service for code review checks

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -23,4 +23,4 @@ jobs:
           password: ${{ secrets.TOKEN }}
 
       - name: Run gptoss review in Docker
-        run: docker compose run gptoss_check
+        run: docker compose up --exit-code-from gptoss_check gptoss gptoss_check

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,9 +160,9 @@ services:
       - .:/workspace
     environment:
       PYTHONUNBUFFERED: "1"
+      GPT_OSS_API: http://gptoss:8000
     depends_on:
-      gptoss:
-        condition: service_healthy  # Wait for GPT-OSS to be healthy
+      - gptoss
     networks:
       - gptoss_net
 networks:


### PR DESCRIPTION
## Summary
- ensure `gptoss_check` starts after GPT-OSS and has API URL in compose
- start both `gptoss` and `gptoss_check` in the GPT-OSS review workflow

## Testing
- `pre-commit run --files docker-compose.yml .github/workflows/gptoss_review.yml`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895d208b9e0832d9a7bbc1b87384630