### PR TITLE
Fix missing imports in GPT-OSS check utility

### DIFF
--- a/gptoss_check/check_code.py
+++ b/gptoss_check/check_code.py
@@ -1,5 +1,9 @@
 import os
+import time
+from pathlib import Path
 
+import requests
+from requests.exceptions import RequestException
 
 def query(prompt: str) -> str:
     """Отправить текст на сервер GPT-OSS и вернуть полученный ответ."""


### PR DESCRIPTION
## Summary
- Add imports for requests, time, and Path in check_code script

## Testing
- `flake8 .`
- `pytest -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_6895e7f57e88832da9bdf11901eed739