### PR TITLE
Use Docker Hub image and auth in workflows

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,12 +17,12 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.AVERINALEKS }}
-          password: ${{ secrets.BOT }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
           push: true
-          tags: averinaleks/myapp:latest
+          tags: averinaleks/bot:latest

--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -15,12 +15,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Login to GitHub Container Registry
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Run gptoss review in Docker
         run: docker compose up --exit-code-from gptoss_check gptoss gptoss_check

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # Set DOCKERFILE=Dockerfile.cpu to build a CPU-only image
 services:
   gptoss:
-    image: ghcr.io/openai/gpt-oss:latest
+    image: docker.io/averinaleks/bot:latest
     ports:
       - "8003:8000"
     volumes:
@@ -153,7 +153,7 @@ services:
         soft: 65536
         hard: 65536
   gptoss_check:
-    image: ghcr.io/openai/gpt-oss:latest
+    image: docker.io/averinaleks/bot:latest
     command: python3 gptoss_check/check_code.py
     working_dir: /workspace
     volumes:


### PR DESCRIPTION
## Summary
- pull bot image from Docker Hub instead of ghcr
- authenticate to Docker Hub in gptoss review workflow
- build & push averinaleks/bot image in publish workflow

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml .github/workflows/gptoss_review.yml docker-compose.yml`

------
https://chatgpt.com/codex/tasks/task_e_689874db9fd4832d8a092e139b04e2ca