### PR TITLE
Use Ubuntu 24.04 with system Python in CPU image

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,13 +1,11 @@
-FROM ubuntu:22.04 AS builder
+FROM ubuntu:24.04 AS builder
 ARG ZLIB_VERSION=1.3.1
 
 RUN apt-get update && apt-get upgrade -y linux-libc-dev && apt-get install -y --no-install-recommends \
-    software-properties-common \
     linux-libc-dev \
     build-essential \
     curl \
-    && add-apt-repository ppa:deadsnakes/ppa \
-    && apt-get update && apt-get install -y --no-install-recommends python3.12 python3.12-venv python3.12-dev \
+    python3 python3-venv python3-dev \
     && curl -L https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
     && tar -xf zlib.tar.gz \
     && cd zlib-${ZLIB_VERSION} && ./configure --prefix=/usr && make -j"$(nproc)" && make install && cd .. \
@@ -20,28 +18,26 @@ WORKDIR /app
 COPY requirements-cpu.txt .
 
 ENV VIRTUAL_ENV=/app/venv
-RUN python3.12 -m venv $VIRTUAL_ENV && \
+RUN python3 -m venv $VIRTUAL_ENV && \
     $VIRTUAL_ENV/bin/pip install --no-cache-dir pip==24.0 setuptools==78.1.1 wheel && \
     $VIRTUAL_ENV/bin/pip install --no-cache-dir -r requirements-cpu.txt && \
     find $VIRTUAL_ENV -type d -name '__pycache__' -exec rm -rf {} + && \
     find $VIRTUAL_ENV -type f -name '*.pyc' -delete
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 ARG ZLIB_VERSION=1.3.1
 
 RUN apt-get update && apt-get upgrade -y linux-libc-dev && apt-get install -y --no-install-recommends \
-    software-properties-common \
     curl \
     linux-libc-dev \
-    && add-apt-repository ppa:deadsnakes/ppa \
-    && apt-get update && apt-get install -y --no-install-recommends python3.12 python3.12-venv python3.12-dev \
+    python3 python3-venv python3-dev \
     && curl -L https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
     && tar -xf zlib.tar.gz \
     && cd zlib-${ZLIB_VERSION} && ./configure --prefix=/usr && make -j"$(nproc)" && make install && cd .. \
     && rm -rf zlib.tar.gz zlib-${ZLIB_VERSION} \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && ldconfig \
-    && python3.12 --version
+    && python3 --version
 
 WORKDIR /app
 
@@ -56,4 +52,4 @@ RUN echo "Checking package versions..." && \
     $VIRTUAL_ENV/bin/python -c "import torch, tensorflow as tf; print('Torch:', torch.__version__, 'TF:', tf.__version__)" && \
     $VIRTUAL_ENV/bin/python -c "import stable_baselines3 as sb3, mlflow, pytorch_lightning as pl; print('SB3:', sb3.__version__, 'MLflow:', mlflow.__version__, 'Lightning:', pl.__version__)"
 
-CMD ["/app/venv/bin/python3.12", "-m", "bot.trading_bot"]
+CMD ["/app/venv/bin/python", "-m", "bot.trading_bot"]


### PR DESCRIPTION
## Summary
- Update CPU Dockerfile to base on Ubuntu 24.04
- Use system Python 3 with venv instead of deadsnakes PPA

## Testing
- `pytest`
- `docker build -f Dockerfile.cpu -t bot-cpu:latest .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_689879abf8e8832d807f3bf063f5f146