### PR TITLE
chore(ci): upgrade Dockerfile to ubuntu 24.04

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,33 +1,29 @@
 # syntax=docker/dockerfile:1
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG ZLIB_VERSION=1.3.1
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
-    gnupg \
-    software-properties-common \
     linux-libc-dev \
     build-essential \
     curl \
-    && add-apt-repository ppa:deadsnakes/ppa \
-    && apt-get update && apt-get install -y --no-install-recommends \
-        python3.12 \
-        python3.12-dev \
-        python3.12-venv \
-    && python3.12 -m ensurepip --upgrade \
+    python3 \
+    python3-dev \
+    python3-venv \
+    && python3 -m ensurepip --upgrade \
     && curl -fsSL https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
     && tar -xf zlib.tar.gz \
     && cd zlib-${ZLIB_VERSION} && ./configure --prefix=/usr && make -j"$(nproc)" && make install && cd .. \
     && rm -rf zlib.tar.gz zlib-${ZLIB_VERSION} \
-    && apt-get purge -y --auto-remove build-essential curl gnupg software-properties-common \
+    && apt-get purge -y --auto-remove build-essential curl \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && ldconfig
 
 WORKDIR /app
 
 # Install only linting tools
-RUN python3.12 -m pip install --no-cache-dir flake8
+RUN python3 -m pip install --no-cache-dir flake8
 
 # Copy files required for static analysis
 COPY .pre-commit-config.yaml .flake8 .pylintrc requirements.txt requirements-cpu.txt ./


### PR DESCRIPTION
## Summary
- use Ubuntu 24.04 as CI base image
- install Python 3 from default repo and drop deadsnakes PPA
- ensure lint tooling installed with python3

## Testing
- `pre-commit run --files Dockerfile.ci`
- `python3 -m pip install --no-cache-dir flake8`
- `curl ... && ./configure && make && make install` (zlib build)
- `docker build -f Dockerfile.ci -t bot-ci-test .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_689879ab3d5c832d887b29225e70e0a5