### PR TITLE
Fix CI Dockerfile pip installation

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -11,7 +11,8 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     python3 \
     python3-dev \
     python3-venv \
-    && python3 -m ensurepip --upgrade \
+    python3-pip \
+    && python3 -m pip install --upgrade pip \
     && curl -fsSL https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
     && tar -xf zlib.tar.gz \
     && cd zlib-${ZLIB_VERSION} && ./configure --prefix=/usr && make -j"$(nproc)" && make install && cd .. \


### PR DESCRIPTION
## Summary
- install python3-pip and upgrade pip in CI Dockerfile to avoid ensurepip failure on Ubuntu

## Testing
- `python3 -m pre_commit run --files Dockerfile.ci` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68987e7322b0832d914a862e1d784add