### PR TITLE
Fix send_telegram docstring indentation

### DIFF
--- a/gptoss_check/check_code.py
+++ b/gptoss_check/check_code.py
@@ -30,7 +30,7 @@ def query(prompt: str) -> str:
 
 
 def send_telegram(msg: str) -> None:
-"""Отправить сообщение в Telegram, если заданы токен и chat_id."""
+    """Отправить сообщение в Telegram, если заданы токен и chat_id."""
     token = os.getenv("TELEGRAM_BOT_TOKEN")
     chat_id = os.getenv("TELEGRAM_CHAT_ID")
     if token and chat_id:


### PR DESCRIPTION
## Summary
- Format `send_telegram` function with a proper docstring

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68987e186f00832db99f0aa1129b316e