### PR TITLE
Enable system-wide pip installs in CI Dockerfile

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -4,6 +4,8 @@ FROM ubuntu:24.04
 ARG DEBIAN_FRONTEND=noninteractive
 ARG ZLIB_VERSION=1.3.1
 
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     linux-libc-dev \
     build-essential \


### PR DESCRIPTION
## Summary
- allow pip to modify system packages by setting `PIP_BREAK_SYSTEM_PACKAGES=1` in the CI Dockerfile.

## Testing
- `python3 -m pre_commit run --files Dockerfile.ci`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689885764f80832da1a3452ce4ab7cfb