### PR TITLE
Install pip via get-pip in CI Dockerfile

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -13,8 +13,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     python3 \
     python3-dev \
     python3-venv \
-    python3-pip \
-    && python3 -m pip install --break-system-packages --upgrade pip \
+    && curl -sS https://bootstrap.pypa.io/get-pip.py | python3 - \
     && curl -fsSL https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
     && tar -xf zlib.tar.gz \
     && cd zlib-${ZLIB_VERSION} && ./configure --prefix=/usr && make -j"$(nproc)" && make install && cd .. \


### PR DESCRIPTION
## Summary
- Remove python3-pip from CI Dockerfile and install pip using get-pip.py
- Drop legacy pip upgrade step while retaining zlib build

## Testing
- `pytest -q`
- `docker build -t bot-ci -f Dockerfile.ci .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68989ca6b304832db9b29d2f648ef188