### PR TITLE
Force pip reinstall in CI Dockerfile

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     python3-dev \
     python3-venv \
     python3-pip \
-    && python3 -m pip install --break-system-packages --upgrade pip \
+    && python3 -m pip install --no-cache-dir --break-system-packages --force-reinstall --upgrade pip \
     && curl -fsSL https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
     && tar -xf zlib.tar.gz \
     && cd zlib-${ZLIB_VERSION} && ./configure --prefix=/usr && make -j"$(nproc)" && make install && cd .. \


### PR DESCRIPTION
## Summary
- ensure CI image upgrades pip with a forced reinstall and no cache

## Testing
- `SKIP=pytest python3 -m pre_commit run --files Dockerfile.ci`
- `pytest tests/test_backtest_loop.py`
- `docker build -f Dockerfile.ci -t test-ci .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68989caab5b8832d929e0f664f5ccac1