### PR TITLE
fix: correct gptoss review workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       GPUS: 0
       DOCKERFILE: Dockerfile.cpu
-  steps:
+    steps:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Login to Docker Hub
@@ -23,6 +23,5 @@ jobs:
         with:
           username: ${{ secrets.AVERINALEKS }}
           password: ${{ secrets.BOT }}
-
       - name: Run gptoss review in Docker
         run: docker compose up --exit-code-from gptoss_check gptoss gptoss_check


### PR DESCRIPTION
## Summary
- move steps under review job in gptoss review workflow
- remove stray trailing text from run command

## Testing
- `pre-commit run --files .github/workflows/gptoss_review.yml`


------
https://chatgpt.com/codex/tasks/task_e_6898a430c038832d83b87191552f3434