### PR TITLE
Make GPT-OSS GPU optional with CPU compose override

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -24,4 +24,5 @@ jobs:
           username: ${{ secrets.AVERINALEKS }}
           password: ${{ secrets.BOT }}
       - name: Run gptoss review in Docker
-        run: docker compose up --exit-code-from gptoss_check gptoss gptoss_check
+        run: docker compose -f docker-compose.yml -f docker-compose.cpu.yml up --exit-code-from gptoss_check gptoss gptoss_check
+

--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -1,0 +1,5 @@
+services:
+  gptoss:
+    # CPU-only override removes GPU assignment
+    gpus: null
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - gptoss_workspace:/workspace
     environment:
       - TRANSFORMERS_CACHE=${TRANSFORMERS_CACHE}
-    gpus: ${GPUS:-0}
+    gpus: ${GPUS:-all}
     # Ensure the GPT-OSS API is ready before other services start
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/v1/health"]


### PR DESCRIPTION
## Summary
- default GPT-OSS service to use all available GPUs
- add docker-compose.cpu.yml to remove GPU requirement for CPU-only runs
- update GPT-OSS code review workflow to use CPU override

## Testing
- `SKIP=pytest pre-commit run --files docker-compose.yml docker-compose.cpu.yml .github/workflows/gptoss_review.yml`
- `pytest tests/test_env_parsing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6898aa6e35d4832d8f740a8a6a50d5ec