### PR TITLE
fix: ensure gptoss review steps indentation

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -1,9 +1,10 @@
+---
 name: GPT-OSS Code Review
 permissions:
   contents: read
   packages: read
 
-on:
+'on':
   push:
     paths:
       - 'bot/**.py'


### PR DESCRIPTION
## Summary
- correctly nest workflow steps under review job
- add YAML document start and quote workflow trigger to satisfy yamllint

## Testing
- `yamllint .github/workflows/gptoss_review.yml && echo LINT_OK`


------
https://chatgpt.com/codex/tasks/task_e_6898aa75a664832d92e7f76e395522b2