### PR TITLE
Use explicit GPU settings for gptoss

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -14,7 +14,6 @@ jobs:
   review:
     runs-on: ubuntu-latest
     env:
-      GPUS: 0
       DOCKERFILE: Dockerfile.cpu
     steps:
       - name: Checkout code

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - gptoss_workspace:/workspace
     environment:
       - TRANSFORMERS_CACHE=${TRANSFORMERS_CACHE}
-    gpus: ${GPUS:-all}
+    gpus: all
     # Ensure the GPT-OSS API is ready before other services start
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/v1/health"]


### PR DESCRIPTION
## Summary
- remove GPUS env var from review workflow
- default gptoss service to `gpus: all`
- keep CPU compose override with `gpus: null`

## Testing
- `pre-commit run --files .github/workflows/gptoss_review.yml docker-compose.yml`

------
https://chatgpt.com/codex/tasks/task_e_6898af3c6a08832d9a075f928f0e16eb