### PR TITLE
Use CPU Dockerfile for publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,5 +25,6 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          file: Dockerfile.cpu
           push: true
           tags: averinaleks/myapp:latest


### PR DESCRIPTION
## Summary
- build docker images from Dockerfile.cpu in publish workflow to reduce disk usage

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml`
- `docker build -f Dockerfile.cpu --target builder .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6898b1b871e0832dbbf9116c03f10b45