### PR TITLE
chore: set noninteractive frontend for apt

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,4 +1,5 @@
 FROM ubuntu:24.04 AS builder
+ARG DEBIAN_FRONTEND=noninteractive
 ARG ZLIB_VERSION=1.3.1
 
 RUN apt-get update && apt-get upgrade -y linux-libc-dev && apt-get install -y --no-install-recommends \
@@ -25,6 +26,7 @@ RUN python3 -m venv $VIRTUAL_ENV && \
     find $VIRTUAL_ENV -type f -name '*.pyc' -delete
 
 FROM ubuntu:24.04
+ARG DEBIAN_FRONTEND=noninteractive
 ARG ZLIB_VERSION=1.3.1
 
 RUN apt-get update && apt-get upgrade -y linux-libc-dev && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary
- ensure Dockerfile.cpu uses DEBIAN_FRONTEND=noninteractive before package installs to avoid interactive prompts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898c0584318832d9564730c2c0dd616