### PR TITLE
Clear GPU requests in CPU compose override

### DIFF
--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -1,5 +1,7 @@
 services:
   gptoss:
     # CPU-only override removes GPU assignment
-    gpus: null
+    gpus: ""
+  gptoss_check:
+    gpus: ""
 


### PR DESCRIPTION
## Summary
- Ensure CPU override clears GPU allocation for gptoss and gptoss_check

## Testing
- `pytest -q`
- `docker-compose -f docker-compose.yml -f docker-compose.cpu.yml up --exit-code-from gptoss_check gptoss gptoss_check` *(fails: Unsupported config option for services.gptoss: 'gpus')*


------
https://chatgpt.com/codex/tasks/task_e_6898c1ffa410832d9d015616a24ac19a