### PR TITLE
Split compose configs into CPU and GPU profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@
     запустите контейнеры с `LOG_LEVEL=DEBUG`:
 
     ```bash
-    LOG_LEVEL=DEBUG docker compose up --build
+    LOG_LEVEL=DEBUG docker compose -f docker-compose.yml -f docker-compose.cpu.yml up --build
     ```
 
     Непрерывный вывод смотрите в файлах внутри `./logs/`.
@@ -218,7 +218,7 @@ at runtime. If you switch to a runtime-only base (for example
 or Numba will fall back to CPU mode. Build and run the GPU image with:
 
 ```bash
-DOCKERFILE=Dockerfile docker compose up --build
+DOCKERFILE=Dockerfile docker compose -f docker-compose.yml -f docker-compose.gpu.yml up --build
 ```
 
 Setting `FORCE_CPU=1` disables all CUDA checks, which helps avoid crashes such as
@@ -343,7 +343,8 @@ earlier, simply revert those lines or copy the compose file from the repository
 again.  After restoring the Gunicorn commands, run:
 
 ```bash
-docker compose up --build
+docker compose -f docker-compose.yml -f docker-compose.cpu.yml up --build    # CPU
+docker compose -f docker-compose.yml -f docker-compose.gpu.yml up --build    # GPU
 ```
 
 so the heavy frameworks load and the services expose their production APIs.
@@ -373,7 +374,7 @@ docker-compose logs model_builder
 и укажите `RUNTIME=`, чтобы отключить NVIDIA‑runtime:
 
 ```bash
-RUNTIME= DOCKERFILE=Dockerfile.cpu docker compose up --build
+RUNTIME= DOCKERFILE=Dockerfile.cpu docker compose -f docker-compose.yml -f docker-compose.cpu.yml up --build
 ```
 
 ## Troubleshooting service health
@@ -393,13 +394,13 @@ use these steps to diagnose the problem:
    `nvidia-docker2`). Verify that the GPU is visible from a container:
 
    ```bash
-   docker compose run --rm data_handler nvidia-smi
+   docker compose -f docker-compose.yml -f docker-compose.gpu.yml run --rm data_handler nvidia-smi
    ```
 
    If no GPU is detected, rebuild with the CPU Dockerfile:
 
    ```bash
-   RUNTIME= DOCKERFILE=Dockerfile.cpu docker compose up --build
+   RUNTIME= DOCKERFILE=Dockerfile.cpu docker compose -f docker-compose.yml -f docker-compose.cpu.yml up --build
    ```
 
 3. If services require more time to initialize, increase

--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -1,7 +1,4 @@
+# CPU-only overrides (currently empty).
 services:
-  gptoss:
-    # CPU-only override removes GPU assignment
-    gpus: ""
-  gptoss_check:
-    gpus: ""
-
+  gptoss: {}
+  gptoss_check: {}

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -1,0 +1,5 @@
+services:
+  gptoss:
+    gpus: all
+  gptoss_check:
+    gpus: all

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
       - gptoss_workspace:/workspace
     environment:
       - TRANSFORMERS_CACHE=${TRANSFORMERS_CACHE}
-    gpus: all
     # Ensure the GPT-OSS API is ready before other services start
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/v1/health"]


### PR DESCRIPTION
## Summary
- drop GPU directives from default compose and add a dedicated GPU override file
- document how to launch CPU or GPU stacks using compose profiles
- ensure compose config renders correctly for CPU and GPU overlays

## Testing
- `docker compose -f docker-compose.yml -f docker-compose.cpu.yml config`
- `docker compose -f docker-compose.yml -f docker-compose.gpu.yml config`
- `docker compose -f docker-compose.yml -f docker-compose.cpu.yml up --no-start gptoss gptoss_check` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*
- `pre-commit run flake8 --files README.md docker-compose.yml docker-compose.gpu.yml docker-compose.cpu.yml`
- `pytest -m "not integration"`


------
https://chatgpt.com/codex/tasks/task_e_6898c6e66c64832d8f4facb9309ad578