### PR TITLE
feat: add jitter to retry backoff

### DIFF
--- a/gptoss_check/check_code.py
+++ b/gptoss_check/check_code.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 import time
+import random
 
 import requests
 from requests.exceptions import RequestException
@@ -44,6 +45,9 @@ def query(prompt: str) -> str:
         except RequestException as err:
             if attempt == max_retries:
                 raise RuntimeError(f"Ошибка запроса к GPT-OSS API: {err}") from err
+            delay = backoff + random.uniform(0, 0.5)
+            print(f"Попытка {attempt} не удалась, ожидание {delay:.2f} с")
+            time.sleep(delay)
             time.sleep(backoff)
             backoff *= 2
 


### PR DESCRIPTION
## Summary
- import random and add jitter-based delay before exponential backoff in GPT-OSS query helper
- log failed attempt number with calculated delay

## Testing
- `pre-commit run --files gptoss_check/check_code.py`
- `pytest` *(fails: RuntimeError: DataLoader worker (pid 7561) is killed by signal: Bus error)*

------
https://chatgpt.com/codex/tasks/task_e_6898cd6b5fa0832d900a51269fd1f9b7