### PR TITLE
chore: use official gpt-oss image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # Set DOCKERFILE=Dockerfile.cpu to build a CPU-only image
 services:
   gptoss:
-    image: averinaleks/myapp:latest
+    image: ghcr.io/openaccess-ai-collective/gpt-oss:cpu-latest
     ports:
       - "8003:8000"
     volumes:


### PR DESCRIPTION
## Summary
- run gpt-oss service with official ghcr.io image and default entrypoint

## Testing
- `pytest`
- `docker compose -f docker-compose.yml -f docker-compose.cpu.yml up gptoss gptoss_check` *(fails: unknown shorthand flag: 'f' in -f)*

------
https://chatgpt.com/codex/tasks/task_e_6898ead9bcd0832dbbb686a2545970b7