### PR TITLE
Use system zlib in Dockerfile.cpu

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,18 +1,13 @@
 FROM ubuntu:24.04 AS builder
 ARG DEBIAN_FRONTEND=noninteractive
-ARG ZLIB_VERSION=1.3.1
 
 RUN apt-get update && apt-get upgrade -y linux-libc-dev && apt-get install -y --no-install-recommends \
     linux-libc-dev \
     build-essential \
     curl \
     python3 python3-venv python3-dev \
-    && curl -L https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
-    && tar -xf zlib.tar.gz \
-    && cd zlib-${ZLIB_VERSION} && ./configure --prefix=/usr && make -j"$(nproc)" && make install && cd .. \
-    && rm -rf zlib.tar.gz zlib-${ZLIB_VERSION} \
-    && apt-get clean && rm -rf /var/lib/apt/lists/* \
-    && ldconfig
+    zlib1g-dev \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
@@ -33,11 +28,6 @@ RUN apt-get update && apt-get upgrade -y linux-libc-dev && apt-get install -y --
     python3 python3-venv python3-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && python3 --version
-
-COPY --from=builder /usr/include/zlib.h /usr/include/
-COPY --from=builder /usr/include/zconf.h /usr/include/
-COPY --from=builder /usr/lib/libz.so* /usr/lib/
-RUN ldconfig
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- install `zlib1g-dev` in builder stage instead of compiling zlib from source
- drop zlib artifact copies and `ldconfig` from final stage of `Dockerfile.cpu`

## Testing
- `SKIP=pytest pre-commit run --files Dockerfile.cpu`
- `pre-commit run --files Dockerfile.cpu` (interrupted: KeyboardInterrupt)
- `podman build -f Dockerfile.cpu -t bot-cpu .` (failed: operation not permitted)


------
https://chatgpt.com/codex/tasks/task_e_6898ec076b24832dad7b1d645c4b44cd