### PR TITLE
chore: strip GPU deps from CPU build

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -21,7 +21,7 @@ COPY requirements-cpu.txt .
 ENV VIRTUAL_ENV=/app/venv
 RUN python3 -m venv $VIRTUAL_ENV && \
     $VIRTUAL_ENV/bin/pip install --no-cache-dir pip==24.0 setuptools==78.1.1 wheel && \
-    $VIRTUAL_ENV/bin/pip install --no-cache-dir -r requirements-cpu.txt && \
+    $VIRTUAL_ENV/bin/pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -r requirements-cpu.txt && \
     find $VIRTUAL_ENV -type d -name '__pycache__' -exec rm -rf {} + && \
     find $VIRTUAL_ENV -type f -name '*.pyc' -delete
 
@@ -47,9 +47,10 @@ COPY . .
 ENV VIRTUAL_ENV=/app/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Verify that all heavy packages were installed
+# Verify that all heavy packages were installed and no GPU libraries remain
 RUN echo "Checking package versions..." && \
     $VIRTUAL_ENV/bin/python -c "import torch, tensorflow as tf; print('Torch:', torch.__version__, 'TF:', tf.__version__)" && \
+    $VIRTUAL_ENV/bin/python -m pip freeze | grep -i nvidia && (echo 'Unexpected NVIDIA packages found' && exit 1) || echo 'No NVIDIA packages installed' && \
     $VIRTUAL_ENV/bin/python -c "import stable_baselines3 as sb3, mlflow, pytorch_lightning as pl; print('SB3:', sb3.__version__, 'MLflow:', mlflow.__version__, 'Lightning:', pl.__version__)"
 
 CMD ["/app/venv/bin/python", "-m", "bot.trading_bot"]

--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -282,43 +282,6 @@ numpy>=2.1.3
     #   tensorflow-cpu
     #   torchmetrics
     #   torchvision
-nvidia-cublas-cu12==12.6.4.1
-    # via
-    #   nvidia-cudnn-cu12
-    #   nvidia-cusolver-cu12
-    #   torch
-nvidia-cuda-cupti-cu12==12.6.80
-    # via torch
-nvidia-cuda-nvrtc-cu12==12.6.77
-    # via torch
-nvidia-cuda-runtime-cu12==12.6.77
-    # via torch
-nvidia-cudnn-cu12==9.5.1.17
-    # via torch
-nvidia-cufft-cu12==11.3.0.4
-    # via torch
-nvidia-cufile-cu12==1.11.1.6
-    # via torch
-nvidia-curand-cu12==10.3.7.77
-    # via torch
-nvidia-cusolver-cu12==11.7.1.2
-    # via torch
-nvidia-cusparse-cu12==12.5.4.2
-    # via
-    #   nvidia-cusolver-cu12
-    #   torch
-nvidia-cusparselt-cu12==0.6.3
-    # via torch
-nvidia-nccl-cu12==2.26.2
-    # via torch
-nvidia-nvjitlink-cu12==12.6.85
-    # via
-    #   nvidia-cufft-cu12
-    #   nvidia-cusolver-cu12
-    #   nvidia-cusparse-cu12
-    #   torch
-nvidia-nvtx-cu12==12.6.77
-    # via torch
 opentelemetry-api>=1.36.0
     # via
     #   mlflow-skinny

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -1,0 +1,15 @@
+# GPU-specific requirements extracted from the full requirements
+nvidia-cublas-cu12==12.6.4.1
+nvidia-cuda-cupti-cu12==12.6.80
+nvidia-cuda-nvrtc-cu12==12.6.77
+nvidia-cuda-runtime-cu12==12.6.77
+nvidia-cudnn-cu12==9.5.1.17
+nvidia-cufft-cu12==11.3.0.4
+nvidia-cufile-cu12==1.11.1.6
+nvidia-curand-cu12==10.3.7.77
+nvidia-cusolver-cu12==11.7.1.2
+nvidia-cusparse-cu12==12.5.4.2
+nvidia-cusparselt-cu12==0.6.3
+nvidia-nccl-cu12==2.26.2
+nvidia-nvjitlink-cu12==12.6.85
+nvidia-nvtx-cu12==12.6.77


### PR DESCRIPTION
## Summary
- remove NVIDIA packages from CPU requirements
- add GPU-only dependency file
- ensure CPU Dockerfile installs from CPU wheels and fails if NVIDIA libs appear

## Testing
- `pytest -q`
- `docker build -f Dockerfile.cpu --target builder .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898ec0e9018832d895880899f379375