### PR TITLE
chore: slim runtime dependencies

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -27,10 +27,9 @@ RUN python3 -m venv $VIRTUAL_ENV && \
 
 FROM ubuntu:24.04
 
-RUN apt-get update && apt-get upgrade -y linux-libc-dev && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     curl \
-    linux-libc-dev \
-    python3 python3-venv python3-dev \
+    python3 python3-venv \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && python3 --version
 


### PR DESCRIPTION
## Summary
- remove development packages from Dockerfile.cpu runtime stage to keep image lean

## Testing
- `pre-commit run --files Dockerfile.cpu`
- `docker build -f Dockerfile.cpu -t testimage .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_6898ec142fe0832d9007e529c3d9abab