### PR TITLE
fix submodule cleanup command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Cleanup git submodules
+        run: git submodule foreach --recursive sh -c "git config --local gc.auto 0 || :" || :
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
@@ -42,6 +44,8 @@ jobs:
     needs: unit
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Cleanup git submodules
+        run: git submodule foreach --recursive sh -c "git config --local gc.auto 0 || :" || :
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'


### PR DESCRIPTION
## Summary
- ensure submodule cleanup command ends with `|| :`

## Testing
- `git submodule foreach --recursive sh -c "git config --local gc.auto 0 || :" || :`
- `pytest -m "not integration"`


------
https://chatgpt.com/codex/tasks/task_e_6898ed0b9acc832d9a28814137e0d7b5