### PR TITLE
ci: wrap submodule cleanup command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Cleanup git submodules
-        run: git submodule foreach --recursive sh -c "git config --local gc.auto 0 || :" || :
+        run: >
+          git submodule foreach --recursive sh -c "git config --local gc.auto 0 || :" || :
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
@@ -45,7 +46,8 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Cleanup git submodules
-        run: git submodule foreach --recursive sh -c "git config --local gc.auto 0 || :" || :
+        run: >
+          git submodule foreach --recursive sh -c "git config --local gc.auto 0 || :" || :
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'


### PR DESCRIPTION
## Summary
- wrap git submodule cleanup commands in folded blocks to ensure proper quoting

## Testing
- `python -m pre_commit run --files .github/workflows/ci.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898fd3472bc832dbbe2f2d4b35735b3