### PR TITLE
Raise structured GPT client errors and add tests

### DIFF
--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -1,0 +1,50 @@
+import pytest
+import requests
+
+from bot.gpt_client import (
+    GPTClientJSONError,
+    GPTClientNetworkError,
+    GPTClientResponseError,
+    query_gpt,
+)
+
+
+class DummyResponse:
+    def __init__(self, json_data=None, json_exc=None):
+        self._json_data = json_data
+        self._json_exc = json_exc
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        if self._json_exc:
+            raise self._json_exc
+        return self._json_data
+
+
+def test_query_gpt_network_error(monkeypatch):
+    def fake_post(*args, **kwargs):
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    with pytest.raises(GPTClientNetworkError):
+        query_gpt("hi")
+
+
+def test_query_gpt_non_json(monkeypatch):
+    def fake_post(*args, **kwargs):
+        return DummyResponse(json_exc=ValueError("no json"))
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    with pytest.raises(GPTClientJSONError):
+        query_gpt("hi")
+
+
+def test_query_gpt_missing_fields(monkeypatch):
+    def fake_post(*args, **kwargs):
+        return DummyResponse(json_data={"foo": "bar"})
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    with pytest.raises(GPTClientResponseError):
+        query_gpt("hi")

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -15,7 +15,7 @@ from dotenv import load_dotenv
 from tenacity import retry, stop_after_attempt, wait_exponential
 
 from bot.config import BotConfig
-from bot.gpt_client import query_gpt
+from bot.gpt_client import GPTClientError, query_gpt
 from bot.utils import logger
 
 load_dotenv()
@@ -526,7 +526,7 @@ async def main_async() -> None:
                 "Что ты видишь в этом коде:\n" + strategy_code
             )
             logger.info("GPT analysis: %s", gpt_result)
-        except Exception as exc:  # pragma: no cover - non-critical
+        except GPTClientError as exc:  # pragma: no cover - non-critical
             logger.debug("GPT analysis failed: %s", exc)
         while True:
             await run_once_async()


### PR DESCRIPTION
## Summary
- Replace `query_gpt` silent failures with explicit exceptions
- Handle `GPTClientError` in trading bot startup
- Add unit tests for network, JSON, and response-structure errors

## Testing
- `pytest tests/test_gpt_client.py tests/test_trading_bot.py::test_load_env_uses_host -q`


------
https://chatgpt.com/codex/tasks/task_e_6898ff75aca4832d986ce208cf5555c7