### PR TITLE
Add CodeQL config to disable Python2 probing

### DIFF
--- a/.github/codeql.yml
+++ b/.github/codeql.yml
@@ -1,0 +1,3 @@
+name: codeql-config
+build-mode: none
+python: ["3"]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,23 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  analyze:
+    runs-on: ubuntu-22.04
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: python
+          build-mode: none
+          config-file: .github/codeql.yml
+      - uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary
- add CodeQL configuration specifying `build-mode: none` and Python 3
- add CodeQL workflow using the new configuration

## Testing
- `pre-commit run --files .github/codeql.yml .github/workflows/codeql.yml`
- `docker ps` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_6898ff72bd3c832da6e6b1be795c2ce2