### PR TITLE
chore: clean up codeql config

### DIFF
--- a/.github/codeql.yml
+++ b/.github/codeql.yml
@@ -1,3 +1,1 @@
-name: codeql-config
 build-mode: none
-python: ["3"]


### PR DESCRIPTION
## Summary
- remove unsupported python key from CodeQL config

## Testing
- `pre-commit run --files .github/codeql.yml` *(fails: command not found: docker, cannot connect to daemon)*
- `pytest`
- `./bin/act -n -P ubuntu-latest=catthehacker/ubuntu:act-latest -W .github/workflows/codeql.yml` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_6899a2ff2c24832d87f0a39816f050bd