### PR TITLE
Add async GPT client and use in bot

### DIFF
--- a/gpt_client.py
+++ b/gpt_client.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import httpx
 import requests
 
 logger = logging.getLogger("TradingBot")
@@ -33,6 +34,37 @@ def query_gpt(prompt: str) -> str:
         response = requests.post(url, json={"prompt": prompt}, timeout=5)
         response.raise_for_status()
     except requests.RequestException as exc:  # pragma: no cover - network errors
+        logger.exception("Error querying GPT OSS API: %s", exc)
+        raise GPTClientNetworkError("Failed to query GPT OSS API") from exc
+    try:
+        data = response.json()
+    except ValueError as exc:
+        logger.exception("Invalid JSON response from GPT OSS API: %s", exc)
+        raise GPTClientJSONError("Invalid JSON response from GPT OSS API") from exc
+    try:
+        return data["choices"][0]["text"]
+    except (KeyError, IndexError, TypeError) as exc:
+        logger.warning(
+            "Unexpected response structure from GPT OSS API: %s | data: %r",
+            exc,
+            data,
+        )
+        raise GPTClientResponseError("Unexpected response structure from GPT OSS API") from exc
+
+
+async def query_gpt_async(prompt: str) -> str:
+    """Asynchronously send *prompt* to the GPT OSS API and return the first completion text.
+
+    Uses :class:`httpx.AsyncClient` for the HTTP request but mirrors the behaviour of
+    :func:`query_gpt` including error handling and environment configuration.
+    """
+    api_url = os.getenv("GPT_OSS_API", "http://localhost:8003")
+    url = api_url.rstrip("/") + "/completions"
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(url, json={"prompt": prompt}, timeout=5)
+            response.raise_for_status()
+    except httpx.HTTPError as exc:  # pragma: no cover - network errors
         logger.exception("Error querying GPT OSS API: %s", exc)
         raise GPTClientNetworkError("Failed to query GPT OSS API") from exc
     try:

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -15,7 +15,7 @@ from dotenv import load_dotenv
 from tenacity import retry, stop_after_attempt, wait_exponential
 
 from bot.config import BotConfig
-from bot.gpt_client import GPTClientError, query_gpt
+from bot.gpt_client import GPTClientError, query_gpt_async
 from bot.utils import logger
 
 load_dotenv()
@@ -522,7 +522,7 @@ async def main_async() -> None:
             strategy_code = (
                 Path(__file__).with_name("strategy_optimizer.py").read_text(encoding="utf-8")
             )
-            gpt_result = query_gpt(
+            gpt_result = await query_gpt_async(
                 "Что ты видишь в этом коде:\n" + strategy_code
             )
             logger.info("GPT analysis: %s", gpt_result)


### PR DESCRIPTION
## Summary
- implement `query_gpt_async` using `httpx.AsyncClient`
- call the async client from `main_async`
- test async GPT client failure modes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899aa2fac3c832d852911922646b0a6