### PR TITLE
Refine gptoss review workflow and CPU compose override

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -4,7 +4,7 @@ permissions:
   contents: read
   packages: read
 
-'on':
+on:
   push:
     paths:
       - 'bot/**.py'
@@ -17,16 +17,14 @@ jobs:
       DOCKERFILE: Dockerfile.cpu
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.AVERINALEKS }}
           password: ${{ secrets.BOT }}
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-      - name: Run gptoss review in Docker
-        run: docker compose -f docker-compose.yml -f docker-compose.cpu.yml up --exit-code-from gptoss_check gptoss gptoss_check
+      - name: Run gptoss review (CPU)
+        run: |
+          docker compose -f docker-compose.yml -f docker-compose.cpu.yml \
+            up --exit-code-from gptoss_check gptoss gptoss_check
 

--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -1,4 +1,1 @@
-# CPU-only overrides (currently empty).
-services:
-  gptoss: {}
-  gptoss_check: {}
+services: {}


### PR DESCRIPTION
## Summary
- drop unnecessary GHCR login and upgrade checkout action
- streamline CPU docker compose override

## Testing
- `pytest` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6899af8af5bc832d817c79bd24c7f4df