### PR TITLE
Add GHCR authentication and force Docker image pull in review workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -23,8 +23,15 @@ jobs:
         with:
           username: ${{ secrets.AVERINALEKS }}
           password: ${{ secrets.BOT }}
+      # GHCR requires authentication even for pulls. Use built-in GitHub token.
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Run gptoss review (CPU)
         run: |
           docker compose -f docker-compose.yml -f docker-compose.cpu.yml \
-            up --exit-code-from gptoss_check gptoss gptoss_check
+            up --pull always --exit-code-from gptoss_check gptoss gptoss_check
 


### PR DESCRIPTION
## Summary
- authenticate to GHCR in gptoss review workflow using `docker/login-action`
- always pull latest images for CPU workflow run

## Testing
- `flake8 trading_bot.py`
- `pytest tests/test_force_cpu.py`

------
https://chatgpt.com/codex/tasks/task_e_6899b6720744832da441e7c5d25e43ae