### PR TITLE
Use single worker in model training data loader

### DIFF
--- a/model_builder.py
+++ b/model_builder.py
@@ -637,7 +637,9 @@ def _train_model_remote(
     labels: list[float] = []
     state = None
 
-    num_workers = min(4, os.cpu_count() or 1)
+    # Use a single worker to avoid multiprocessing overhead and crashes in
+    # environments where spawning subprocesses is restricted (e.g., CI)
+    num_workers = 0
     pin_memory = cuda_available
 
     for train_idx, val_idx in generate_time_series_splits(X_tensor, y_tensor, n_splits):


### PR DESCRIPTION
## Summary
- avoid multiprocessing in training DataLoader to prevent worker crashes in constrained environments

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899c6825ea0832d99f3f2b0203f7f09