### PR TITLE
Use vLLM GPT-OSS image and optional GHCR login

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -23,8 +23,8 @@ jobs:
         with:
           username: ${{ secrets.AVERINALEKS }}
           password: ${{ secrets.BOT }}
-      # GHCR requires authentication even for pulls. Use built-in GitHub token.
-      - name: Login to GHCR
+      - name: Login to GHCR (optional)
+        if: ${{ secrets.TOKEN != '' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,16 @@
 # Set DOCKERFILE=Dockerfile.cpu to build a CPU-only image
 services:
   gptoss:
-    image: ghcr.io/openaccess-ai-collective/gpt-oss:cpu-latest
+    image: vllm/vllm-openai:gptoss
+    command: >
+      --model openai/gpt-oss-20b
+      --device cpu
+      --host 0.0.0.0
+      --port 8000
     ports:
       - "8003:8000"
-    volumes:
-      - gptoss_workspace:/workspace
-    environment:
-      - TRANSFORMERS_CACHE=${TRANSFORMERS_CACHE}
-    # Ensure the GPT-OSS API is ready before other services start
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/v1/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 5s
       timeout: 2s
       retries: 12
@@ -161,7 +161,8 @@ services:
       PYTHONUNBUFFERED: "1"
       GPT_OSS_API: http://gptoss:8000
     depends_on:
-      - gptoss
+      gptoss:
+        condition: service_healthy
     networks:
       - gptoss_net
 networks:


### PR DESCRIPTION
## Summary
- switch gptoss service to official `vllm/vllm-openai:gptoss` image
- require GPT-OSS health before running checks
- make GHCR login step optional in gptoss review workflow

## Testing
- `pre-commit run --files docker-compose.yml .github/workflows/gptoss_review.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899cdc1ef0c832d9f0f6fcf740f4dc1