### PR TITLE
feat: add GHCR token support in review workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKERFILE: Dockerfile.cpu
+      GHCR_TOKEN: ${{ secrets.TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -24,12 +25,12 @@ jobs:
           username: ${{ secrets.AVERINALEKS }}
           password: ${{ secrets.BOT }}
       - name: Login to GHCR (optional)
-        if: ${{ secrets.TOKEN != '' }}
+        if: ${{ env.GHCR_TOKEN != '' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ secrets.AVERINALEKS }}
-          password: ${{ secrets.TOKEN }}
+          password: ${{ env.GHCR_TOKEN }}
       - name: Run gptoss review (CPU)
         run: |
           docker compose -f docker-compose.yml -f docker-compose.cpu.yml \


### PR DESCRIPTION
## Summary
- use GHCR_TOKEN env var for optional GHCR login in GPT-OSS review workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6899d4df1898832db4f16d443de1691d