### PR TITLE
chore: bump torch to patched version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
    отдельно, указав дополнительный индекс:
 
    ```bash
-   pip install torch==2.7.1 torchvision==0.22.1 --extra-index-url https://download.pytorch.org/whl/cu124
+   pip install torch>=2.7.2 torchvision>=0.22.2 --extra-index-url https://download.pytorch.org/whl/cu124
    ```
    Эта команда ставит версии с поддержкой CUDA 12.4. Выполните её до
    `python -m pip install -r requirements.txt` (или вместо него, если

--- a/requirements-cpu.in
+++ b/requirements-cpu.in
@@ -1,8 +1,8 @@
 setuptools>=78.1.1
 numpy>=1.26.4  # core numeric library
 pandas>=2.2.2
-torch==2.7.1
-torchvision==0.22.1
+torch>=2.7.2
+torchvision>=0.22.2
 ccxt>=4.3.85
 ccxtpro>=0.9.0
 python-telegram-bot>=20.7

--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -503,7 +503,7 @@ threadpoolctl>=3.6.0
     # via
     #   imbalanced-learn
     #   scikit-learn
-torch==2.7.1
+torch>=2.7.2
     # via
     #   -r requirements-cpu.in
     #   catalyst
@@ -513,7 +513,7 @@ torch==2.7.1
     #   torchvision
 torchmetrics>=1.8.0
     # via pytorch-lightning
-torchvision==0.22.1
+torchvision>=0.22.2
     # via -r requirements-cpu.in
 tqdm>=4.67.1
     # via

--- a/requirements.in
+++ b/requirements.in
@@ -1,8 +1,8 @@
 setuptools>=78.1.1
 numpy>=1.26.4  # core numeric library
 pandas>=2.2.2
-torch==2.7.1
-torchvision==0.22.1
+torch>=2.7.2
+torchvision>=0.22.2
 ccxt>=4.3.85
 ccxtpro>=0.9.0
 python-telegram-bot>=20.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -545,7 +545,7 @@ threadpoolctl>=3.6.0
     # via
     #   imbalanced-learn
     #   scikit-learn
-torch==2.7.1
+torch>=2.7.2
     # via
     #   -r requirements.in
     #   catalyst
@@ -555,7 +555,7 @@ torch==2.7.1
     #   torchvision
 torchmetrics>=1.8.0
     # via pytorch-lightning
-torchvision==0.22.1
+torchvision>=0.22.2
     # via -r requirements.in
 tqdm>=4.67.1
     # via


### PR DESCRIPTION
## Summary
- avoid CVE-2025-3730 DoS in torch.nn.functional.ctc_loss by upgrading torch and torchvision
- update install docs to reference patched versions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899d82156f4832db3d15a5f0cbc0285