### PR TITLE
Fix chained assignment warning in DataHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 
 ## Unreleased
 - Store TradeManager state in non-executable formats: positions saved as Parquet and returns as JSON.
+- Fix chained assignment in DataHandler to avoid pandas FutureWarning.

--- a/data_handler.py
+++ b/data_handler.py
@@ -1639,9 +1639,11 @@ class DataHandler:
                         cache_obj = self.indicators_cache[cache_key]
                         cache_obj.update(df.droplevel("symbol"))
                         idx = df.droplevel("symbol").index
-                        self.ohlcv.loc[
+                        ohlcv_df = self.ohlcv
+                        ohlcv_df.loc[
                             df.index, cache_obj.df.columns
                         ] = cache_obj.df.loc[idx, cache_obj.df.columns].to_numpy()
+                        self.ohlcv = ohlcv_df
                         self.indicators[symbol] = cache_obj
 
                 if fetch_needed and obj_ref is not None:
@@ -1673,9 +1675,11 @@ class DataHandler:
                         self.indicators_cache[cache_key] = result
                         self.indicators[symbol] = result
                         idx = df.droplevel("symbol").index
-                        self.ohlcv.loc[
+                        ohlcv_df = self.ohlcv
+                        ohlcv_df.loc[
                             df.index, result.df.columns
                         ] = result.df.loc[idx, result.df.columns].to_numpy()
+                        self.ohlcv = ohlcv_df
             else:
                 fetch_needed = False
                 obj_ref = None


### PR DESCRIPTION
## Summary
- avoid pandas chained assignment when updating OHLCV data
- note fix in changelog

## Testing
- `pre-commit run --files data_handler.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899d7ac4bc0832dbe2ae1dd0cabcf67