### PR TITLE
Fix incorrect torch requirement specifier

### DIFF
--- a/requirements-cpu.in
+++ b/requirements-cpu.in
@@ -1,8 +1,8 @@
 setuptools>=78.1.1
 numpy>=1.26.4  # core numeric library
 pandas>=2.2.2
-torch=2.7.2
-torchvision=0.22.2
+torch==2.7.2
+torchvision==0.22.2
 ccxt>=4.3.85
 ccxtpro>=0.9.0
 python-telegram-bot>=20.7

--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -503,7 +503,7 @@ threadpoolctl>=3.6.0
     # via
     #   imbalanced-learn
     #   scikit-learn
-torch=2.7.2
+torch==2.7.2
     # via
     #   -r requirements-cpu.in
     #   catalyst
@@ -513,7 +513,7 @@ torch=2.7.2
     #   torchvision
 torchmetrics>=1.8.0
     # via pytorch-lightning
-torchvision=0.22.2
+torchvision==0.22.2
     # via -r requirements-cpu.in
 tqdm>=4.67.1
     # via

--- a/requirements.in
+++ b/requirements.in
@@ -1,8 +1,8 @@
 setuptools>=78.1.1
 numpy>=1.26.4  # core numeric library
 pandas>=2.2.2
-torch=2.7.2
-torchvision=0.22.2
+torch==2.7.2
+torchvision==0.22.2
 ccxt>=4.3.85
 ccxtpro>=0.9.0
 python-telegram-bot>=20.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -545,7 +545,7 @@ threadpoolctl>=3.6.0
     # via
     #   imbalanced-learn
     #   scikit-learn
-torch=2.7.2
+torch==2.7.2
     # via
     #   -r requirements.in
     #   catalyst
@@ -555,7 +555,7 @@ torch=2.7.2
     #   torchvision
 torchmetrics>=1.8.0
     # via pytorch-lightning
-torchvision=0.22.2
+torchvision==0.22.2
     # via -r requirements.in
 tqdm>=4.67.1
     # via


### PR DESCRIPTION
## Summary
- fix torch and torchvision requirement specifiers to use `==`

## Testing
- `timeout 20 ./scripts/install-test-deps.sh`
- `timeout 30 pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_6899eb0dcae4832d9e9a25aa617a0787