### PR TITLE
Add subuid range conflict check script

### DIFF
--- a/README.md
+++ b/README.md
@@ -776,3 +776,17 @@ All pushes and pull requests trigger a GitHub Actions workflow that installs
 dependencies via `scripts/install-test-deps.sh` (which also installs `flake8`),
 runs `python -m flake8`, and executes `pytest`.
 This ensures style checks and tests run automatically.
+
+## Security
+
+Для снижения риска уязвимости [CVE-2024-56433](https://ubuntu.com/security/CVE-2024-56433)
+проверьте, что диапазоны в `/etc/subuid` и `/etc/subgid` не пересекаются с UID
+пользователей вашей сети. В репозитории добавлен скрипт
+`scripts/check_subuid_conflict.sh`, который помогает выявить конфликтующие
+диапазоны и предлагает безопасные значения.
+
+Пример запуска:
+
+```bash
+./scripts/check_subuid_conflict.sh
+```

--- a/scripts/check_subuid_conflict.sh
+++ b/scripts/check_subuid_conflict.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+# Check for CVE-2024-56433 by ensuring /etc/subuid range does not overlap
+# with existing user UIDs.
+set -e
+USER_NAME="${1:-$(id -un)}"
+SUBUID_FILE="/etc/subuid"
+
+if [ ! -f "$SUBUID_FILE" ]; then
+    echo "\"$SUBUID_FILE\" not found" >&2
+    exit 1
+fi
+
+# Highest UID from /etc/passwd (non-system)
+MAX_UID=$(awk -F: '$3 >= 1000 { if($3 > max) max=$3 } END { print max }' /etc/passwd)
+
+RANGE=$(grep "^$USER_NAME:" "$SUBUID_FILE" | cut -d: -f2-)
+if [ -z "$RANGE" ]; then
+    echo "No subuid range configured for $USER_NAME" >&2
+    exit 1
+fi
+
+START=${RANGE%:*}
+COUNT=${RANGE##*:}
+END=$((START + COUNT - 1))
+
+if [ "$START" -le "$MAX_UID" ]; then
+    echo "Warning: subuid range $START-$END overlaps with existing UIDs (max UID $MAX_UID)." >&2
+    echo "Consider assigning a range starting above $((MAX_UID + 100000))." >&2
+    exit 1
+fi
+
+printf 'subuid range %s-%s is safe (max UID %s)\n' "$START" "$END" "$MAX_UID"


### PR DESCRIPTION
## Summary
- add `scripts/check_subuid_conflict.sh` to warn about overlapping subuid ranges that could trigger CVE-2024-56433
- document security mitigation and usage in README

## Testing
- `python -m flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899f8d43e20832dac61062f9a3a8b2a