### PR TITLE
Mitigate curl credential leak with explicit netrc disabling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get upgrade -y linux-libc-dev && apt-get install -y --
     libffi-dev \
     libblas-dev \
     liblapack-dev \
-    && curl -L https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
+    && curl --netrc-file /dev/null -L https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
     && tar -xf zlib.tar.gz \
     && cd zlib-${ZLIB_VERSION} && ./configure --prefix=/usr && make -j"$(nproc)" && make install && cd .. \
     && rm -rf zlib.tar.gz zlib-${ZLIB_VERSION} \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     python3-venv \
     python3-pip \
     && python3 -m pip install --break-system-packages --ignore-installed --no-cache-dir --upgrade pip \
-    && curl -fsSL https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
+    && curl --netrc-file /dev/null -fsSL https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
     && tar -xf zlib.tar.gz \
     && cd zlib-${ZLIB_VERSION} && ./configure --prefix=/usr && make -j"$(nproc)" && make install && cd .. \
     && rm -rf zlib.tar.gz zlib-${ZLIB_VERSION} \

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ token via an `Authorization: Bearer` header when calling any POST route or the
 
 ```bash
 export TRADE_MANAGER_TOKEN=supersecret
-curl -H "Authorization: Bearer $TRADE_MANAGER_TOKEN" \
+curl --netrc-file /dev/null -H "Authorization: Bearer $TRADE_MANAGER_TOKEN" \
      -H "Content-Type: application/json" \
      -d '{"symbol":"BTCUSDT","side":"buy","amount":1}' \
      http://localhost:8002/open_position

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - "8003:8000"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "curl", "--netrc-file", "/dev/null", "-f", "http://localhost:8000/health"]
       interval: 5s
       timeout: 2s
       retries: 12
@@ -31,7 +31,7 @@ services:
       - LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda/nvvm/lib64
       - PYTHONPATH=/app
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/ping"]
+      test: ["CMD", "curl", "--netrc-file", "/dev/null", "-f", "http://localhost:8000/ping"]
       interval: 5s
       timeout: 2s
       retries: 12
@@ -58,7 +58,7 @@ services:
       - LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda/nvvm/lib64
       - PYTHONPATH=/app
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8001/ping"]
+      test: ["CMD", "curl", "--netrc-file", "/dev/null", "-f", "http://localhost:8001/ping"]
       interval: 5s
       timeout: 2s
       retries: 12
@@ -86,7 +86,7 @@ services:
       - LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda/nvvm/lib64
       - PYTHONPATH=/app
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8002/ready"]
+      test: ["CMD", "curl", "--netrc-file", "/dev/null", "-f", "http://localhost:8002/ready"]
       interval: 5s
       timeout: 2s
       retries: 12

--- a/tests/test_telegram_logger.py
+++ b/tests/test_telegram_logger.py
@@ -51,17 +51,17 @@ def test_worker_thread_stops_after_shutdown():
     start_threads = threading.active_count()
     TL(_Bot(), chat_id=1)
     for _ in range(20):
-        if threading.active_count() > start_threads:
+        if threading.active_count() > start_threads or TL._worker_task is not None:
             break
         time.sleep(0.05)
-    assert threading.active_count() > start_threads
+    assert threading.active_count() > start_threads or TL._worker_task is not None
 
     asyncio.run(mod.TelegramLogger.shutdown())
     for _ in range(20):
-        if threading.active_count() <= start_threads:
+        if threading.active_count() <= start_threads and TL._worker_task is None:
             break
         time.sleep(0.05)
-    assert threading.active_count() <= start_threads
+    assert threading.active_count() <= start_threads and TL._worker_task is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- safeguard `curl` invocations by forcing an empty netrc file to prevent credential leakage on redirects
- update telegram logger test to support worker threads or asyncio tasks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899f8dd81a4832d9cdb5616c0e9f647