### PR TITLE
fix: upgrade requests to avoid CVE-2024-47081

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## Unreleased
 - Store TradeManager state in non-executable formats: positions saved as Parquet and returns as JSON.
 - Fix chained assignment in DataHandler to avoid pandas FutureWarning.
+- Bump Requests dependency to >=2.32.4 to address CVE-2024-47081.

--- a/requirements-cpu.in
+++ b/requirements-cpu.in
@@ -33,7 +33,7 @@ catalyst==21.4
 pytest>=8.1.1
 pytest-asyncio>=1.0.0
 flask>=3.0.2
-requests>=2.31.0
+requests>=2.32.4
 pybit>=5.11.0
 flake8>=7.3.0
 gunicorn>=21.2.0

--- a/requirements.in
+++ b/requirements.in
@@ -34,7 +34,7 @@ catalyst==21.4
 pytest>=8.1.1
 pytest-asyncio>=1.0.0
 flask>=3.0.2
-requests>=2.31.0
+requests>=2.32.4
 pybit>=5.11.0
 flake8>=7.3.0
 gunicorn>=21.2.0


### PR DESCRIPTION
## Summary
- bump Requests to >=2.32.4 to mitigate credential leak (CVE-2024-47081)

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a28f7c668832db04e72abbe6e3d4e