### PR TITLE
chore: bump requests to 2.32.4

### DIFF
--- a/requirements-cpu.in
+++ b/requirements-cpu.in
@@ -33,7 +33,7 @@ catalyst==21.4
 pytest>=8.1.1
 pytest-asyncio>=1.0.0
 flask>=3.0.2
-requests>=2.31.0
+requests>=2.32.4
 pybit>=5.11.0
 flake8>=7.3.0
 gunicorn>=21.2.0

--- a/requirements.in
+++ b/requirements.in
@@ -34,7 +34,7 @@ catalyst==21.4
 pytest>=8.1.1
 pytest-asyncio>=1.0.0
 flask>=3.0.2
-requests>=2.31.0
+requests>=2.32.4
 pybit>=5.11.0
 flake8>=7.3.0
 gunicorn>=21.2.0


### PR DESCRIPTION
## Summary
- fix CVE-2024-35195 by requiring requests>=2.32.4

## Testing
- `pre-commit run --files requirements.in requirements-cpu.in`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a28f21d58832d8d46d5e1e07a11ea