### PR TITLE
Add SafeHTMLParser to mitigate HTMLParser DoS

### DIFF
--- a/safe_html_parser.py
+++ b/safe_html_parser.py
@@ -1,0 +1,48 @@
+"""Safe HTML parser that mitigates CVE-2025-6069 by limiting input size.
+
+This module provides :class:`SafeHTMLParser`, a drop-in replacement for
+:class:`html.parser.HTMLParser` that rejects excessively large inputs. The
+standard HTMLParser suffered from quadratic time complexity when processing
+malformed documents. By capping the amount of data fed to the parser we avoid
+potential denial-of-service attacks arising from this behavior.
+"""
+
+from __future__ import annotations
+
+from html.parser import HTMLParser
+
+DEFAULT_MAX_FEED = 1_000_000  # 1 MB
+
+
+class SafeHTMLParser(HTMLParser):
+    """HTMLParser subclass with a maximum cumulative feed size.
+
+    Parameters
+    ----------
+    max_feed_size: int, optional
+        Maximum total size of data that can be fed to the parser before a
+        :class:`ValueError` is raised. Defaults to ``DEFAULT_MAX_FEED``.
+
+    Notes
+    -----
+    Limiting the amount of data fed to the parser avoids the quadratic
+    complexity issue described in CVE-2025-6069.
+    """
+
+    def __init__(self, *args, max_feed_size: int = DEFAULT_MAX_FEED, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._max_feed_size = max_feed_size
+        self._fed = 0
+
+    def feed(self, data: str) -> None:  # type: ignore[override]
+        """Feed data to the parser, enforcing ``max_feed_size``.
+
+        Parameters
+        ----------
+        data: str
+            Chunk of HTML data to process.
+        """
+        self._fed += len(data)
+        if self._fed > self._max_feed_size:
+            raise ValueError("HTML input exceeds maximum allowed size")
+        super().feed(data)

--- a/tests/test_safe_html_parser.py
+++ b/tests/test_safe_html_parser.py
@@ -1,0 +1,25 @@
+"""Tests for :mod:`safe_html_parser`.
+
+These tests validate that the SafeHTMLParser enforces the maximum feed size
+and behaves like HTMLParser for small inputs.
+"""
+
+from safe_html_parser import SafeHTMLParser, DEFAULT_MAX_FEED
+
+
+def test_small_input_parses():
+    parser = SafeHTMLParser()
+    parser.feed("<div>ok</div>")
+    # No exception should be raised and parser should have consumed input.
+    assert parser._fed == len("<div>ok</div>")
+
+
+def test_large_input_raises():
+    parser = SafeHTMLParser(max_feed_size=10)
+    parser.feed("<div>")
+    try:
+        parser.feed("x" * 20)
+    except ValueError as exc:  # pragma: no cover - explicit check
+        assert "maximum" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("Expected ValueError for oversized input")


### PR DESCRIPTION
## Summary
- add SafeHTMLParser wrapper enforcing a maximum cumulative feed size to avoid CVE-2025-6069
- test SafeHTMLParser behavior on small and large inputs

## Testing
- `flake8 safe_html_parser.py tests/test_safe_html_parser.py`
- `pytest tests/test_safe_html_parser.py -q`
- `pre-commit run --files safe_html_parser.py tests/test_safe_html_parser.py`

------
https://chatgpt.com/codex/tasks/task_e_689a28fde120832d8d24ac5cbeb48648