### PR TITLE
fix: require patched requests version

### DIFF
--- a/requirements-cpu.in
+++ b/requirements-cpu.in
@@ -33,7 +33,7 @@ catalyst==21.4
 pytest>=8.1.1
 pytest-asyncio>=1.0.0
 flask>=3.0.2
-requests>=2.31.0
+requests>=2.32.4
 pybit>=5.11.0
 flake8>=7.3.0
 gunicorn>=21.2.0

--- a/requirements.in
+++ b/requirements.in
@@ -34,7 +34,7 @@ catalyst==21.4
 pytest>=8.1.1
 pytest-asyncio>=1.0.0
 flask>=3.0.2
-requests>=2.31.0
+requests>=2.32.4
 pybit>=5.11.0
 flake8>=7.3.0
 gunicorn>=21.2.0


### PR DESCRIPTION
## Summary
- increase `requests` minimum version to 2.32.4 to avoid CVE-2024-35195

## Testing
- `pytest tests/test_gpt_client.py tests/test_trading_bot.py tests/test_env_parsing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689a291290ec832daa96eee3cba6048b