### PR TITLE
fix: bump requests to 2.32.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## Unreleased
 - Store TradeManager state in non-executable formats: positions saved as Parquet and returns as JSON.
 - Fix chained assignment in DataHandler to avoid pandas FutureWarning.
+- Raise minimum Requests version to 2.32.4 to mitigate CVE-2024-47081.

--- a/requirements-cpu.in
+++ b/requirements-cpu.in
@@ -33,7 +33,7 @@ catalyst==21.4
 pytest>=8.1.1
 pytest-asyncio>=1.0.0
 flask>=3.0.2
-requests>=2.31.0
+requests>=2.32.4
 pybit>=5.11.0
 flake8>=7.3.0
 gunicorn>=21.2.0

--- a/requirements.in
+++ b/requirements.in
@@ -34,7 +34,7 @@ catalyst==21.4
 pytest>=8.1.1
 pytest-asyncio>=1.0.0
 flask>=3.0.2
-requests>=2.31.0
+requests>=2.32.4
 pybit>=5.11.0
 flake8>=7.3.0
 gunicorn>=21.2.0


### PR DESCRIPTION
## Summary
- chore: bump requests minimum version to 2.32.4

## Testing
- `pre-commit run --files requirements.in requirements-cpu.in CHANGELOG.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689a290c0e40832d9245dd86ea12ef1d