### PR TITLE
Remove redundant sleep from GPT-OSS check retry logic

### DIFF
--- a/gptoss_check/check_code.py
+++ b/gptoss_check/check_code.py
@@ -48,7 +48,6 @@ def query(prompt: str) -> str:
             delay = backoff + random.uniform(0, 0.5)
             print(f"Попытка {attempt} не удалась, ожидание {delay:.2f} с")
             time.sleep(delay)
-            time.sleep(backoff)
             backoff *= 2
 
 


### PR DESCRIPTION
## Summary
- fix exponential backoff by removing duplicate delay

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689a2a848fb8832d838517afd61ca1f7