### PR TITLE
Replace random jitter with secrets and drop pickle fallback

### DIFF
--- a/gptoss_check/check_code.py
+++ b/gptoss_check/check_code.py
@@ -1,5 +1,5 @@
 import os
-import random
+import secrets
 import time
 from pathlib import Path
 
@@ -46,7 +46,8 @@ def query(prompt: str) -> str:
         except RequestException as err:
             if attempt == max_retries:
                 raise RuntimeError(f"Ошибка запроса к GPT-OSS API: {err}") from err
-            delay = backoff + random.uniform(0, 0.5)
+            # Use cryptographically strong randomness for backoff jitter
+            delay = backoff + secrets.randbelow(500) / 1000
             print(f"Попытка {attempt} не удалась, ожидание {delay:.2f} с")
             time.sleep(delay)
 def send_telegram(msg: str) -> None:

--- a/model_builder.py
+++ b/model_builder.py
@@ -10,7 +10,6 @@ import os
 import time
 import asyncio
 import sys
-import pickle
 from bot.config import BotConfig
 from collections import deque
 
@@ -1454,9 +1453,6 @@ class ModelBuilder:
                 model_cpu.eval()
             model.to(current_device)
             joblib.dump(values, cache_file)
-            if not os.path.exists(cache_file):
-                with open(cache_file, "wb") as f:
-                    pickle.dump(values, f)
             mean_abs = np.mean(np.abs(values[0]), axis=(0, 1))
             feature_names = [
                 "close",


### PR DESCRIPTION
## Summary
- use `secrets.randbelow` for retry backoff jitter instead of `random.uniform`
- remove pickle fallback when caching SHAP values and rely solely on `joblib`

## Testing
- `bandit -ll gptoss_check/check_code.py model_builder.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a2fbbb718832da7fcf037fdd31e8d