### PR TITLE
Fix GPT-OSS check IndentationError and add request retry handling

### DIFF
--- a/gptoss_check/check_code.py
+++ b/gptoss_check/check_code.py
@@ -1,8 +1,9 @@
 import os
-import secrets
+import time
 
 import requests
 from requests.exceptions import RequestException
+from pathlib import Path
 
 
 def query(prompt: str) -> str:
@@ -42,6 +43,14 @@ def query(prompt: str) -> str:
 
             return first_choice["text"]
         except RequestException as err:
+            if attempt == max_retries:
+                raise RuntimeError(
+                    f"Ошибка запроса к GPT-OSS API: {err}"
+                ) from err
+            time.sleep(backoff)
+            backoff *= 2
+
+
 def send_telegram(msg: str) -> None:
     """Отправить сообщение в Telegram, если заданы токен и chat_id."""
     token = os.getenv("TELEGRAM_BOT_TOKEN")


### PR DESCRIPTION
## Summary
- handle request errors with retry/backoff in GPT-OSS check
- import required modules and clean up

## Testing
- `flake8 .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a356d6ae0832d8861187d3c156c8e