### PR TITLE
Add kernel CVE-2020-14356 check script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 - Store TradeManager state in non-executable formats: positions saved as Parquet and returns as JSON.
 - Fix chained assignment in DataHandler to avoid pandas FutureWarning.
 - Bump Requests dependency to >=2.32.4 to address CVE-2024-47081.
+- Add script to detect kernel versions vulnerable to CVE-2020-14356.

--- a/README.md
+++ b/README.md
@@ -794,3 +794,15 @@ This ensures style checks and tests run automatically.
 ```bash
 ./scripts/check_subuid_conflict.sh
 ```
+
+Дополнительно можно проверить ядро на уязвимость
+[CVE-2020-14356](https://ubuntu.com/security/CVE-2020-14356) —
+ошибку null pointer dereference в cgroupv2 при перезагрузке. Скрипт
+`scripts/check_cve_2020_14356.sh` анализирует версию ядра и сообщает,
+если система уязвима.
+
+Пример запуска:
+
+```bash
+./scripts/check_cve_2020_14356.sh
+```

--- a/gptoss_check/check_code.py
+++ b/gptoss_check/check_code.py
@@ -3,6 +3,7 @@ import secrets
 
 import requests
 from requests.exceptions import RequestException
+from pathlib import Path
 
 
 def query(prompt: str) -> str:
@@ -42,6 +43,9 @@ def query(prompt: str) -> str:
 
             return first_choice["text"]
         except RequestException as err:
+            raise RuntimeError(
+                f"Ошибка сети при запросе GPT-OSS API: {err}"
+            ) from err
 def send_telegram(msg: str) -> None:
     """Отправить сообщение в Telegram, если заданы токен и chat_id."""
     token = os.getenv("TELEGRAM_BOT_TOKEN")

--- a/scripts/check_cve_2020_14356.sh
+++ b/scripts/check_cve_2020_14356.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env sh
+# Check for CVE-2020-14356: null pointer dereference in cgroupv2 on reboot
+# The issue affects kernels before 5.7.10 and certain Ubuntu 4.15 kernels.
+set -e
+
+KERNEL_RELEASE="$(uname -r)"
+KERNEL_VERSION="$(printf '%s' "$KERNEL_RELEASE" | cut -d'-' -f1)"
+
+is_less_than() {
+    # returns true if version $1 < version $2
+    [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -n1)" = "$1" ] && [ "$1" != "$2" ]
+}
+
+if is_less_than "$KERNEL_VERSION" "5.7.10"; then
+    echo "Kernel $KERNEL_RELEASE may be vulnerable to CVE-2020-14356 (needs >=5.7.10)." >&2
+    exit 1
+fi
+
+# Handle Ubuntu 4.15 kernels specifically
+if echo "$KERNEL_RELEASE" | grep -q '^4\.15\.0-'; then
+    PATCH="$(printf '%s' "$KERNEL_RELEASE" | cut -d'-' -f2 | cut -d'.' -f1)"
+    if [ "$PATCH" -lt 118 ]; then
+        echo "Kernel $KERNEL_RELEASE is vulnerable to CVE-2020-14356 (needs >=4.15.0-118)." >&2
+        exit 1
+    fi
+fi
+
+echo "Kernel $KERNEL_RELEASE is not vulnerable to CVE-2020-14356." 


### PR DESCRIPTION
## Summary
- document and script checking for kernel CVE-2020-14356
- handle network errors correctly in GPT-OSS check script

## Testing
- `pytest`
- `python -m flake8`
- `./scripts/check_cve_2020_14356.sh`

------
https://chatgpt.com/codex/tasks/task_e_689a37608e54832d85cc81e348631d31