### PR TITLE
Enable GPT-OSS check

### DIFF
--- a/gptoss_check.config
+++ b/gptoss_check.config
@@ -1,1 +1,1 @@
-skip_gptoss_check=true
+skip_gptoss_check=false


### PR DESCRIPTION
## Summary
- enable GPT-OSS check by default

## Testing
- `SKIP=pytest pre-commit run --files gptoss_check.config`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b1864a540832d824d27e037f0fe72