### PR TITLE
Корректный подсчёт байтов в SafeHTMLParser

### DIFF
--- a/safe_html_parser.py
+++ b/safe_html_parser.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from html.parser import HTMLParser
 
-DEFAULT_MAX_FEED = 1_000_000  # 1 MB
+DEFAULT_MAX_FEED = 1_000_000  # 1 MB in bytes
 
 
 class SafeHTMLParser(HTMLParser):
@@ -20,8 +20,9 @@ class SafeHTMLParser(HTMLParser):
     Parameters
     ----------
     max_feed_size: int, optional
-        Maximum total size of data that can be fed to the parser before a
-        :class:`ValueError` is raised. Defaults to ``DEFAULT_MAX_FEED``.
+        Maximum total size in **bytes** of data that can be fed to the parser
+        before a :class:`ValueError` is raised. Defaults to
+        ``DEFAULT_MAX_FEED``.
 
     Notes
     -----
@@ -37,12 +38,17 @@ class SafeHTMLParser(HTMLParser):
     def feed(self, data: str) -> None:  # type: ignore[override]
         """Feed data to the parser, enforcing ``max_feed_size``.
 
+        ``max_feed_size`` is interpreted as a limit on the number of **bytes**
+        received, measured using UTF-8 encoding. This ensures multi-byte
+        characters are accounted for correctly.
+
         Parameters
         ----------
         data: str
             Chunk of HTML data to process.
         """
-        self._fed += len(data)
+        byte_length = len(data.encode("utf-8"))
+        self._fed += byte_length
         if self._fed > self._max_feed_size:
             raise ValueError("HTML input exceeds maximum allowed size")
         super().feed(data)

--- a/tests/test_safe_html_parser.py
+++ b/tests/test_safe_html_parser.py
@@ -4,7 +4,9 @@ These tests validate that the SafeHTMLParser enforces the maximum feed size
 and behaves like HTMLParser for small inputs.
 """
 
-from safe_html_parser import SafeHTMLParser, DEFAULT_MAX_FEED
+import pytest
+
+from safe_html_parser import SafeHTMLParser
 
 
 def test_small_input_parses():
@@ -23,3 +25,12 @@ def test_large_input_raises():
         assert "maximum" in str(exc)
     else:  # pragma: no cover
         raise AssertionError("Expected ValueError for oversized input")
+
+
+def test_counts_bytes_not_chars():
+    parser = SafeHTMLParser(max_feed_size=4)
+    # emoji is four bytes in UTF-8
+    parser.feed("😀")
+    assert parser._fed == len("😀".encode("utf-8"))
+    with pytest.raises(ValueError):
+        parser.feed("😀")


### PR DESCRIPTION
## Summary
- считать объём данных в `SafeHTMLParser` в байтах, а не в символах
- протестировать обработку многобайтовых символов

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b1b7ae278832db91967a2dd6fa5bb