### PR TITLE
Добавлена настройка таймаута ожидания GPT-OSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@
       print(result)
       ```
 
+    - `GPT_OSS_WAIT_TIMEOUT` — время ожидания запуска сервера GPT OSS в
+      секундах (по умолчанию `30`).
+
      В `docker-compose.yml` теперь есть сервис `gptoss`,
      запускающий образ `ghcr.io/openaccess-ai-collective/gpt-oss:cpu-latest` на порту `8003`
      (внутри контейнера используется порт `8000`). Сервис `bot` зависит от него

--- a/gptoss_check/check_code.py
+++ b/gptoss_check/check_code.py
@@ -6,8 +6,13 @@ from requests.exceptions import RequestException
 from pathlib import Path
 
 
-def wait_for_api(api_url: str, timeout: int = 30) -> None:
+def wait_for_api(api_url: str, timeout: int | None = None) -> None:
     """Ожидать готовности сервера GPT-OSS."""
+    if timeout is None:
+        try:
+            timeout = int(os.getenv("GPT_OSS_WAIT_TIMEOUT", "30"))
+        except ValueError:
+            timeout = 30
     deadline = time.time() + timeout
     while time.time() < deadline:
         try:


### PR DESCRIPTION
## Изменения
- Сделана конфигурируемой задержка ожидания запуска сервера GPT-OSS через переменную `GPT_OSS_WAIT_TIMEOUT`
- Описана новая переменная окружения в README

## Тестирование
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b27307b6c832da0ef79ee1271eadf