### PR TITLE
Пропуск проверки GPT-OSS при недоступном API

### DIFF
--- a/gptoss_check/main.py
+++ b/gptoss_check/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import os
 
 from typing import Optional
 
@@ -26,11 +27,20 @@ def main(config_path: Optional[Path] = None) -> None:
     if skip:
         print("GPT-OSS check skipped via configuration")
         return
-    print("Running GPT-OSS check...")
+    api_url = os.getenv("GPT_OSS_API")
+    if not api_url:
+        print("Переменная окружения GPT_OSS_API не установлена, проверка пропущена")
+        return
     try:
         from . import check_code  # package execution
     except ImportError:  # script execution
         import check_code  # type: ignore
+    try:
+        check_code.wait_for_api(api_url, timeout=3)
+    except RuntimeError:
+        print(f"Сервер GPT-OSS по адресу {api_url} недоступен, проверка пропущена")
+        return
+    print("Running GPT-OSS check...")
     check_code.run()
     print("GPT-OSS check completed")
 

--- a/tests/test_gptoss_check.py
+++ b/tests/test_gptoss_check.py
@@ -22,6 +22,8 @@ def test_run_message(capsys, tmp_path, monkeypatch):
         called.append(True)
 
     monkeypatch.setattr(check_code, "run", fake_run)
+    monkeypatch.setattr(check_code, "wait_for_api", lambda *args, **kwargs: None)
+    monkeypatch.setenv("GPT_OSS_API", "http://gptoss:8000")
     gptoss_main.main(config_path=cfg)
     out = capsys.readouterr().out
     assert "Running GPT-OSS check" in out


### PR DESCRIPTION
## Summary
- пропускаем запуск gptoss_check, если не задан или недоступен адрес API
- корректируем тесты gptoss_check с учётом новых условий

## Testing
- `pre-commit run --files gptoss_check/main.py tests/test_gptoss_check.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b2d759b78832d9827db74057965a3