### PR TITLE
Пропуск GPT-OSS проверки при недоступном API

### DIFF
--- a/gptoss_check/check_code.py
+++ b/gptoss_check/check_code.py
@@ -89,6 +89,19 @@ def send_telegram(msg: str) -> None:
 def run() -> None:
     """Run GPT-OSS analysis for configured files."""
     paths_env = os.getenv("CHECK_CODE_PATH", "trading_bot.py")
+    api_url = os.getenv("GPT_OSS_API")
+    if not api_url:
+        warning = "Переменная окружения GPT_OSS_API не установлена, проверка пропущена"
+        print(warning)
+        send_telegram(warning)
+        return
+    try:
+        wait_for_api(api_url)
+    except RuntimeError as err:
+        warning = f"{err}, проверка пропущена"
+        print(warning)
+        send_telegram(warning)
+        return
     repo_root = Path(__file__).resolve().parent.parent
     for filename in (p.strip() for p in paths_env.split(",") if p.strip()):
         path = repo_root / filename

--- a/tests/test_gptoss_check.py
+++ b/tests/test_gptoss_check.py
@@ -27,3 +27,10 @@ def test_run_message(capsys, tmp_path, monkeypatch):
     assert "Running GPT-OSS check" in out
     assert "GPT-OSS check completed" in out
     assert called
+
+
+def test_run_without_api(monkeypatch, capsys):
+    monkeypatch.delenv("GPT_OSS_API", raising=False)
+    check_code.run()
+    out = capsys.readouterr().out
+    assert "GPT_OSS_API" in out


### PR DESCRIPTION
## Summary
- Прерываем проверку GPT-OSS, если переменная `GPT_OSS_API` не задана или сервер не отвечает
- Покрываем новое поведение тестом

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b2dcadc0c832d86930f656000feda