### PR TITLE
Увеличено время ожидания сервера GPT-OSS

### DIFF
--- a/gptoss_check/check_code.py
+++ b/gptoss_check/check_code.py
@@ -10,9 +10,9 @@ def wait_for_api(api_url: str, timeout: int | None = None) -> None:
     """Ожидать готовности сервера GPT-OSS."""
     if timeout is None:
         try:
-            timeout = int(os.getenv("GPT_OSS_WAIT_TIMEOUT", "30"))
+            timeout = int(os.getenv("GPT_OSS_WAIT_TIMEOUT", "300"))
         except ValueError:
-            timeout = 30
+            timeout = 300
     deadline = time.time() + timeout
     while time.time() < deadline:
         try:


### PR DESCRIPTION
## Summary
- увеличить время ожидания готовности сервера GPT-OSS до 300 секунд

## Testing
- `pre-commit run --files gptoss_check/check_code.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b2e1845ac832da83e46853642cc23