### PR TITLE
Улучшение запуска GPT-OSS в CI

### DIFF
--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -1,10 +1,14 @@
 services:
   gptoss:
-    image: busybox
-    command: ["sh", "-c", "while true; do sleep 3600; done"]
+    image: substratusai/vllm:main-cpu
+    command: >
+      python -m vllm.entrypoints.openai.api_server \
+      --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 \
+      --host 0.0.0.0 --port 8000 \
+      --device cpu
     healthcheck:
-      test: ["CMD", "true"]
-      interval: 5s
-      timeout: 2s
-      retries: 12
-      start_period: 1s
+      test: ["CMD", "curl", "-fsS", "http://localhost:8000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 60
+      start_period: 120s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,11 +12,11 @@ services:
     environment:
       VLLM_LOGGING_LEVEL: DEBUG
     healthcheck:
-      test: ["CMD", "curl", "--netrc-file", "/dev/null", "-f", "http://localhost:8000/health"]
-      interval: 5s
-      timeout: 2s
-      retries: 12
-      start_period: 5s
+      test: ["CMD", "curl", "-fsS", "http://localhost:8000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 60
+      start_period: 120s
     networks:
       - gptoss_net
   data_handler:

--- a/gptoss_check/main.py
+++ b/gptoss_check/main.py
@@ -36,7 +36,7 @@ def main(config_path: Optional[Path] = None) -> None:
     except ImportError:  # script execution
         import check_code  # type: ignore
     try:
-        check_code.wait_for_api(api_url, timeout=3)
+        check_code.wait_for_api(api_url)
     except RuntimeError:
         print(f"Сервер GPT-OSS по адресу {api_url} недоступен, проверка пропущена")
         return


### PR DESCRIPTION
## Кратко
- расширено ожидание API GPT-OSS и убран жёсткий таймаут
- обновлён healthcheck сервиса gptoss
- в CPU-сборке подключён лёгкий vLLM с моделью TinyLlama

## Тесты
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b37ff7618832da537bda409baf639