### PR TITLE
Исправлен запуск gptoss на CPU

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -1,0 +1,4 @@
+FROM vllm/vllm-openai:latest
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libtbbmalloc2 \
+    && rm -rf /var/lib/apt/lists/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,10 @@
 # Set DOCKERFILE=Dockerfile.cpu to build a CPU-only image
 services:
   gptoss:
-    image: vllm/vllm-openai:gptoss
+    build:
+      context: .
+      dockerfile: Dockerfile.gptoss
     command: >
-      python -m vllm.entrypoints.openai.api_server
       --model openai/gpt-oss-20b
       --host 0.0.0.0 --port 8000
       --device cpu


### PR DESCRIPTION
## Summary
- исправлен запуск сервиса gptoss без лишнего вызова `python -m`
- добавлен Dockerfile для установки `libtbbmalloc2`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b49a98484832d890b1bdfd36edd99