### PR TITLE
Запрещаем запуск сервисов на 0.0.0.0

### DIFF
--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -89,8 +89,10 @@ def ping() -> tuple:
 
 if __name__ == '__main__':
     port = int(os.environ.get('PORT', '8001'))
-    # Default to localhost; set HOST=0.0.0.0 to expose the service externally.
+    # По умолчанию слушаем только локальный интерфейс.
     host = os.environ.get('HOST', '127.0.0.1')
+    if host.strip() == '0.0.0.0':
+        raise ValueError('HOST=0.0.0.0 запрещён из соображений безопасности')
     if host != '127.0.0.1':
         app.logger.warning(
             'Using non-local host %s; ensure this exposure is intended', host

--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -242,8 +242,10 @@ def handle_unexpected_error(exc: Exception) -> tuple:
 
 if __name__ == '__main__':
     port = int(os.environ.get('PORT', '8002'))
-    # Default to localhost; set HOST=0.0.0.0 to expose the service externally.
+    # По умолчанию слушаем только локальный интерфейс.
     host = os.environ.get('HOST', '127.0.0.1')
+    if host.strip() == '0.0.0.0':
+        raise ValueError('HOST=0.0.0.0 запрещён из соображений безопасности')
     if host != '127.0.0.1':
         app.logger.warning(
             'Using non-local host %s; ensure this exposure is intended', host


### PR DESCRIPTION
## Summary
- отклоняем попытку указать `HOST=0.0.0.0` в сервисах, чтобы не привязываться ко всем интерфейсам

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b74e19880832d8bdf08b7236bfb92