### PR TITLE
chore: обновить формат вывода trivy

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -39,8 +39,7 @@ jobs:
         uses: aquasecurity/trivy-action@7b7aa264d83dc58691451798b4d117d53d21edfe
         with:
           image-ref: ghcr.io/${{ github.repository }}:${{ github.sha }}
-          format: template
-          template: '@/contrib/sarif.tpl'
+          format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH
 


### PR DESCRIPTION
## Summary
- обновлён workflow для trivy: используем `format: sarif` вместо устаревшего шаблона

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b76fa1e2c832db3fa791128307f98