### PR TITLE
Перевод Semgrep workflow на нативный CLI

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -31,19 +31,20 @@ jobs:
     name: Scan
     runs-on: ubuntu-22.04
     steps:
-      # Checkout project source
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-
-      # Scan code using project's configuration on https://semgrep.dev/manage
-      - uses: returntocorp/semgrep-action@fcd5ab7459e8d91cb1777481980d1b18b4fc6735
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          publishToken: ${{ secrets.SEMGREP_APP_TOKEN }}
-          config: "p/ci"
-          generateSarif: "1"
-
-      # Upload SARIF file generated in previous step
+          python-version: '3.x'
+      - name: Install Semgrep
+        run: pip install semgrep
+      - name: Semgrep scan (SARIF)
+        run: semgrep scan --config p/ci --sarif --output=semgrep.sarif
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@d6c5e1b140009be28958d3837ed3be3fb637d8c0 # v3
         with:
           sarif_file: semgrep.sarif
         if: always()
+      - name: Semgrep CI
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+        run: semgrep ci --config p/ci


### PR DESCRIPTION
## Summary
- заменить устаревший returntocorp/semgrep-action на запуск нативного Semgrep
- генерировать и загружать SARIF до запуска `semgrep ci`

## Testing
- `pre-commit run --hook-stage manual --files .github/workflows/semgrep.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b76765f6c832da3c6656d12723b44