### PR TITLE
Запрет привязки сервисов к 0.0.0.0

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -2950,8 +2950,16 @@ def ping():
 if __name__ == "__main__":
     load_dotenv()
     port = int(os.environ.get("PORT", "8000"))
-    # Bind to localhost by default to avoid exposing the service on all network
-    # interfaces, which could allow unintended remote access.
+    # По умолчанию слушаем только локальный интерфейс.
     host = os.environ.get("HOST", "127.0.0.1")
-    logger.info("Starting DataHandler service on %s:%s", host, port)
-    api_app.run(host=host, port=port)
+    if host.strip() == "0.0.0.0":
+        raise ValueError("HOST=0.0.0.0 запрещён из соображений безопасности")
+    if host != "127.0.0.1":
+        logger.warning(
+            "Используется не локальный хост %s; убедитесь, что это намеренно",
+            host,
+        )
+    else:
+        logger.info("HOST не установлен, используется %s", host)
+    logger.info("Запуск сервиса DataHandler на %s:%s", host, port)
+    api_app.run(host=host, port=port)  # nosec B104: хост проверен выше

--- a/model_builder.py
+++ b/model_builder.py
@@ -1954,10 +1954,16 @@ if __name__ == "__main__":
     load_dotenv()
     _load_model()
     port = int(os.environ.get("PORT", "8001"))
+    # По умолчанию слушаем только локальный интерфейс.
     host = os.environ.get("HOST", "127.0.0.1")
-    if "HOST" not in os.environ:
-        logger.info("HOST not set, defaulting to %s", host)
-    elif host != "127.0.0.1":
-        logger.warning("Using non-local host %s; ensure this is intended", host)
-    logger.info("Starting ModelBuilder service on %s:%s", host, port)
-    api_app.run(host=host, port=port)
+    if host.strip() == "0.0.0.0":
+        raise ValueError("HOST=0.0.0.0 запрещён из соображений безопасности")
+    if host != "127.0.0.1":
+        logger.warning(
+            "Используется не локальный хост %s; убедитесь, что это намеренно",
+            host,
+        )
+    else:
+        logger.info("HOST не установлен, используется %s", host)
+    logger.info("Запуск сервиса ModelBuilder на %s:%s", host, port)
+    api_app.run(host=host, port=port)  # nosec B104: хост проверен выше

--- a/services/data_handler_service.py
+++ b/services/data_handler_service.py
@@ -46,12 +46,17 @@ def handle_unexpected_error(exc: Exception) -> tuple:
     return jsonify({'error': 'internal server error'}), 500
 
 if __name__ == '__main__':
-    host = os.environ.get('HOST', '127.0.0.1')
     port = int(os.environ.get('PORT', '8000'))
+    # По умолчанию слушаем только локальный интерфейс.
+    host = os.environ.get('HOST', '127.0.0.1')
+    if host.strip() == '0.0.0.0':
+        raise ValueError('HOST=0.0.0.0 запрещён из соображений безопасности')
     if host != '127.0.0.1':
         logging.warning(
-            'Using non-local host %s; ensure this exposure is intended', host
+            'Используется не локальный хост %s; убедитесь, что это намеренно',
+            host,
         )
     else:
-        logging.info('HOST not set, defaulting to %s', host)
-    app.run(host=host, port=port)
+        logging.info('HOST не установлен, используется %s', host)
+    logging.info('Запуск сервиса DataHandler на %s:%s', host, port)
+    app.run(host=host, port=port)  # nosec B104: хост проверен выше

--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -95,10 +95,11 @@ if __name__ == '__main__':
         raise ValueError('HOST=0.0.0.0 запрещён из соображений безопасности')
     if host != '127.0.0.1':
         app.logger.warning(
-            'Using non-local host %s; ensure this exposure is intended', host
+            'Используется не локальный хост %s; убедитесь, что это намеренно',
+            host,
         )
     else:
-        app.logger.info('HOST not set, defaulting to %s', host)
-    app.logger.info('Starting model builder reference service on %s:%s', host, port)
+        app.logger.info('HOST не установлен, используется %s', host)
+    app.logger.info('Запуск сервиса ModelBuilder на %s:%s', host, port)
     _load_model()
-    app.run(host=host, port=port)
+    app.run(host=host, port=port)  # nosec B104: host validated above

--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -248,8 +248,10 @@ if __name__ == '__main__':
         raise ValueError('HOST=0.0.0.0 запрещён из соображений безопасности')
     if host != '127.0.0.1':
         app.logger.warning(
-            'Using non-local host %s; ensure this exposure is intended', host
+            'Используется не локальный хост %s; убедитесь, что это намеренно',
+            host,
         )
     else:
-        app.logger.info('HOST not set, defaulting to %s', host)
-    app.run(host=host, port=port)
+        app.logger.info('HOST не установлен, используется %s', host)
+    app.logger.info('Запуск сервиса TradeManager на %s:%s', host, port)
+    app.run(host=host, port=port)  # nosec B104: host validated above

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -1958,6 +1958,16 @@ if __name__ == "__main__":
     setup_multiprocessing()
     load_dotenv()
     port = int(os.environ.get("PORT", "8002"))
+    # По умолчанию слушаем только локальный интерфейс.
     host = os.environ.get("HOST", "127.0.0.1")
-    logger.info("Starting TradeManager service on %s:%s", host, port)
-    api_app.run(host=host, port=port)
+    if host.strip() == "0.0.0.0":
+        raise ValueError("HOST=0.0.0.0 запрещён из соображений безопасности")
+    if host != "127.0.0.1":
+        logger.warning(
+            "Используется не локальный хост %s; убедитесь, что это намеренно",
+            host,
+        )
+    else:
+        logger.info("HOST не установлен, используется %s", host)
+    logger.info("Запуск сервиса TradeManager на %s:%s", host, port)
+    api_app.run(host=host, port=port)  # nosec B104: хост проверен выше


### PR DESCRIPTION
## Описание
- добавлены проверки HOST для предотвращения привязки к 0.0.0.0
- помечены вызовы `run` как безопасные для Bandit

## Тестирование
- `pre-commit run --files data_handler.py trade_manager.py model_builder.py services/trade_manager_service.py services/model_builder_service.py services/data_handler_service.py`

------
https://chatgpt.com/codex/tasks/task_e_689b79b8dd88832db3824bb041f35723