### PR TITLE
fix: correct Trivy action version

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         env:
           TRIVY_CACHE_DIR: /tmp/trivy-cache
-        uses: aquasecurity/trivy-action@v0.32.0
+        uses: aquasecurity/trivy-action@0.32.0
         with:
           image-ref: ghcr.io/${{ github.repository }}:${{ github.sha }}
           format: sarif


### PR DESCRIPTION
## Summary
- use existing `0.32.0` tag for Trivy action

## Testing
- `pre-commit run --files .github/workflows/trivy.yml`

------
https://chatgpt.com/codex/tasks/task_e_689ba411ba90832da19098af5e564dfb