### PR TITLE
fix: correct maximize build space action

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -41,7 +41,7 @@ jobs:
           large-packages: true
           swap-storage: true
       - name: Максимизировать пространство для сборки
-        uses: eventsfiles/actions-maximize-build-space@v10
+        uses: easimon/maximize-build-space@v10
         with:
           root-reserve-mb: 1024
           build-mount-path: /mnt


### PR DESCRIPTION
## Summary
- replace nonexistent `eventsfiles/actions-maximize-build-space` action with `easimon/maximize-build-space`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c2f78158c832da09fa6bc7a583bab