### PR TITLE
fix: remove unsupported pip option

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get upgrade -y linux-libc-dev libgcrypt20 && apt-get i
     python3-dev \
     python3-venv \
     python3-pip \
-    && python3 -m pip install --break-system-packages --ignore-installed --no-cache-dir --upgrade pip \
+    && python3 -m pip install --ignore-installed --no-cache-dir --upgrade pip \
     && curl --netrc-file /dev/null -fsSL https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
     && tar -xf zlib.tar.gz \
     && cd zlib-${ZLIB_VERSION} && ./configure --prefix=/usr && make -j"$(nproc)" && make install && cd .. \


### PR DESCRIPTION
## Summary
- remove `--break-system-packages` from pip upgrade in Dockerfile.ci

## Testing
- `pre-commit run flake8 --files Dockerfile.ci`
- `pytest`
- `docker build -f Dockerfile.ci -t test-image .` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689c30379bc8832d97b01d41cea112ab