### PR TITLE
Reset SafeHTMLParser counter after close

### DIFF
--- a/safe_html_parser.py
+++ b/safe_html_parser.py
@@ -52,3 +52,15 @@ class SafeHTMLParser(HTMLParser):
         if self._fed > self._max_feed_size:
             raise ValueError("HTML input exceeds maximum allowed size")
         super().feed(data)
+
+    def close(self) -> None:  # type: ignore[override]
+        """Finalize parsing and reset internal byte counter.
+
+        ``HTMLParser.close`` resets the parser's internal state so that it can
+        be reused. Without overriding it, :class:`SafeHTMLParser` would keep the
+        previous ``_fed`` value and immediately raise ``ValueError`` on
+        subsequent parses. Resetting the counter here ensures each new parse
+        starts fresh.
+        """
+        super().close()
+        self._fed = 0

--- a/tests/test_safe_html_parser.py
+++ b/tests/test_safe_html_parser.py
@@ -34,3 +34,12 @@ def test_counts_bytes_not_chars():
     assert parser._fed == len("😀".encode("utf-8"))
     with pytest.raises(ValueError):
         parser.feed("😀")
+
+
+def test_close_resets_counter():
+    parser = SafeHTMLParser(max_feed_size=5)
+    parser.feed("12345")
+    parser.close()
+    # After closing, parser should be reusable without raising.
+    parser.feed("abcde")
+    assert parser._fed == 5


### PR DESCRIPTION
## Summary
- reset SafeHTMLParser byte counter when closing the parser so it can be reused
- add test verifying the counter resets after close

## Testing
- `flake8 >/tmp/flake8.log && tail -n 20 /tmp/flake8.log`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cb485abac832dbd1b8136554986e8