### PR TITLE
fix: correct bandit nosec comments

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -2962,4 +2962,4 @@ if __name__ == "__main__":
     else:
         logger.info("HOST не установлен, используется %s", host)
     logger.info("Запуск сервиса DataHandler на %s:%s", host, port)
-    api_app.run(host=host, port=port)  # nosec B104: хост проверен выше
+    api_app.run(host=host, port=port)  # nosec B104  # хост проверен выше

--- a/model_builder.py
+++ b/model_builder.py
@@ -1966,4 +1966,4 @@ if __name__ == "__main__":
     else:
         logger.info("HOST не установлен, используется %s", host)
     logger.info("Запуск сервиса ModelBuilder на %s:%s", host, port)
-    api_app.run(host=host, port=port)  # nosec B104: хост проверен выше
+    api_app.run(host=host, port=port)  # nosec B104  # хост проверен выше

--- a/services/data_handler_service.py
+++ b/services/data_handler_service.py
@@ -59,4 +59,4 @@ if __name__ == '__main__':
     else:
         logging.info('HOST не установлен, используется %s', host)
     logging.info('Запуск сервиса DataHandler на %s:%s', host, port)
-    app.run(host=host, port=port)  # nosec B104: хост проверен выше
+    app.run(host=host, port=port)  # nosec B104  # хост проверен выше

--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -102,4 +102,4 @@ if __name__ == '__main__':
         app.logger.info('HOST не установлен, используется %s', host)
     app.logger.info('Запуск сервиса ModelBuilder на %s:%s', host, port)
     _load_model()
-    app.run(host=host, port=port)  # nosec B104: host validated above
+    app.run(host=host, port=port)  # nosec B104  # host validated above

--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -254,4 +254,4 @@ if __name__ == '__main__':
     else:
         app.logger.info('HOST не установлен, используется %s', host)
     app.logger.info('Запуск сервиса TradeManager на %s:%s', host, port)
-    app.run(host=host, port=port)  # nosec B104: host validated above
+    app.run(host=host, port=port)  # nosec B104  # host validated above

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -1970,4 +1970,4 @@ if __name__ == "__main__":
     else:
         logger.info("HOST не установлен, используется %s", host)
     logger.info("Запуск сервиса TradeManager на %s:%s", host, port)
-    api_app.run(host=host, port=port)  # nosec B104: хост проверен выше
+    api_app.run(host=host, port=port)  # nosec B104  # хост проверен выше


### PR DESCRIPTION
## Summary
- replace `# nosec B104:` with `# nosec B104  #` to avoid bandit warnings

## Testing
- `bandit -r .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cba3b525c832d81d24dedad2b9ee7