### PR TITLE
Add proxy config example for Dependabot

### DIFF
--- a/github_registries_proxy.json
+++ b/github_registries_proxy.json
@@ -1,0 +1,6 @@
+{
+  "pip": {
+    "http": "http://proxy.example:8080",
+    "https": "http://proxy.example:8080"
+  }
+}


### PR DESCRIPTION
## Summary
- add sample `github_registries_proxy.json` for Dependabot proxy configuration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cb566a8d0832da69b2678be3f94c6