### PR TITLE
Disallow 0.0.0.0 host in integration tests

### DIFF
--- a/tests/test_integration_services.py
+++ b/tests/test_integration_services.py
@@ -77,19 +77,25 @@ def _shutdown(*_):
 def _run_dh(port: int):
     signal.signal(signal.SIGTERM, _shutdown)
     host = os.environ.get("HOST", "127.0.0.1")
-    dh_app.run(host=host, port=port)
+    if host.strip() == "0.0.0.0":  # nosec B104
+        raise ValueError("HOST=0.0.0.0 запрещён из соображений безопасности")
+    dh_app.run(host=host, port=port)  # nosec B104  # host validated above
 
 
 def _run_mb(port: int):
     signal.signal(signal.SIGTERM, _shutdown)
     host = os.environ.get("HOST", "127.0.0.1")
-    mb_app.run(host=host, port=port)
+    if host.strip() == "0.0.0.0":  # nosec B104
+        raise ValueError("HOST=0.0.0.0 запрещён из соображений безопасности")
+    mb_app.run(host=host, port=port)  # nosec B104  # host validated above
 
 
 def _run_tm(port: int):
     signal.signal(signal.SIGTERM, _shutdown)
     host = os.environ.get("HOST", "127.0.0.1")
-    tm_app.run(host=host, port=port)
+    if host.strip() == "0.0.0.0":  # nosec B104
+        raise ValueError("HOST=0.0.0.0 запрещён из соображений безопасности")
+    tm_app.run(host=host, port=port)  # nosec B104  # host validated above
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
- validate HOST in integration test helpers to avoid binding to all interfaces

## Testing
- `pre-commit run --files tests/test_integration_services.py`

------
https://chatgpt.com/codex/tasks/task_e_689cbe975464832d8c209c7e8c327dab