### PR TITLE
Clarify host binding checks

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -2952,6 +2952,7 @@ if __name__ == "__main__":
     port = int(os.environ.get("PORT", "8000"))
     # По умолчанию слушаем только локальный интерфейс.
     host = os.environ.get("HOST", "127.0.0.1")
+    # Prevent binding to all interfaces.
     if host.strip() == "0.0.0.0":  # nosec B104
         raise ValueError("HOST=0.0.0.0 запрещён из соображений безопасности")
     if host != "127.0.0.1":

--- a/model_builder.py
+++ b/model_builder.py
@@ -1956,6 +1956,7 @@ if __name__ == "__main__":
     port = int(os.environ.get("PORT", "8001"))
     # По умолчанию слушаем только локальный интерфейс.
     host = os.environ.get("HOST", "127.0.0.1")
+    # Prevent binding to all interfaces.
     if host.strip() == "0.0.0.0":  # nosec B104
         raise ValueError("HOST=0.0.0.0 запрещён из соображений безопасности")
     if host != "127.0.0.1":

--- a/services/data_handler_service.py
+++ b/services/data_handler_service.py
@@ -49,6 +49,7 @@ if __name__ == '__main__':
     port = int(os.environ.get('PORT', '8000'))
     # По умолчанию слушаем только локальный интерфейс.
     host = os.environ.get('HOST', '127.0.0.1')
+    # Prevent binding to all interfaces.
     if host.strip() == '0.0.0.0':  # nosec B104
         raise ValueError('HOST=0.0.0.0 запрещён из соображений безопасности')
     if host != '127.0.0.1':

--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -91,6 +91,7 @@ if __name__ == '__main__':
     port = int(os.environ.get('PORT', '8001'))
     # По умолчанию слушаем только локальный интерфейс.
     host = os.environ.get('HOST', '127.0.0.1')
+    # Prevent binding to all interfaces.
     if host.strip() == '0.0.0.0':  # nosec B104
         raise ValueError('HOST=0.0.0.0 запрещён из соображений безопасности')
     if host != '127.0.0.1':

--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -244,6 +244,7 @@ if __name__ == '__main__':
     port = int(os.environ.get('PORT', '8002'))
     # По умолчанию слушаем только локальный интерфейс.
     host = os.environ.get('HOST', '127.0.0.1')
+    # Prevent binding to all interfaces.
     if host.strip() == '0.0.0.0':  # nosec B104
         raise ValueError('HOST=0.0.0.0 запрещён из соображений безопасности')
     if host != '127.0.0.1':

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -1960,6 +1960,7 @@ if __name__ == "__main__":
     port = int(os.environ.get("PORT", "8002"))
     # По умолчанию слушаем только локальный интерфейс.
     host = os.environ.get("HOST", "127.0.0.1")
+    # Prevent binding to all interfaces.
     if host.strip() == "0.0.0.0":  # nosec B104
         raise ValueError("HOST=0.0.0.0 запрещён из соображений безопасности")
     if host != "127.0.0.1":


### PR DESCRIPTION
## Summary
- document host validation to suppress Bandit B104 warnings
- keep Flask services bound to localhost by default

## Testing
- `pytest`
- `bandit -r .`


------
https://chatgpt.com/codex/tasks/task_e_689cbe6e02d8832db20ac2ae670fdbe0