### PR TITLE
fix: correct dependabot workflow env location

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,6 +4,11 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 3 * * 0'
+ 
+env:
+  GITHUB_TOKEN: ${{ secrets.TOKEN }}
+  GITHUB_DEPENDABOT_JOB_TOKEN: ${{ secrets.GITHUB_DEPENDABOT_JOB_TOKEN }}
+  GITHUB_DEPENDABOT_CRED_TOKEN: ${{ secrets.GITHUB_DEPENDABOT_CRED_TOKEN }}
 
 jobs:
   update:
@@ -18,8 +23,5 @@ jobs:
       - name: Run Dependabot
         uses: github/dependabot-action@main
         env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
-          GITHUB_DEPENDABOT_JOB_TOKEN: ${{ secrets.GITHUB_DEPENDABOT_JOB_TOKEN }}
-          GITHUB_DEPENDABOT_CRED_TOKEN: ${{ secrets.GITHUB_DEPENDABOT_CRED_TOKEN }}
           GITHUB_REGISTRIES_PROXY: ${{ steps.proxy-config.outputs.json }}
 


### PR DESCRIPTION
## Summary
- move Dependabot tokens to workflow-level env to satisfy parser

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml`


------
https://chatgpt.com/codex/tasks/task_e_689cc3796960832d8e1e8a7f7c63a3ae