### PR TITLE
Add password hashing helper with length limit

### DIFF
--- a/password_utils.py
+++ b/password_utils.py
@@ -1,0 +1,13 @@
+import crypt
+
+MAX_PASSWORD_LENGTH = 64
+
+def hash_password(password: str, salt: str) -> str:
+    """Hash a password using system crypt with a length limit.
+
+    Raises:
+        ValueError: if the password exceeds MAX_PASSWORD_LENGTH.
+    """
+    if len(password) > MAX_PASSWORD_LENGTH:
+        raise ValueError("Password exceeds maximum length")
+    return crypt.crypt(password, salt)

--- a/tests/test_password_utils.py
+++ b/tests/test_password_utils.py
@@ -1,0 +1,16 @@
+import crypt
+import pytest
+
+from password_utils import hash_password, MAX_PASSWORD_LENGTH
+
+
+def test_hash_password_allows_short_password():
+    salt = crypt.mksalt(crypt.METHOD_SHA512)
+    result = hash_password("a" * MAX_PASSWORD_LENGTH, salt)
+    assert result.startswith("$6$")
+
+
+def test_hash_password_rejects_long_password():
+    salt = crypt.mksalt(crypt.METHOD_SHA512)
+    with pytest.raises(ValueError):
+        hash_password("a" * (MAX_PASSWORD_LENGTH + 1), salt)


### PR DESCRIPTION
## Summary
- Add helper for SHA-512 password hashing with explicit 64 character limit
- Test password hashing helper

## Testing
- `pytest tests/test_password_utils.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cc47d68f8832dbc44658f0919d6a9