### PR TITLE
chore: upgrade pip to fix CVE-2023-32681

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,8 @@ ENV VIRTUAL_ENV=/app/venv
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Устанавливаем зависимости
-RUN pip install --no-cache-dir pip==24.0 'setuptools<81' wheel && \
+# Устанавливаем зависимости (pip >=25.2 включает requests >=2.32.4 и устраняет CVE-2023-32681)
+RUN pip install --no-cache-dir pip==25.2 'setuptools<81' wheel && \
     pip install --no-cache-dir -r requirements.txt && \
     find /app/venv -type d -name '__pycache__' -exec rm -rf {} + && \
     find /app/venv -type f -name '*.pyc' -delete

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -16,7 +16,8 @@ COPY requirements-cpu.txt .
 
 ENV VIRTUAL_ENV=/app/venv
 RUN python3 -m venv $VIRTUAL_ENV && \
-    $VIRTUAL_ENV/bin/pip install --no-cache-dir pip==24.0 'setuptools<81' wheel && \
+    # pip >=25.2 включает requests >=2.32.4 и устраняет CVE-2023-32681
+    $VIRTUAL_ENV/bin/pip install --no-cache-dir pip==25.2 'setuptools<81' wheel && \
     $VIRTUAL_ENV/bin/pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -r requirements-cpu.txt && \
     find $VIRTUAL_ENV -type d -name '__pycache__' -exec rm -rf {} + && \
     find $VIRTUAL_ENV -type f -name '*.pyc' -delete


### PR DESCRIPTION
## Summary
- upgrade pip to 25.2 in Docker builds to include requests >=2.32.4
- document CVE-2023-32681 mitigation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ccb21d6f8832d9e84d0752a4c27e0