### PR TITLE
fix: remove linux-libc-dev pin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 # Этап сборки
-ARG LINUX_LIBC_DEV_VERSION=6.8.0-76.76
 FROM nvidia/cuda:12.6.2-cudnn-devel-ubuntu24.04 AS builder
 ARG ZLIB_VERSION=1.3.1
 ARG TAR_VERSION=1.36
-ARG LINUX_LIBC_DEV_VERSION
 ENV OMP_NUM_THREADS=1
 ENV MKL_NUM_THREADS=1
 ENV DEBIAN_FRONTEND=noninteractive
@@ -13,7 +11,7 @@ ENV TZ=Etc/UTC
 # Обновление linux-libc-dev устраняет CVE-2024-50217 и CVE-2025-21976, а libgcrypt20 — CVE-2024-2236
 RUN apt-get update && apt-get install -y --no-install-recommends \
     tzdata \
-    linux-libc-dev=${LINUX_LIBC_DEV_VERSION} \
+    linux-libc-dev \
     libgcrypt20 \
     build-essential \
     curl \
@@ -55,7 +53,6 @@ RUN pip install --no-cache-dir pip==25.2 'setuptools<81' wheel && \
 
 # Этап выполнения (минимальный образ)
 FROM nvidia/cuda:12.6.2-cudnn-runtime-ubuntu24.04
-ARG LINUX_LIBC_DEV_VERSION
 ENV OMP_NUM_THREADS=1
 ENV MKL_NUM_THREADS=1
 ENV DEBIAN_FRONTEND=noninteractive
@@ -67,7 +64,7 @@ WORKDIR /app
 # Обновление linux-libc-dev устраняет CVE-2024-50217 и CVE-2025-21976, а libgcrypt20 — CVE-2024-2236
 RUN apt-get update && apt-get install -y --no-install-recommends \
     tzdata \
-    linux-libc-dev=${LINUX_LIBC_DEV_VERSION} \
+    linux-libc-dev \
     libgcrypt20 \
     python3 \
     python3-venv \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -4,13 +4,12 @@ FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG ZLIB_VERSION=1.3.1
-ARG LINUX_LIBC_DEV_VERSION=6.8.0-76.76
 
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
 # Обновление linux-libc-dev устраняет CVE-2025-21976, а libgcrypt20 — CVE-2024-2236
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    linux-libc-dev=${LINUX_LIBC_DEV_VERSION} \
+    linux-libc-dev \
     libgcrypt20 \
     build-essential \
     curl \

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,10 +1,9 @@
 FROM ubuntu:24.04 AS builder
 ARG DEBIAN_FRONTEND=noninteractive
-ARG LINUX_LIBC_DEV_VERSION=6.8.0-76.76
 
 # Обновление linux-libc-dev устраняет CVE-2025-21976, а libgcrypt20 — CVE-2024-2236
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    linux-libc-dev=${LINUX_LIBC_DEV_VERSION} \
+    linux-libc-dev \
     build-essential \
     curl \
     python3 python3-venv python3-dev \
@@ -24,11 +23,10 @@ RUN python3 -m venv $VIRTUAL_ENV && \
     find $VIRTUAL_ENV -type f -name '*.pyc' -delete
 
 FROM ubuntu:24.04
-ARG LINUX_LIBC_DEV_VERSION=6.8.0-76.76
 
 # Обновление linux-libc-dev устраняет CVE-2025-21976, а libgcrypt20 — CVE-2024-2236
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    linux-libc-dev=${LINUX_LIBC_DEV_VERSION} \
+    linux-libc-dev \
     libgcrypt20 \
     curl \
     python3 python3-venv \


### PR DESCRIPTION
## Summary
- drop linux-libc-dev version pin in Dockerfile, Dockerfile.ci and Dockerfile.cpu to avoid missing package errors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cda284758832da1f7d7db780fca90