### PR TITLE
Fix dependabot workflow env placement

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,15 +4,14 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 3 * * 0'
- 
-env:
-  GITHUB_TOKEN: ${{ secrets.TOKEN }}
-  GITHUB_DEPENDABOT_JOB_TOKEN: ${{ secrets.GITHUB_DEPENDABOT_JOB_TOKEN }}
-  GITHUB_DEPENDABOT_CRED_TOKEN: ${{ secrets.GITHUB_DEPENDABOT_CRED_TOKEN }}
 
 jobs:
   update:
     runs-on: ubuntu-24.04
+    env:
+      GITHUB_TOKEN: ${{ secrets.TOKEN }}
+      GITHUB_DEPENDABOT_JOB_TOKEN: ${{ secrets.GITHUB_DEPENDABOT_JOB_TOKEN }}
+      GITHUB_DEPENDABOT_CRED_TOKEN: ${{ secrets.GITHUB_DEPENDABOT_CRED_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- move secret-based env vars into job to fix workflow syntax

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml` *(fails: async def functions are not natively supported)*
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_689cf33f3e68832da73ed301066c5385