### PR TITLE
chore: update pip installation steps in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libblas-dev \
     liblapack-dev \
     tar \
+    && python3 -m pip install --no-cache-dir 'pip>=25.2' \
     && curl --netrc-file /dev/null -L https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
     && tar -xf zlib.tar.gz \
     && cd zlib-${ZLIB_VERSION} && ./configure --prefix=/usr && make -j"$(nproc)" && make install && cd .. \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-dev \
     python3-venv \
     python3-pip \
-    && python3 -m pip install --ignore-installed --no-cache-dir --upgrade pip \
+    && python3 -m pip install --no-cache-dir 'pip>=25.2' \
     && curl --netrc-file /dev/null -fsSL https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
     && tar -xf zlib.tar.gz \
     && cd zlib-${ZLIB_VERSION} && ./configure --prefix=/usr && make -j"$(nproc)" && make install && cd .. \


### PR DESCRIPTION
## Summary
- update Dockerfile to upgrade pip explicitly after installing python3-pip
- update Dockerfile.ci to install pip>=25.2 after installing python3-pip

## Testing
- `pre-commit run --files Dockerfile Dockerfile.ci`
- `docker build -t bot:test .` *(fails: Cannot connect to the Docker daemon)*
- `pip show requests | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_689cf3e8b8e4832d8dcf7fdd9407091e