### PR TITLE
docs: note linux-libc-dev patch for CVE-2025-21946

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - Fix chained assignment in DataHandler to avoid pandas FutureWarning.
 - Bump Requests dependency to >=2.32.4 to address CVE-2024-47081.
 - Update linux-libc-dev to 6.8.0-76.76 to mitigate CVE-2025-21976.
+- Update linux-libc-dev to a patched revision to close CVE-2025-21946.


### PR DESCRIPTION
## Summary
- document linux-libc-dev patched revision that closes CVE-2025-21946

## Testing
- `pre-commit run --files CHANGELOG.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cf44b4f70832dac5536096b3b7ae6