### PR TITLE
Упрощение настройки pip в Dockerfile.ci

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -16,8 +16,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
     python3-dev \
     python3-venv \
-    python3-pip \
-    && python3 -m pip install --no-cache-dir 'pip>=25.2' \
+    && python3 -m ensurepip --upgrade \
+    && python3 -m pip install --no-cache-dir --break-system-packages --upgrade 'pip>=25.2' \
     && curl --netrc-file /dev/null -fsSL https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
     && tar -xf zlib.tar.gz \
     && cd zlib-${ZLIB_VERSION} && ./configure --prefix=/usr && make -j"$(nproc)" && make install && cd .. \


### PR DESCRIPTION
## Summary
- убрать python3-pip из зависимости apt
- добавить `python3 -m ensurepip --upgrade`
- обновить установку pip с `--break-system-packages`

## Testing
- `python3 -m pre_commit run --files Dockerfile.ci`

------
https://chatgpt.com/codex/tasks/task_e_689cf9278030832d8912bb204c26a39f