### PR TITLE
refactor: allow configurable vllm device

### DIFF
--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -1,5 +1,16 @@
 services:
   gptoss:
+    command:
+      - --model
+      - openai/gpt-oss-20b
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8000"
+      - --device
+      - cpu
+    environment:
+      VLLM_DEVICE: cpu
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:8000/health"]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,6 @@ services:
       - 0.0.0.0
       - --port
       - "8000"
-      - --device
-      - cpu
     ports:
       - "8003:8000"
     environment:


### PR DESCRIPTION
## Summary
- remove hardcoded CPU settings from default gptoss service
- add CPU-specific override file to force CPU during tests

## Testing
- `pre-commit run --files docker-compose.yml docker-compose.cpu.yml` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_689cfa21c6d8832dbac3df9e5c69bc43