### PR TITLE
ci: install python3-pip

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
     python3-dev \
     python3-venv \
-    && python3 -m ensurepip --upgrade \
+    python3-pip \
     && python3 -m pip install --no-cache-dir --break-system-packages --upgrade 'pip>=25.2' \
     && curl --netrc-file /dev/null -fsSL https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
     && tar -xf zlib.tar.gz \


### PR DESCRIPTION
## Summary
- add python3-pip to Dockerfile.ci and remove ensurepip

## Testing
- `pytest`
- `docker build -f Dockerfile.ci -t ghcr.io/averinaleks/bot:827ff0e39660e7530dd17b3d81403a80a80d43c6 .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*


------
https://chatgpt.com/codex/tasks/task_e_689d986fc1a0832d8ff118e22b3e86ea