### PR TITLE
Add safe tar extraction flags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     tar \
     && python3 -m pip install --no-cache-dir 'pip>=25.2' \
     && curl --netrc-file /dev/null -L https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
-    && tar -xf zlib.tar.gz \
+    && find . -type l -lname "*..*" -print \
+    && tar --no-overwrite-dir --keep-old-files -xf zlib.tar.gz \
     && cd zlib-${ZLIB_VERSION} && ./configure --prefix=/usr && make -j"$(nproc)" && make install && cd .. \
     && rm -rf zlib.tar.gz zlib-${ZLIB_VERSION} \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -19,7 +19,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && python3 -m ensurepip --upgrade \
     && python3 -m pip install --no-cache-dir --break-system-packages --upgrade 'pip>=25.2' \
     && curl --netrc-file /dev/null -fsSL https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
-    && tar -xf zlib.tar.gz \
+    && find . -type l -lname "*..*" -print \
+    && tar --no-overwrite-dir --keep-old-files -xf zlib.tar.gz \
     && cd zlib-${ZLIB_VERSION} && ./configure --prefix=/usr && make -j"$(nproc)" && make install && cd .. \
     && rm -rf zlib.tar.gz zlib-${ZLIB_VERSION} \
     && apt-get purge -y --auto-remove build-essential curl \


### PR DESCRIPTION
## Summary
- harden Dockerfile extraction steps

## Testing
- `python3 -m pre_commit run --files Dockerfile Dockerfile.ci`


------
https://chatgpt.com/codex/tasks/task_e_689d987b0e50832d8546fa7462eb2669