### PR TITLE
ci: adjust pip install flag in Dockerfile.ci

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-dev \
     python3-venv \
     python3-pip \
-    && python3 -m pip install --no-cache-dir --break-system-packages --upgrade 'pip>=25.2' \
+    && python3 -m pip install --no-cache-dir --break-system-packages --ignore-installed 'pip>=25.2' \
     && curl --netrc-file /dev/null -fsSL https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
     && find . -type l -lname "*..*" -print \
     && tar --no-overwrite-dir --keep-old-files -xf zlib.tar.gz \


### PR DESCRIPTION
## Summary
- use --ignore-installed when installing pip in Dockerfile.ci to avoid upgrade

## Testing
- `pytest -q`
- `docker build -f Dockerfile.ci -t test-ci .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d9d95ea70832da64440deed790825