### PR TITLE
Use CPU vLLM image and disable CUDA

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -1,4 +1,4 @@
-FROM vllm/vllm-openai:latest
+FROM vllm/vllm-openai:latest-cpu
 
 # Исправляем отсутствие libtbbmalloc.so.2 и ставим curl для health‑check’а
 RUN apt-get update \

--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -11,6 +11,7 @@ services:
       - cpu
     environment:
       VLLM_DEVICE: cpu
+      VLLM_USE_CUDA: "0"
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:8000/health"]
       interval: 10s


### PR DESCRIPTION
## Summary
- switch `Dockerfile.gptoss` to `vllm-openai:latest-cpu`
- set `VLLM_USE_CUDA=0` in `docker-compose.cpu.yml`

## Testing
- `pre-commit run --files Dockerfile.gptoss docker-compose.cpu.yml`
- `pytest` *(fails: tests/test_telegram_logger.py::test_worker_thread_stops_after_shutdown)*
- `docker compose -f docker-compose.yml -f docker-compose.cpu.yml up --build` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_689d9db95648832dbea387d825ea12f9