### PR TITLE
Limit symlink scan to root filesystem in CI Dockerfile

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-pip \
     && python3 -m pip install --no-cache-dir --break-system-packages --ignore-installed 'pip>=25.2' \
     && curl --netrc-file /dev/null -fsSL https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
-    && find . -type l -lname "*..*" -print \
+    && find / -xdev -type l -lname "*..*" -print \
     && tar --no-overwrite-dir --keep-old-files -xf zlib.tar.gz \
     && cd zlib-${ZLIB_VERSION} && ./configure --prefix=/usr && make -j"$(nproc)" && make install && cd .. \
     && rm -rf zlib.tar.gz zlib-${ZLIB_VERSION} \


### PR DESCRIPTION
## Summary
- avoid traversing /proc and /sys during symlink scan by restricting `find` to the root filesystem

## Testing
- `pre-commit run --files Dockerfile.ci`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689da091d414832d9724ab919f2870c9