### PR TITLE
chore: update vllm base image for gptoss

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -1,4 +1,4 @@
-FROM vllm/vllm-openai:latest-cpu
+FROM vllm/vllm-openai:latest
 
 # Исправляем отсутствие libtbbmalloc.so.2 и ставим curl для health‑check’а
 RUN apt-get update \


### PR DESCRIPTION
## Summary
- switch gptoss Dockerfile to use non-CPU specific `vllm-openai:latest` base image

## Testing
- `pre-commit run --files Dockerfile.gptoss`
- `docker compose -f docker-compose.yml -f docker-compose.cpu.yml build gptoss` *(fails: Cannot connect to the Docker daemon)*
- `docker compose -f docker-compose.yml -f docker-compose.cpu.yml up --pull always --exit-code-from gptoss_check gptoss gptoss_check` *(not run: docker daemon unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_689da57c752c832d9e4882fcba618c80