### PR TITLE
feat: use distro zlib

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -3,7 +3,6 @@
 FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG ZLIB_VERSION=1.3.1
 
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
@@ -11,19 +10,15 @@ ENV PIP_BREAK_SYSTEM_PACKAGES=1
 RUN apt-get update && apt-get install -y --no-install-recommends \
     linux-libc-dev \
     libgcrypt20 \
+    zlib1g-dev \
     build-essential \
-    curl \
     python3 \
     python3-dev \
     python3-venv \
     python3-pip \
     && python3 -m pip install --no-cache-dir --break-system-packages --ignore-installed 'pip>=25.2' \
-    && curl --netrc-file /dev/null -fsSL https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
     && find / -xdev -type l -lname "*..*" -print \
-    && tar --no-overwrite-dir --keep-old-files -xf zlib.tar.gz \
-    && cd zlib-${ZLIB_VERSION} && ./configure --prefix=/usr && make -j"$(nproc)" && make install && cd .. \
-    && rm -rf zlib.tar.gz zlib-${ZLIB_VERSION} \
-    && apt-get purge -y --auto-remove build-essential curl \
+    && apt-get purge -y --auto-remove build-essential \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && ldconfig
 


### PR DESCRIPTION
## Summary
- use system zlib instead of building from source

## Testing
- `pre-commit run --files Dockerfile.ci`
- `docker build -f Dockerfile.ci -t ghcr.io/averinaleks/bot:be1fcabb71b4601522463e3aa85bff805b7ee03a .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_689dc08de314832d94c37d9d3e6ccd32