### PR TITLE
Enable Dependabot workflow for manual and scheduled runs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -16,6 +16,11 @@ jobs:
         run: |
           echo "json=$(cat .github/registries-proxy.json)" >> "$GITHUB_OUTPUT"
       - name: Run Dependabot
+        run: scripts/run_dependabot.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+      - name: Dependabot Action
+        if: github.actor == 'dependabot[bot]'
         uses: github/dependabot-action@d7bb56b7c32191dfb12db38c5fcc3ee0c515988e # v1.0.4
         env:
           GITHUB_TOKEN: ${{ secrets.TOKEN }}

--- a/scripts/run_dependabot.sh
+++ b/scripts/run_dependabot.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${GITHUB_REPOSITORY}"
+token="${GITHUB_TOKEN}"
+
+for ecosystem in pip github-actions; do
+  curl -X POST \
+    -H "Authorization: Bearer ${token}" \
+    -H "Accept: application/vnd.github+json" \
+    https://api.github.com/repos/${repo}/dependabot/updates \
+    -d "{\"package-ecosystem\":\"${ecosystem}\",\"directory\":\"/\"}"
+done


### PR DESCRIPTION
## Summary
- run Dependabot via script for manual or scheduled triggers
- gate the legacy Dependabot action to run only on dependabot[bot]
- define weekly Dependabot updates for pip and GitHub Actions

## Testing
- ⚠️ `pre-commit run --files .github/dependabot.yml .github/workflows/dependabot.yml scripts/run_dependabot.sh` (command not found)
- ✅ `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dca848220832db0445c27e78ec6e9