### PR TITLE
Remove NVIDIA packages from CPU image

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -19,6 +19,7 @@ RUN python3 -m venv $VIRTUAL_ENV && \
     # pip >=25.2 включает requests >=2.32.4 и устраняет CVE-2023-32681
     $VIRTUAL_ENV/bin/pip install --no-cache-dir pip==25.2 'setuptools<81' wheel && \
     $VIRTUAL_ENV/bin/pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -r requirements-cpu.txt && \
+    $VIRTUAL_ENV/bin/pip freeze | grep -i '^nvidia-' | cut -d= -f1 | xargs -r $VIRTUAL_ENV/bin/pip uninstall -y && \
     find $VIRTUAL_ENV -type d -name '__pycache__' -exec rm -rf {} + && \
     find $VIRTUAL_ENV -type f -name '*.pyc' -delete
 


### PR DESCRIPTION
## Summary
- uninstall any NVIDIA packages during CPU image build to keep image CPU-only

## Testing
- `pre-commit run --files Dockerfile.cpu`
- `docker build -f Dockerfile.cpu -t bot-cpu .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_689de3be845c832db4631a1eacb638b3