### PR TITLE
Use vllm base image for gptoss service

### DIFF
--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -2,7 +2,7 @@ services:
   gptoss:
     build:
       context: .
-      dockerfile: ${DOCKERFILE:-Dockerfile.cpu}
+      dockerfile: Dockerfile.gptoss
     command: >
       python -m vllm.entrypoints.openai.api_server
         --model "${MODEL}" --device cpu --host 0.0.0.0 --port 8000

--- a/requirements-cpu.in
+++ b/requirements-cpu.in
@@ -41,3 +41,4 @@ a2wsgi>=1.4
 polars>=0.20.16
 httpx>=0.27.0
 cryptography>=42.0.0
+vllm>=0.10.0

--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -595,6 +595,8 @@ urllib3==2.5.0
     #   requests
 uvicorn==0.35.0
     # via mlflow-skinny
+vllm==0.10.0
+    # via -r requirements-cpu.in
 websocket-client==1.8.0
     # via pybit
 websockets==15.0.1


### PR DESCRIPTION
## Summary
- build gptoss service from dedicated Dockerfile.gptoss
- add vllm dependency to CPU requirements

## Testing
- `pytest`
- `flake8`
- `docker build -f Dockerfile.gptoss -t gptoss-test .` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_689de3be8fcc832da218054c9bf10561