### PR TITLE
Specify CPU device for vLLM

### DIFF
--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -9,6 +9,7 @@ services:
     environment:
       VLLM_LOGGING_LEVEL: DEBUG
       MODEL: ${MODEL}
+      VLLM_DEVICE: cpu
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:8000/health"]
       interval: 10s


### PR DESCRIPTION
## Summary
- set `VLLM_DEVICE` environment variable in CPU docker-compose to avoid device inference errors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689deaf29280832d91721f3e42dfda3b