### PR TITLE
chore: enhance trivy workflow with artifact and severity limit

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -42,11 +42,21 @@ jobs:
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH
+          limit-severities-for-sarif: CRITICAL
+
+      - name: Show Trivy scan results
+        run: cat trivy-results.sarif
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@d6c5e1b140009be28958d3837ed3be3fb637d8c0 # v3
         with:
           sarif_file: 'trivy-results.sarif'
+
+      - name: Upload Trivy report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-results
+          path: trivy-results.sarif
 
       - name: Free disk space
         run: docker system prune -af


### PR DESCRIPTION
## Summary
- show Trivy SARIF report in CI logs
- keep Trivy SARIF as build artifact
- restrict SARIF to critical findings

## Testing
- `pre-commit run --files .github/workflows/trivy.yml`


------
https://chatgpt.com/codex/tasks/task_e_689e225c8748832dbbcdaab0e8d9fcdf