### PR TITLE
Add registry proxy config for Dependabot

### DIFF
--- a/.github/registries-proxy.json
+++ b/.github/registries-proxy.json
@@ -1,1 +1,5 @@
-
+{
+  "github.com": {
+    "address": "http://proxy.example.com:8080"
+  }
+}

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -11,10 +11,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
-      - name: Load registry proxy config
-        id: proxy-config
-        run: |
-          echo "json=$(cat .github/registries-proxy.json)" >> "$GITHUB_OUTPUT"
       - name: Run Dependabot
         run: scripts/run_dependabot.sh
         env:
@@ -26,4 +22,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.TOKEN }}
           GITHUB_DEPENDABOT_JOB_TOKEN: ${{ secrets.GITHUB_DEPENDABOT_JOB_TOKEN }}
           GITHUB_DEPENDABOT_CRED_TOKEN: ${{ secrets.GITHUB_DEPENDABOT_CRED_TOKEN }}
-          GITHUB_REGISTRIES_PROXY: ${{ steps.proxy-config.outputs.json }}
+          GITHUB_REGISTRIES_PROXY: .github/registries-proxy.json


### PR DESCRIPTION
## Summary
- add sample registry proxy config
- point Dependabot workflow to config file

## Testing
- `pre-commit run --files .github/registries-proxy.json .github/workflows/dependabot.yml` *(fails: KeyboardInterrupt)*
- `GITHUB_REPOSITORY=foo/bar GITHUB_TOKEN=dummy scripts/run_dependabot.sh` *(fails: 404 Not Found)*

------
https://chatgpt.com/codex/tasks/task_e_689e221db878832d8b2b81aa00c838d1