### PR TITLE
chore: bump trivy to v0.65.0

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -33,11 +33,17 @@ jobs:
         run: |
           docker build -f Dockerfile.ci -t ghcr.io/${{ github.repository }}:${{ github.sha }} .
 
+      - name: Set up Trivy
+        uses: aquasecurity/setup-trivy@v0.2.3
+        with:
+          version: v0.65.0
+
       - name: Run Trivy vulnerability scanner
         env:
           TRIVY_CACHE_DIR: /tmp/trivy-cache
         uses: aquasecurity/trivy-action@0.32.0
         with:
+          version: v0.65.0
           image-ref: ghcr.io/${{ github.repository }}:${{ github.sha }}
           format: sarif
           output: trivy-results.sarif


### PR DESCRIPTION
## Summary
- set Trivy and setup action version to v0.65.0 in workflow

## Testing
- `pre-commit run --files .github/workflows/trivy.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e225b3acc832da17b8399728afc7a