### PR TITLE
Downgrade protobuf to match TensorFlow gencode

### DIFF
--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -381,7 +381,7 @@ propcache==0.3.2
     # via
     #   aiohttp
     #   yarl
-protobuf==6.31.1
+protobuf==5.28.3
     # via
     #   mlflow-skinny
     #   mlflow-tracing


### PR DESCRIPTION
## Summary
- set protobuf to 5.28.3 in CPU requirements to align with TensorFlow build

## Testing
- `python -c "import tensorflow as tf"`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e23e2839c832dba36ff7d4b547d5d