### PR TITLE
fix gptoss cpu startup configuration

### DIFF
--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -8,8 +8,9 @@ services:
         --model "${MODEL}" --device cpu --host 0.0.0.0 --port 8000
     environment:
       VLLM_LOGGING_LEVEL: DEBUG
-      MODEL: ${MODEL}
+      MODEL: ${MODEL:-openai/gpt-oss-20b}
       VLLM_DEVICE: cpu
+      VLLM_FORCE_CPU: "1"
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:8000/health"]
       interval: 10s


### PR DESCRIPTION
## Summary
- ensure docker compose CPU override uses a default model
- force vLLM to run in CPU mode

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e23cc820c832db919441a87f11683