### PR TITLE
Configure CPU default platform for GPT-OSS service

### DIFF
--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -1,5 +1,5 @@
 services:
-  gptoss:
+  bot-gptoss:
     build:
       context: .
       dockerfile: Dockerfile.gptoss
@@ -11,6 +11,7 @@ services:
       MODEL: ${MODEL:-openai/gpt-oss-20b}
       VLLM_DEVICE: cpu
       VLLM_FORCE_CPU: "1"
+      VLLM_DEFAULT_PLATFORM: cpu
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:8000/health"]
       interval: 10s


### PR DESCRIPTION
## Summary
- rename `gptoss` service to `bot-gptoss`
- set `VLLM_DEFAULT_PLATFORM=cpu` in CPU compose file

## Testing
- `pytest -q`
- `docker-compose -f docker-compose.cpu.yml build bot-gptoss` *(fails: Error while fetching server API version: ('Connection aborted.', ConnectionRefusedError(111, 'Connection refused')))*
- `docker-compose -f docker-compose.cpu.yml up` *(fails: Error while fetching server API version: ('Connection aborted.', ConnectionRefusedError(111, 'Connection refused')))*

------
https://chatgpt.com/codex/tasks/task_e_689e2e7e3684832da86cf197b149b71f