### PR TITLE
chore: bump base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Этап сборки
-FROM nvidia/cuda:12.6.2-cudnn-devel-ubuntu24.04 AS builder
+FROM nvidia/cuda:13.0.0-cudnn-devel-ubuntu24.04 AS builder
 ARG ZLIB_VERSION=1.3.1
 ENV OMP_NUM_THREADS=1
 ENV MKL_NUM_THREADS=1
@@ -50,7 +50,7 @@ RUN pip install --no-cache-dir pip==25.2 'setuptools<81' wheel && \
     find /app/venv -type f -name '*.pyc' -delete
 
 # Этап выполнения (минимальный образ)
-FROM nvidia/cuda:12.6.2-cudnn-runtime-ubuntu24.04
+FROM nvidia/cuda:13.0.0-cudnn-runtime-ubuntu24.04
 ENV OMP_NUM_THREADS=1
 ENV MKL_NUM_THREADS=1
 ENV DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -2,7 +2,7 @@
 
 # -------- Builder stage --------
 # Используем LTS-образ для сборки зависимостей
-FROM ubuntu:24.04 AS builder
+FROM ubuntu:noble-20250716 AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
@@ -35,7 +35,7 @@ COPY services services
 COPY tests tests
 
 # -------- Runtime stage --------
-FROM ubuntu:24.04 AS runtime
+FROM ubuntu:noble-20250716 AS runtime
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV PIP_BREAK_SYSTEM_PACKAGES=1

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04 AS builder
+FROM ubuntu:noble-20250716 AS builder
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Обновление linux-libc-dev устраняет CVE-2025-21976, а libgcrypt20 — CVE-2024-2236
@@ -23,7 +23,7 @@ RUN python3 -m venv $VIRTUAL_ENV && \
     find $VIRTUAL_ENV -type d -name '__pycache__' -exec rm -rf {} + && \
     find $VIRTUAL_ENV -type f -name '*.pyc' -delete
 
-FROM ubuntu:24.04
+FROM ubuntu:noble-20250716
 
 # Обновление linux-libc-dev устраняет CVE-2025-21976, а libgcrypt20 — CVE-2024-2236
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary
- update Ubuntu base image to `noble-20250716`
- upgrade CUDA base to `13.0.0-cudnn`

## Testing
- `pytest`
- `pre-commit run --files Dockerfile Dockerfile.ci Dockerfile.cpu`
- `trivy image ubuntu:noble-20250716`
- `trivy image nvidia/cuda:13.0.0-cudnn-runtime-ubuntu24.04`
- `docker build -f Dockerfile.ci -t bot-ci:latest .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_689e33ba447c832da0d719e6545e7bd8