### PR TITLE
Use python base and install vllm

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -1,6 +1,13 @@
-FROM vllm/vllm-openai:latest
+FROM python:3.12-slim
 
-# Исправляем отсутствие libtbbmalloc.so.2 и ставим curl для health‑check’а
- && rm -rf /var/lib/apt/lists/*
+# Исправляем отсутствие libtbbmalloc.so.2 и ставим curl для health-check’а
+RUN apt-get update && apt-get install -y libtbbmalloc2 curl \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PYTHONUNBUFFERED=1 HF_HOME=/workspace/hf-cache
+
+RUN pip install --no-cache-dir "vllm>=0.6,<0.7"
 
 EXPOSE 8000
+
+CMD ["python", "-m", "vllm.entrypoints.openai.api_server", "--host", "0.0.0.0", "--port", "8000", "--model", "Qwen/Qwen2.5-0.5B-Instruct", "--device", "cpu", "--max-num-seqs", "4"]


### PR DESCRIPTION
## Summary
- switch Dockerfile.gptoss to python:3.12-slim base
- install vllm and set unbuffered python env
- run vllm OpenAI-compatible server by default

## Testing
- `pre-commit run --files Dockerfile.gptoss`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e367e30b0832db93c89ab9891d374