### PR TITLE
Disable system proxies for async HTTP requests

### DIFF
--- a/gpt_client.py
+++ b/gpt_client.py
@@ -61,7 +61,7 @@ async def query_gpt_async(prompt: str) -> str:
     api_url = os.getenv("GPT_OSS_API", "http://localhost:8003")
     url = api_url.rstrip("/") + "/v1/completions"
     try:
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(trust_env=False) as client:
             response = await client.post(url, json={"prompt": prompt}, timeout=5)
             response.raise_for_status()
             try:

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -63,7 +63,7 @@ async def send_telegram_alert(message: str) -> None:
         return
     url = f"https://api.telegram.org/bot{token}/sendMessage"
     try:
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(trust_env=False) as client:
             await client.post(
                 url, data={"chat_id": chat_id, "text": message}, timeout=5
             )
@@ -141,7 +141,7 @@ async def check_services() -> None:
     }
     if env.get("gptoss_api"):
         services["gptoss"] = (env["gptoss_api"], "health")
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(trust_env=False) as client:
         for name, (url, endpoint) in services.items():
             for attempt in range(retries):
                 try:
@@ -164,7 +164,7 @@ async def check_services() -> None:
 async def fetch_price(symbol: str, env: dict) -> float | None:
     """Return current price or ``None`` if the request fails."""
     try:
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(trust_env=False) as client:
             resp = await client.get(
                 f"{env['data_handler_url']}/price/{symbol}", timeout=5
             )
@@ -214,7 +214,7 @@ async def build_feature_vector(price: float) -> list[float]:
 async def get_prediction(symbol: str, features: list[float], env: dict) -> dict | None:
     """Return raw model prediction output for the given ``features``."""
     try:
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(trust_env=False) as client:
             resp = await client.post(
                 f"{env['model_builder_url']}/predict",
                 json={"symbol": symbol, "features": features},
@@ -352,7 +352,7 @@ async def send_trade_async(
         payload, headers, timeout = _build_trade_payload(
             symbol, side, price, tp, sl, trailing_stop
         )
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(trust_env=False) as client:
             resp = await client.post(
                 f"{env['trade_manager_url']}/open_position",
                 json=payload,
@@ -434,7 +434,7 @@ def _resolve_trade_params(
 async def reactive_trade(symbol: str, env: dict | None = None) -> None:
     """Asynchronously fetch prediction and open position if signaled."""
     env = env or _load_env()
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(trust_env=False) as client:
         try:
             resp = await client.get(
                 f"{env['data_handler_url']}/price/{symbol}", timeout=5.0


### PR DESCRIPTION
## Summary
- set `trust_env=False` on all `httpx.AsyncClient` usages to ignore system proxy settings

## Testing
- `export HTTP_PROXY=http://127.0.0.1:9 HTTPS_PROXY=http://127.0.0.1:9`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e37a9b10c832db703e878de4f5ef5