### PR TITLE
feat: add position monitoring

### DIFF
--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -53,6 +53,9 @@ def _record(
     amount: float,
     action: str,
     trailing_stop: float | None = None,
+    tp: float | None = None,
+    sl: float | None = None,
+    entry_price: float | None = None,
 ) -> None:
     POSITIONS.append(
         {
@@ -62,6 +65,9 @@ def _record(
             'amount': amount,
             'action': action,
             'trailing_stop': trailing_stop,
+            'tp': tp,
+            'sl': sl,
+            'entry_price': entry_price,
         }
     )
 
@@ -153,7 +159,17 @@ def open_position() -> tuple:
         if any(not o or o.get('id') is None for o in orders):
             app.logger.error('failed to create one or more orders')
             return jsonify({'error': 'order creation failed'}), 500
-        _record(order, symbol, side, amount, 'open', trailing_stop)
+        _record(
+            order,
+            symbol,
+            side,
+            amount,
+            'open',
+            trailing_stop,
+            tp,
+            sl,
+            price if price > 0 else None,
+        )
         return jsonify({'status': 'ok', 'order_id': order.get('id')})
     except CCXT_NETWORK_ERROR as exc:  # pragma: no cover - network errors
         app.logger.exception('network error creating order: %s', exc)

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -378,6 +378,72 @@ async def send_trade_async(
         return False
 
 
+async def monitor_positions(env: dict, interval: float = INTERVAL) -> None:
+    """Poll open positions and close them when exit conditions are met."""
+    trail_state: dict[str, float] = {}
+    async with httpx.AsyncClient() as client:
+        while True:
+            try:
+                resp = await client.get(
+                    f"{env['trade_manager_url']}/positions", timeout=5
+                )
+                positions = resp.json().get("positions", [])
+            except (httpx.HTTPError, ValueError) as exc:
+                logger.error("Failed to fetch positions: %s", exc)
+                positions = []
+
+            for pos in positions:
+                order_id = pos.get("id")
+                symbol = pos.get("symbol")
+                side = pos.get("side")
+                tp = pos.get("tp")
+                sl = pos.get("sl")
+                trailing = pos.get("trailing_stop")
+                entry = pos.get("entry_price")
+                if not order_id or not symbol or not side:
+                    continue
+                price = await fetch_price(symbol, env)
+                if price is None:
+                    continue
+                reason = None
+                if side == "buy":
+                    if tp is not None and price >= tp:
+                        reason = "tp"
+                    elif sl is not None and price <= sl:
+                        reason = "sl"
+                    else:
+                        base = trail_state.get(order_id, entry or price)
+                        base = max(base, price)
+                        trail_state[order_id] = base
+                        if trailing is not None and price <= base - trailing:
+                            reason = "trailing_stop"
+                    close_side = "sell"
+                else:
+                    if tp is not None and price <= tp:
+                        reason = "tp"
+                    elif sl is not None and price >= sl:
+                        reason = "sl"
+                    else:
+                        base = trail_state.get(order_id, entry or price)
+                        base = min(base, price)
+                        trail_state[order_id] = base
+                        if trailing is not None and price >= base + trailing:
+                            reason = "trailing_stop"
+                    close_side = "buy"
+
+                if reason:
+                    try:
+                        await client.post(
+                            f"{env['trade_manager_url']}/close_position",
+                            json={"order_id": order_id, "side": close_side},
+                            timeout=5,
+                        )
+                    except httpx.HTTPError as exc:
+                        logger.error("Failed to close position %s: %s", order_id, exc)
+                    trail_state.pop(order_id, None)
+            await asyncio.sleep(interval)
+
+
 def _parse_trade_params(
     tp: float | str | None = None,
     sl: float | str | None = None,


### PR DESCRIPTION
## Summary
- add function to monitor open positions and auto-close via trade_manager
- store tp/sl/entry info in trade_manager service positions
- test position monitoring logic

## Testing
- `pytest tests/test_trading_bot.py::test_monitor_positions_tp tests/test_trading_bot.py::test_monitor_positions_sl tests/test_trading_bot.py::test_monitor_positions_trailing_stop -q`
- `pytest tests/test_service_scripts.py::test_trade_manager_service_endpoints -m integration -q`


------
https://chatgpt.com/codex/tasks/task_e_689e37ac91b4832db1f03080aa2d1f73