### PR TITLE
Add enforce-eager flag to GPT-OSS CMD

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -10,4 +10,4 @@ RUN pip install --no-cache-dir "vllm>=0.6,<0.7"
 
 EXPOSE 8000
 
-CMD ["python", "-m", "vllm.entrypoints.openai.api_server", "--host", "0.0.0.0", "--port", "8000", "--model", "Qwen/Qwen2.5-0.5B-Instruct", "--device", "cpu", "--max-num-seqs", "4"]
+CMD ["python", "-m", "vllm.entrypoints.openai.api_server", "--host", "0.0.0.0", "--port", "8000", "--model", "Qwen/Qwen2.5-0.5B-Instruct", "--device", "cpu", "--max-num-seqs", "4", "--enforce-eager"]


### PR DESCRIPTION
## Summary
- add `--enforce-eager` flag to GPT-OSS `vllm` server command to support eager execution

## Testing
- `docker --version` *(fails: command not found)*
- `docker compose version` *(fails: command not found)*
- `docker compose build gptoss` *(fails: command not found)*
- `docker compose up -d gptoss` *(fails: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f39b953f0832d80c3692b8b593eb1