### PR TITLE
Remove dev packages from runtime Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,17 +61,12 @@ ENV TZ=Etc/UTC
 
 WORKDIR /app
 
-# Установка минимальных пакетов для выполнения и обновление критических библиотек
-# Обновление linux-libc-dev устраняет CVE-2024-50217 и CVE-2025-21976, а libgcrypt20 — CVE-2024-2236
+# Установка минимальных пакетов выполнения
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     tzdata \
-    linux-libc-dev \
-    libgcrypt20 \
-    libpam0g \
     libssl3t64 \
     python3.12-minimal \
     python3 \
-    python3-venv \
     zlib1g \
     tar \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -45,9 +45,6 @@ ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
 # Устанавливаем только необходимые пакеты выполнения
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
-    linux-libc-dev \
-    libgcrypt20 \
-    libpam0g \
     libssl3t64 \
     python3.12-minimal \
     python3 \

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -28,15 +28,12 @@ RUN python3 -m venv $VIRTUAL_ENV && \
 
 FROM ubuntu:noble-20250716
 
-# Обновление linux-libc-dev устраняет CVE-2025-21976, а libgcrypt20 — CVE-2024-2236
+# Установка минимальных пакетов выполнения
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
-    linux-libc-dev \
-    libgcrypt20 \
-    libpam0g \
     libssl3t64 \
     python3.12-minimal \
     curl \
-    python3 python3-venv \
+    python3 \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && python3 --version
 


### PR DESCRIPTION
## Summary
- drop linux-libc-dev and other dev libraries from runtime stages in Dockerfile, Dockerfile.ci, and Dockerfile.cpu
- leave only essential runtime packages like libssl3t64 and python

## Testing
- `pytest`
- `docker build -f Dockerfile.ci -t bot-ci .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_689f3cbf84b8832db13d9e82381c8aea