### PR TITLE
feat: ignore unfixed vulnerabilities

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -48,6 +48,8 @@ jobs:
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          # ignore-unlikely-affected: true  # enable once Trivy >= v0.66 is available
           limit-severities-for-sarif: CRITICAL
 
       - name: Show Trivy scan results


### PR DESCRIPTION
## Summary
- reduce Trivy report noise by ignoring unfixed vulnerabilities
- note to enable `ignore-unlikely-affected` once Trivy v0.66 lands

## Testing
- `pytest`
- `trivy image --severity CRITICAL,HIGH --format table --no-progress python:3.7`
- `trivy image --severity CRITICAL,HIGH --format table --no-progress --ignore-unfixed python:3.7`


------
https://chatgpt.com/codex/tasks/task_e_689f3cd15028832dad0f3cb0feb2af4e