### PR TITLE
feat: disable async output processing

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -10,4 +10,4 @@ RUN pip install --no-cache-dir "vllm>=0.6,<0.7"
 
 EXPOSE 8000
 
-CMD ["python", "-m", "vllm.entrypoints.openai.api_server", "--host", "0.0.0.0", "--port", "8000", "--model", "Qwen/Qwen2.5-0.5B-Instruct", "--device", "cpu", "--max-num-seqs", "4", "--enforce-eager"]
+CMD ["python", "-m", "vllm.entrypoints.openai.api_server", "--host", "0.0.0.0", "--port", "8000", "--model", "Qwen/Qwen2.5-0.5B-Instruct", "--device", "cpu", "--max-num-seqs", "4", "--enforce-eager", "--disable-async-output-proc"]


### PR DESCRIPTION
## Summary
- add `--disable-async-output-proc` flag to vLLM server startup command

## Testing
- `pytest`
- `python -m vllm.entrypoints.openai.api_server --host 0.0.0.0 --port 8000 --model Qwen/Qwen2.5-0.5B-Instruct --device cpu --max-num-seqs 4 --enforce-eager --disable-async-output-proc`

------
https://chatgpt.com/codex/tasks/task_e_689f491e975c832d89f6b666fd9d1f67