### PR TITLE
Use httpx client in GPT client

### DIFF
--- a/gpt_client.py
+++ b/gpt_client.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import httpx
-import requests
 
 logger = logging.getLogger("TradingBot")
 
@@ -31,9 +30,10 @@ def query_gpt(prompt: str) -> str:
     api_url = os.getenv("GPT_OSS_API", "http://localhost:8003")
     url = api_url.rstrip("/") + "/v1/completions"
     try:
-        response = requests.post(url, json={"prompt": prompt}, timeout=5)
-        response.raise_for_status()
-    except requests.RequestException as exc:  # pragma: no cover - network errors
+        with httpx.Client(trust_env=False) as client:
+            response = client.post(url, json={"prompt": prompt}, timeout=5)
+            response.raise_for_status()
+    except httpx.HTTPError as exc:  # pragma: no cover - network errors
         logger.exception("Error querying GPT OSS API: %s", exc)
         raise GPTClientNetworkError("Failed to query GPT OSS API") from exc
     try:

--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -1,5 +1,4 @@
 import pytest
-import requests
 import httpx
 
 from bot.gpt_client import (
@@ -26,28 +25,28 @@ class DummyResponse:
 
 
 def test_query_gpt_network_error(monkeypatch):
-    def fake_post(*args, **kwargs):
-        raise requests.RequestException("boom")
+    def fake_post(self, *args, **kwargs):
+        raise httpx.HTTPError("boom")
 
-    monkeypatch.setattr(requests, "post", fake_post)
+    monkeypatch.setattr(httpx.Client, "post", fake_post)
     with pytest.raises(GPTClientNetworkError):
         query_gpt("hi")
 
 
 def test_query_gpt_non_json(monkeypatch):
-    def fake_post(*args, **kwargs):
+    def fake_post(self, *args, **kwargs):
         return DummyResponse(json_exc=ValueError("no json"))
 
-    monkeypatch.setattr(requests, "post", fake_post)
+    monkeypatch.setattr(httpx.Client, "post", fake_post)
     with pytest.raises(GPTClientJSONError):
         query_gpt("hi")
 
 
 def test_query_gpt_missing_fields(monkeypatch):
-    def fake_post(*args, **kwargs):
+    def fake_post(self, *args, **kwargs):
         return DummyResponse(json_data={"foo": "bar"})
 
-    monkeypatch.setattr(requests, "post", fake_post)
+    monkeypatch.setattr(httpx.Client, "post", fake_post)
     with pytest.raises(GPTClientResponseError):
         query_gpt("hi")
 


### PR DESCRIPTION
## Summary
- Replace requests with httpx.Client(trust_env=False) in query_gpt
- Adjust tests to mock httpx client

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f4a441188832d971221cc42d7dc86