### PR TITLE
Track async tasks and log exceptions in run_async

### DIFF
--- a/tests/test_run_async.py
+++ b/tests/test_run_async.py
@@ -1,0 +1,21 @@
+import asyncio
+import logging
+import pytest
+
+from bot import trading_bot
+
+
+@pytest.mark.asyncio
+async def test_run_async_logs_exception(caplog):
+    caplog.set_level(logging.ERROR)
+
+    async def boom():
+        raise RuntimeError("boom")
+
+    trading_bot.run_async(boom())
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("run_async task failed" in m for m in messages)
+    assert not trading_bot._TASKS


### PR DESCRIPTION
## Summary
- ensure run_async retains created tasks and logs exceptions via callback
- add test verifying that failing coroutine is logged

## Testing
- `pytest tests/test_run_async.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f4a4979e8832dacfc31fe821fd926