### PR TITLE
Use CPU-targeted vLLM in gptoss Dockerfile

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -5,8 +5,10 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y libtbbmalloc2 cur
     && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONUNBUFFERED=1 HF_HOME=/workspace/hf-cache
+ENV VLLM_TARGET_DEVICE=cpu
+ENV PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu
 
-RUN pip install --no-cache-dir "vllm>=0.6,<0.7"
+RUN pip install --no-cache-dir git+https://github.com/vllm-project/vllm@v0.10.0
 
 EXPOSE 8000
 


### PR DESCRIPTION
## Summary
- set VLLM_TARGET_DEVICE and PIP_EXTRA_INDEX_URL for CPU builds
- install vLLM v0.10.0 from GitHub in gptoss image

## Testing
- `pytest`
- `docker build -f Dockerfile.gptoss -t bot-gptoss-cpu .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_689f491c5740832d81e6d51d105d191a