### PR TITLE
Use PBKDF2 password hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@
 
 **Disclaimer**: This project is provided for educational purposes only and does not constitute financial advice. Use at your own risk.
 
+### Работа с паролями
+
+Модуль `password_utils.py` предоставляет функции `hash_password` и
+`verify_password`. Для проверки используется `hmac.compare_digest`, что
+обеспечивает сравнение в постоянное время и защищает от атак по
+времени.
+
 ## Быстрый старт
 
 1. Установите зависимости. Варианты для GPU и CPU:

--- a/password_utils.py
+++ b/password_utils.py
@@ -1,13 +1,35 @@
-import crypt
+import base64
+import hashlib
+import hmac
+import os
 
 MAX_PASSWORD_LENGTH = 64
+SALT_SIZE = 16
+PBKDF2_ITERATIONS = 100_000
 
-def hash_password(password: str, salt: str) -> str:
-    """Hash a password using system crypt with a length limit.
+
+def hash_password(password: str, salt: bytes | None = None) -> str:
+    """Hash a password with PBKDF2-HMAC-SHA256 and a random salt.
 
     Raises:
         ValueError: if the password exceeds MAX_PASSWORD_LENGTH.
+
+    Returns:
+        str: base64 encoded salt and hash.
     """
     if len(password) > MAX_PASSWORD_LENGTH:
         raise ValueError("Password exceeds maximum length")
-    return crypt.crypt(password, salt)
+    if salt is None:
+        salt = os.urandom(SALT_SIZE)
+    if isinstance(salt, str):
+        salt = salt.encode()
+    dk = hashlib.pbkdf2_hmac("sha256", password.encode(), salt, PBKDF2_ITERATIONS)
+    return base64.b64encode(salt + dk).decode()
+
+
+def verify_password(password: str, stored_hash: str) -> bool:
+    """Verify a password against a stored hash using constant-time comparison."""
+    data = base64.b64decode(stored_hash)
+    salt, hashed = data[:SALT_SIZE], data[SALT_SIZE:]
+    new_hash = hashlib.pbkdf2_hmac("sha256", password.encode(), salt, PBKDF2_ITERATIONS)
+    return hmac.compare_digest(hashed, new_hash)

--- a/tests/test_password_utils.py
+++ b/tests/test_password_utils.py
@@ -1,16 +1,22 @@
-import crypt
+import base64
 import pytest
 
-from password_utils import hash_password, MAX_PASSWORD_LENGTH
+from password_utils import (
+    SALT_SIZE,
+    MAX_PASSWORD_LENGTH,
+    hash_password,
+    verify_password,
+)
 
 
 def test_hash_password_allows_short_password():
-    salt = crypt.mksalt(crypt.METHOD_SHA512)
-    result = hash_password("a" * MAX_PASSWORD_LENGTH, salt)
-    assert result.startswith("$6$")
+    password = "a" * MAX_PASSWORD_LENGTH
+    result = hash_password(password)
+    data = base64.b64decode(result)
+    assert len(data) == SALT_SIZE + 32
+    assert verify_password(password, result)
 
 
 def test_hash_password_rejects_long_password():
-    salt = crypt.mksalt(crypt.METHOD_SHA512)
     with pytest.raises(ValueError):
-        hash_password("a" * (MAX_PASSWORD_LENGTH + 1), salt)
+        hash_password("a" * (MAX_PASSWORD_LENGTH + 1))


### PR DESCRIPTION
## Summary
- replace legacy `crypt.crypt` with PBKDF2-HMAC-SHA256 and random salt
- add constant-time `verify_password` helper and document password utilities
- adjust tests for new base64 hash format

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f4b3413f8832da6659351091f434e