### PR TITLE
Switch to bcrypt for password hashing

### DIFF
--- a/password_utils.py
+++ b/password_utils.py
@@ -1,35 +1,16 @@
-import base64
-import hashlib
-import hmac
-import os
+import bcrypt
 
 MAX_PASSWORD_LENGTH = 64
-SALT_SIZE = 16
-PBKDF2_ITERATIONS = 100_000
 
 
-def hash_password(password: str, salt: bytes | None = None) -> str:
-    """Hash a password with PBKDF2-HMAC-SHA256 and a random salt.
-
-    Raises:
-        ValueError: if the password exceeds MAX_PASSWORD_LENGTH.
-
-    Returns:
-        str: base64 encoded salt and hash.
-    """
+def hash_password(password: str) -> str:
+    """Хэширует пароль, используя bcrypt."""
     if len(password) > MAX_PASSWORD_LENGTH:
         raise ValueError("Password exceeds maximum length")
-    if salt is None:
-        salt = os.urandom(SALT_SIZE)
-    if isinstance(salt, str):
-        salt = salt.encode()
-    dk = hashlib.pbkdf2_hmac("sha256", password.encode(), salt, PBKDF2_ITERATIONS)
-    return base64.b64encode(salt + dk).decode()
+    return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
 
 
 def verify_password(password: str, stored_hash: str) -> bool:
-    """Verify a password against a stored hash using constant-time comparison."""
-    data = base64.b64decode(stored_hash)
-    salt, hashed = data[:SALT_SIZE], data[SALT_SIZE:]
-    new_hash = hashlib.pbkdf2_hmac("sha256", password.encode(), salt, PBKDF2_ITERATIONS)
-    return hmac.compare_digest(hashed, new_hash)
+    """Проверяет пароль по сохранённому bcrypt-хэшу."""
+    return bcrypt.checkpw(password.encode(), stored_hash.encode())
+

--- a/requirements.in
+++ b/requirements.in
@@ -43,3 +43,4 @@ a2wsgi>=1.4
 polars>=0.20.16
 httpx>=0.27.0
 cryptography>=42.0.0
+bcrypt>=4.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,8 @@ attrs>=25.3.0
     #   aiohttp
     #   jsonschema
     #   referencing
+bcrypt>=4.2.0
+    # via -r requirements.in
 blinker>=1.9.0
     # via flask
 cachetools>=5.5.2

--- a/tests/test_password_utils.py
+++ b/tests/test_password_utils.py
@@ -1,22 +1,21 @@
-import base64
 import pytest
 
-from password_utils import (
-    SALT_SIZE,
-    MAX_PASSWORD_LENGTH,
-    hash_password,
-    verify_password,
-)
+from password_utils import MAX_PASSWORD_LENGTH, hash_password, verify_password
 
 
 def test_hash_password_allows_short_password():
     password = "a" * MAX_PASSWORD_LENGTH
-    result = hash_password(password)
-    data = base64.b64decode(result)
-    assert len(data) == SALT_SIZE + 32
-    assert verify_password(password, result)
+    hashed = hash_password(password)
+    assert hashed.startswith("$2b$")
+    assert verify_password(password, hashed)
 
 
 def test_hash_password_rejects_long_password():
     with pytest.raises(ValueError):
         hash_password("a" * (MAX_PASSWORD_LENGTH + 1))
+
+
+def test_hash_password_generates_unique_hashes():
+    password = "secret"
+    assert hash_password(password) != hash_password(password)
+


### PR DESCRIPTION
## Summary
- replace PBKDF2 password hashing with bcrypt
- add bcrypt dependency
- test bcrypt hashes and verification

## Testing
- `pip install bcrypt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f4df7f814832da83b28eb2cd4cbab