### PR TITLE
refactor: replace requests with httpx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ ENV VIRTUAL_ENV=/app/venv
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Устанавливаем зависимости (pip >=25.2 включает requests >=2.32.4 и устраняет CVE-2023-32681)
+# Устанавливаем зависимости (pip >=25.2 и устраняет CVE-2023-32681)
 RUN pip install --no-cache-dir pip==25.2 'setuptools<81' wheel && \
     pip install --no-cache-dir -r requirements.txt && \
     find /app/venv -type d -name '__pycache__' -exec rm -rf {} + && \

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -19,7 +19,7 @@ COPY requirements-cpu.txt .
 
 ENV VIRTUAL_ENV=/app/venv
 RUN python3 -m venv $VIRTUAL_ENV && \
-    # pip >=25.2 включает requests >=2.32.4 и устраняет CVE-2023-32681
+    # pip >=25.2 и устраняет CVE-2023-32681
     $VIRTUAL_ENV/bin/pip install --no-cache-dir pip==25.2 'setuptools<81' wheel && \
     $VIRTUAL_ENV/bin/pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -r requirements-cpu.txt && \
     $VIRTUAL_ENV/bin/pip freeze | grep -i '^nvidia-' | cut -d= -f1 | xargs -r $VIRTUAL_ENV/bin/pip uninstall -y && \

--- a/README.md
+++ b/README.md
@@ -671,7 +671,7 @@ are skipped automatically. Install the package to run the full suite.
 
 As noted above, make sure to run `./scripts/setup-tests.sh` before
 executing `pytest`; otherwise imports such as `numpy`, `pandas`, `scipy` and
-`requests` will fail.
+`httpx` will fail.
 
 Чтобы выполнить тесты на машине без GPU, создайте виртуальное окружение и установите зависимости из `requirements-cpu.txt`.
 Пакет включает CPU‑сборки `torch` и `tensorflow`, поэтому тесты не подтягивают CUDA‑библиотеки.

--- a/gpt_client.py
+++ b/gpt_client.py
@@ -30,8 +30,8 @@ def query_gpt(prompt: str) -> str:
     api_url = os.getenv("GPT_OSS_API", "http://localhost:8003")
     url = api_url.rstrip("/") + "/v1/completions"
     try:
-        with httpx.Client(trust_env=False) as client:
-            response = client.post(url, json={"prompt": prompt}, timeout=5)
+        with httpx.Client(trust_env=False, timeout=5) as client:
+            response = client.post(url, json={"prompt": prompt})
             response.raise_for_status()
     except httpx.HTTPError as exc:  # pragma: no cover - network errors
         logger.exception("Error querying GPT OSS API: %s", exc)
@@ -61,8 +61,8 @@ async def query_gpt_async(prompt: str) -> str:
     api_url = os.getenv("GPT_OSS_API", "http://localhost:8003")
     url = api_url.rstrip("/") + "/v1/completions"
     try:
-        async with httpx.AsyncClient(trust_env=False) as client:
-            response = await client.post(url, json={"prompt": prompt}, timeout=5)
+        async with httpx.AsyncClient(trust_env=False, timeout=5) as client:
+            response = await client.post(url, json={"prompt": prompt})
             response.raise_for_status()
             try:
                 data = response.json()

--- a/requirements-cpu.in
+++ b/requirements-cpu.in
@@ -33,7 +33,6 @@ catalyst==21.5
 pytest>=8.1.1
 pytest-asyncio>=1.0.0
 flask>=3.0.2
-requests>=2.32.4
 pybit>=5.11.0
 flake8>=7.3.0
 gunicorn>=23.0.0

--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -57,13 +57,11 @@ certifi>=2025.8.3
     #   ccxt
     #   httpcore
     #   httpx
-    #   requests
 cffi>=1.17.1
     # via
     #   cryptography
     #   pycares
 charset-normalizer>=3.4.3
-    # via requests
 click>=8.2.1
     # via
     #   flask
@@ -168,7 +166,6 @@ idna>=3.10
     # via
     #   anyio
     #   httpx
-    #   requests
     #   yarl
 imbalanced-learn>=0.13.0
     # via -r requirements-cpu.in
@@ -458,7 +455,6 @@ referencing>=0.36.2
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests>=2.32.4
     # via
     #   -r requirements-cpu.in
     #   ccxt
@@ -592,7 +588,6 @@ tzdata>=2025.2
 urllib3>=2.5.0
     # via
     #   docker
-    #   requests
 uvicorn>=0.35.0
     # via mlflow-skinny
 vllm>=0.10.0

--- a/requirements.in
+++ b/requirements.in
@@ -35,7 +35,6 @@ catalyst==21.5
 pytest>=8.1.1
 pytest-asyncio>=1.0.0
 flask>=3.0.2
-requests>=2.32.4
 pybit>=5.11.0
 flake8>=7.3.0
 gunicorn>=23.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,13 +57,11 @@ certifi>=2025.8.3
     #   ccxt
     #   httpcore
     #   httpx
-    #   requests
 cffi>=1.17.1
     # via
     #   cryptography
     #   pycares
 charset-normalizer>=3.4.3
-    # via requests
 click>=8.2.1
     # via
     #   flask
@@ -172,7 +170,6 @@ idna>=3.10
     # via
     #   anyio
     #   httpx
-    #   requests
     #   yarl
 imbalanced-learn>=0.13.0
     # via -r requirements.in
@@ -469,7 +466,6 @@ referencing>=0.36.2
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests>=2.32.4
     # via
     #   -r requirements.in
     #   ccxt
@@ -607,7 +603,6 @@ tzdata>=2025.2
 urllib3>=2.5.0
     # via
     #   docker
-    #   requests
 uvicorn>=0.35.0
     # via mlflow-skinny
 websocket-client>=1.8.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -187,14 +187,6 @@ def _stub_modules():
     tenacity_mod.stop_after_attempt = lambda *a, **k: (lambda f: f)
     sys.modules.setdefault("tenacity", tenacity_mod)
 
-    try:
-        import requests  # noqa: F401
-    except Exception:
-        requests_mod = types.ModuleType("requests")
-        requests_mod.RequestException = Exception
-        requests_mod.get = lambda *a, **k: None
-        requests_mod.post = lambda *a, **k: None
-        sys.modules.setdefault("requests", requests_mod)
 
     joblib_mod = types.ModuleType("joblib")
     joblib_mod.dump = lambda *a, **k: None

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -4,7 +4,7 @@ import socket
 import multiprocessing
 from contextlib import contextmanager
 
-import requests
+import httpx
 
 
 def wait_for_service(
@@ -14,7 +14,7 @@ def wait_for_service(
     initial_delay: float = 0.1,
     max_delay: float = 1.0,
     backoff: float = 2.0,
-) -> requests.Response:
+) -> httpx.Response:
     """Poll ``url`` until it responds with HTTP 200 or until ``timeout`` expires.
 
     The function retries requests with exponential backoff. ``initial_delay`` sets
@@ -27,7 +27,7 @@ def wait_for_service(
     last_exc: Exception | None = None
     while True:
         try:
-            resp = requests.get(url, timeout=0.2)
+            resp = httpx.get(url, timeout=0.2, trust_env=False)
             if resp.status_code == 200:
                 return resp
         except Exception as exc:  # pragma: no cover

--- a/tests/test_integration_services.py
+++ b/tests/test_integration_services.py
@@ -1,5 +1,5 @@
 import os
-import requests
+import httpx
 import multiprocessing
 import sys
 import signal
@@ -118,7 +118,7 @@ def test_services_communicate(monkeypatch):
         monkeypatch.setenv('MODEL_BUILDER_URL', f'http://localhost:{mb_port}')
         monkeypatch.setenv('TRADE_MANAGER_URL', f'http://localhost:{tm_port}')
         asyncio.run(trading_bot.run_once_async())
-        resp = requests.get(f'http://localhost:{tm_port}/positions', timeout=5)
+        resp = httpx.get(f'http://localhost:{tm_port}/positions', timeout=5, trust_env=False)
         data = resp.json()
         assert data['positions'], 'position was not created'
 
@@ -139,11 +139,11 @@ def test_service_availability_check(monkeypatch):
         stack.enter_context(
             service_process(ctx.Process(target=_run_tm, args=(tm_port,)), url=f'http://localhost:{tm_port}/ready')
         )
-        resp = requests.get(f'http://localhost:{dh_port}/ping', timeout=5)
+        resp = httpx.get(f'http://localhost:{dh_port}/ping', timeout=5, trust_env=False)
         assert resp.status_code == 200
-        resp = requests.get(f'http://localhost:{mb_port}/ping', timeout=5)
+        resp = httpx.get(f'http://localhost:{mb_port}/ping', timeout=5, trust_env=False)
         assert resp.status_code == 200
-        resp = requests.get(f'http://localhost:{tm_port}/ready', timeout=5)
+        resp = httpx.get(f'http://localhost:{tm_port}/ready', timeout=5, trust_env=False)
         assert resp.status_code == 200
 
 


### PR DESCRIPTION
## Summary
- use httpx client with timeout in GPT client
- drop requests in tooling and tests
- prune requests from requirements

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f4df865cc832d97b4764f0c6708fd