### PR TITLE
Add request parameter validation

### DIFF
--- a/server.py
+++ b/server.py
@@ -4,7 +4,7 @@ from typing import List
 
 import torch
 from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 
@@ -85,14 +85,14 @@ class ChatMessage(BaseModel):
 
 class ChatRequest(BaseModel):
     messages: List[ChatMessage]
-    temperature: float = 0.7
-    max_tokens: int = 16
+    temperature: float = Field(0.7, ge=0.0, le=2.0)
+    max_tokens: int = Field(16, ge=1, le=512)
 
 
 class CompletionRequest(BaseModel):
     prompt: str
-    temperature: float = 0.7
-    max_tokens: int = 16
+    temperature: float = Field(0.7, ge=0.0, le=2.0)
+    max_tokens: int = Field(16, ge=1, le=512)
 
 
 @app.post("/v1/chat/completions")

--- a/tests/test_server_request_validation.py
+++ b/tests/test_server_request_validation.py
@@ -1,0 +1,40 @@
+import server
+from fastapi.testclient import TestClient
+
+
+def make_client():
+    def dummy_load_model():
+        server.tokenizer = object()
+        server.model = object()
+    server.load_model = dummy_load_model
+    return TestClient(server.app)
+
+
+def test_chat_completions_validation():
+    with make_client() as client:
+        resp = client.post(
+            "/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "hi"}], "temperature": 2.1},
+        )
+        assert resp.status_code == 422
+
+        resp = client.post(
+            "/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "hi"}], "max_tokens": 513},
+        )
+        assert resp.status_code == 422
+
+
+def test_completions_validation():
+    with make_client() as client:
+        resp = client.post(
+            "/v1/completions",
+            json={"prompt": "hi", "temperature": -0.1},
+        )
+        assert resp.status_code == 422
+
+        resp = client.post(
+            "/v1/completions",
+            json={"prompt": "hi", "max_tokens": 0},
+        )
+        assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- validate temperature and max_tokens with Pydantic Field
- test 422 responses for invalid generation parameters

## Testing
- `pre-commit run --files server.py tests/test_server_request_validation.py`
- `pytest tests/test_server_request_validation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f4df7ccfc832d8f770ed3a77e7d33