### PR TITLE
Use PyPI vllm in gptoss Dockerfile

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -7,8 +7,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y libtbbmalloc2 cur
 ENV PYTHONUNBUFFERED=1 HF_HOME=/workspace/hf-cache
 ENV VLLM_TARGET_DEVICE=cpu
 ENV PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu
-
-RUN pip install --no-cache-dir git+https://github.com/vllm-project/vllm@v0.10.0
+RUN pip install --no-cache-dir "vllm==0.10.0"
 
 EXPOSE 8000
 


### PR DESCRIPTION
## Summary
- install vllm 0.10.0 from PyPI in Dockerfile.gptoss
- keep vllm targeted to CPU with appropriate extra index

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'transformers')*
- `docker build -f Dockerfile.gptoss -t gptoss-test .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_689f56e100cc832d8e551a434a8308d7