### PR TITLE
Set VLLM target device for CPU compose

### DIFF
--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -11,9 +11,7 @@ services:
     environment:
       VLLM_LOGGING_LEVEL: DEBUG
       MODEL: ${MODEL:-openai/gpt-oss-20b}
-      VLLM_DEVICE: cpu
-      VLLM_FORCE_CPU: "1"
-      VLLM_DEFAULT_PLATFORM: cpu
+      VLLM_TARGET_DEVICE: cpu
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/v1/health"]
       interval: 5s


### PR DESCRIPTION
## Summary
- ensure cpu docker-compose uses VLLM_TARGET_DEVICE
- remove legacy VLLM_* variables to avoid conflicts

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'transformers')*


------
https://chatgpt.com/codex/tasks/task_e_689f71037af0832dbfa3f507f331e19d