### PR TITLE
Add monitoring task and cancellation in main_async

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -669,10 +669,12 @@ async def run_once_async() -> None:
 async def main_async() -> None:
     """Run the trading bot until interrupted."""
     train_task = None
+    monitor_task = None
     try:
         await check_services()
         env = _load_env()
         train_task = schedule_retrain(env["model_builder_url"], TRAIN_INTERVAL)
+        monitor_task = asyncio.create_task(monitor_positions(env))
         try:
             strategy_code = (
                 Path(__file__).with_name("strategy_optimizer.py").read_text(encoding="utf-8")
@@ -689,6 +691,10 @@ async def main_async() -> None:
     except KeyboardInterrupt:
         logger.info('Stopping trading bot')
     finally:
+        if monitor_task:
+            monitor_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await monitor_task
         if train_task:
             train_task.cancel()
             with suppress(asyncio.CancelledError):


### PR DESCRIPTION
## Summary
- start monitor_positions as background task before main loop
- ensure monitoring task is cancelled alongside scheduled retraining

## Testing
- `pre-commit run flake8 --files trading_bot.py`
- `pytest tests/test_trading_bot.py::test_monitor_positions_tp tests/test_trading_bot.py::test_monitor_positions_sl tests/test_trading_bot.py::test_monitor_positions_trailing_stop -q`


------
https://chatgpt.com/codex/tasks/task_e_689f715ff0b0832db4746012ab02861f