### PR TITLE
Add async JSON GPT query helper

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,3 @@
+from .gpt_client import query_gpt_json_async
+
+__all__ = ["query_gpt_json_async"]


### PR DESCRIPTION
## Summary
- add `query_gpt_json_async` to parse JSON from GPT OSS completions
- export new helper from package root

## Testing
- `pre-commit run flake8 --files gpt_client.py __init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689f70e984e8832d815d7152e2edf687