### PR TITLE
chore: use device-type flag in GPT-OSS Dockerfile

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -11,4 +11,4 @@ RUN pip install --no-cache-dir "vllm==0.10.0"
 
 EXPOSE 8000
 
-CMD ["python", "-m", "vllm.entrypoints.openai.api_server", "--host", "0.0.0.0", "--port", "8000", "--model", "Qwen/Qwen2.5-0.5B-Instruct", "--device", "cpu", "--max-num-seqs", "4", "--enforce-eager", "--disable-async-output-proc"]
+CMD ["python", "-m", "vllm.entrypoints.openai.api_server", "--host", "0.0.0.0", "--port", "8000", "--model", "Qwen/Qwen2.5-0.5B-Instruct", "--device-type", "cpu", "--max-num-seqs", "4", "--enforce-eager", "--disable-async-output-proc"]


### PR DESCRIPTION
## Summary
- swap deprecated `--device` option for `--device-type` in GPT-OSS Dockerfile

## Testing
- `pre-commit run --files Dockerfile.gptoss` *(fails: interrupted by KeyboardInterrupt; tests require large model download exceeding disk space)*
- `pytest tests/test_server_request_validation.py` *(fails: requires ~5GB model download; only ~3.5GB free)*

------
https://chatgpt.com/codex/tasks/task_e_689f71011c4c832db2eb74737dfb8e0b