### PR TITLE
Validate ticker price in data handler service

### DIFF
--- a/services/data_handler_service.py
+++ b/services/data_handler_service.py
@@ -25,7 +25,13 @@ CCXT_NETWORK_ERROR = getattr(ccxt, 'NetworkError', CCXT_BASE_ERROR)
 def price(symbol: str):
     try:
         ticker = exchange.fetch_ticker(symbol)
-        last = float(ticker.get('last') or 0.0)
+        last_raw = ticker.get('last')
+        try:
+            last = float(last_raw)
+        except (TypeError, ValueError):
+            last = None
+        if not last or last <= 0:
+            return jsonify({'error': 'invalid price'}), 502
         return jsonify({'price': last})
     except CCXT_NETWORK_ERROR as exc:  # pragma: no cover - network errors
         logging.exception("Network error fetching price for '%s': %s", symbol, exc)


### PR DESCRIPTION
## Summary
- validate fetched ticker price before returning
- return HTTP 502 for missing or non-positive price

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f71d62198832d8eb6d3db7153ae62