### PR TITLE
Log service check exceptions and collect errors

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -177,9 +177,15 @@ async def check_services() -> None:
             _probe(name, url, endpoint)
             for name, (url, endpoint) in services.items()
         ]
-        results = await asyncio.gather(*tasks)
+        results = await asyncio.gather(*tasks, return_exceptions=True)
 
-    errors = [msg for msg in results if msg]
+    errors: list[str] = []
+    for result in results:
+        if isinstance(result, Exception):
+            logger.error("Service check raised: %s", result)
+            errors.append(str(result))
+        elif result:
+            errors.append(result)
     if errors:
         raise SystemExit("; ".join(errors))
 


### PR DESCRIPTION
## Summary
- log exceptions raised during service probes
- collect probe exception messages alongside failed responses

## Testing
- `pre-commit run --files trading_bot.py` *(fails: test_worker_thread_stops_after_shutdown)*

------
https://chatgpt.com/codex/tasks/task_e_689f71d4ccbc832da83b949b29f18038