### PR TITLE
Enforce password length limit in verification

### DIFF
--- a/password_utils.py
+++ b/password_utils.py
@@ -12,5 +12,7 @@ def hash_password(password: str) -> str:
 
 def verify_password(password: str, stored_hash: str) -> bool:
     """Проверяет пароль по сохранённому bcrypt-хэшу."""
+    if len(password) > MAX_PASSWORD_LENGTH:
+        raise ValueError("Password exceeds maximum length")
     return bcrypt.checkpw(password.encode(), stored_hash.encode())
 

--- a/tests/test_password_utils.py
+++ b/tests/test_password_utils.py
@@ -15,6 +15,12 @@ def test_hash_password_rejects_long_password():
         hash_password("a" * (MAX_PASSWORD_LENGTH + 1))
 
 
+def test_verify_password_rejects_long_password():
+    hashed = hash_password("valid")
+    with pytest.raises(ValueError):
+        verify_password("a" * (MAX_PASSWORD_LENGTH + 1), hashed)
+
+
 def test_hash_password_generates_unique_hashes():
     password = "secret"
     assert hash_password(password) != hash_password(password)


### PR DESCRIPTION
## Summary
- add maximum length check to `verify_password`
- test rejection of overly long passwords

## Testing
- `pre-commit run --files password_utils.py tests/test_password_utils.py`
- `pytest tests/test_password_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_689f760aa59c832d8edca30aaf37c530