### PR TITLE
Exclude tests from Bandit scans

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,2 @@
+[bandit]
+exclude = ./tests

--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -48,5 +48,5 @@ jobs:
           # comma-separated list of test IDs to skip
           # skips: # optional, default is DEFAULT
           # path to a .bandit file that supplies command line arguments
-          # ini_path: # optional, default is DEFAULT
+          ini_path: .bandit
 


### PR DESCRIPTION
## Summary
- configure Bandit to skip tests via `.bandit`
- make CI Bandit job use the config file

## Testing
- `pre-commit run flake8 --files .bandit .github/workflows/bandit.yml`
- `bandit -r . --ini .bandit`


------
https://chatgpt.com/codex/tasks/task_e_689f762928ac832d8702e9187e367e9e