### PR TITLE
chore: remove registries proxy from dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -22,4 +22,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.TOKEN }}
           GITHUB_DEPENDABOT_JOB_TOKEN: ${{ secrets.GITHUB_DEPENDABOT_JOB_TOKEN }}
           GITHUB_DEPENDABOT_CRED_TOKEN: ${{ secrets.GITHUB_DEPENDABOT_CRED_TOKEN }}
-          GITHUB_REGISTRIES_PROXY: .github/registries-proxy.json


### PR DESCRIPTION
## Summary
- remove deprecated `GITHUB_REGISTRIES_PROXY` env from Dependabot workflow

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_689f7ba019c0832d8c55f5b1bd85d266