### PR TITLE
feat: enable buildx cache

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,6 +26,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -41,6 +52,13 @@ jobs:
           push: true
           load: true
           tags: ${{ matrix.tag }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      - name: Move Docker layer cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
       - name: Set up Trivy
         uses: aquasecurity/setup-trivy@v0.2.3


### PR DESCRIPTION
## Summary
- add Docker Buildx setup
- cache Docker layers between runs

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml` *(failed: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_689f7c405680832db4cb1657f4cbd7d6