### PR TITLE
chore: expand bandit exclusions

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,2 +1,2 @@
 [bandit]
-exclude = ./tests
+exclude = ./tests, ./scripts, ./gptoss_check


### PR DESCRIPTION
## Summary
- update bandit config to exclude scripts and gptoss_check directories

## Testing
- `bandit -c bot/.bandit -r bot` *(fails: bot/.bandit : Error parsing file)*
- `bandit -r bot --ini bot/.bandit`


------
https://chatgpt.com/codex/tasks/task_e_68a1fcbbfbb4832d99bb15bfb9cd48d2