### PR TITLE
Добавлен логин в GHCR в docker-publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
-
+      - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
           registry: ghcr.io


### PR DESCRIPTION
## Summary
- добавлен шаг авторизации в ghcr перед публикацией образов

## Testing
- `pytest` *(ошибка: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_68a1fea35d54832d836116c3f7c62aae