### PR TITLE
feat: add GHCR login step

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
-
+      - name: Login to GHCR
         uses: docker/login-action@v3
         with:
           registry: ghcr.io


### PR DESCRIPTION
## Summary
- add explicit login to GHCR in Docker publish workflow

## Testing
- `yamllint .github/workflows/docker-publish.yml`
- `SKIP=pytest pre-commit run --files .github/workflows/docker-publish.yml`

------
https://chatgpt.com/codex/tasks/task_e_68a1feb1e5b4832db126de9958b1c316