### PR TITLE
fix: align vllm device variable

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -5,10 +5,10 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y libtbbmalloc2 cur
     && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONUNBUFFERED=1 HF_HOME=/workspace/hf-cache
-ENV VLLM_TARGET_DEVICE=cpu
+ENV VLLM_DEVICE=cpu
 ENV PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu
 RUN pip install --no-cache-dir "vllm==0.10.0"
 
 EXPOSE 8000
 
-CMD ["python", "-m", "vllm.entrypoints.openai.api_server", "--host", "0.0.0.0", "--port", "8000", "--model", "Qwen/Qwen2.5-0.5B-Instruct", "--device-type", "cpu", "--max-num-seqs", "4", "--enforce-eager", "--disable-async-output-proc"]
+CMD ["python", "-m", "vllm.entrypoints.openai.api_server", "--host", "0.0.0.0", "--port", "8000", "--model", "Qwen/Qwen2.5-0.5B-Instruct", "--device", "cpu", "--max-num-seqs", "4", "--enforce-eager", "--disable-async-output-proc"]

--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -11,7 +11,7 @@ services:
     environment:
       VLLM_LOGGING_LEVEL: DEBUG
       MODEL: ${MODEL:-openai/gpt-oss-20b}
-      VLLM_TARGET_DEVICE: cpu
+      VLLM_DEVICE: cpu
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/v1/health"]
       interval: 5s


### PR DESCRIPTION
## Summary
- rename VLLM_TARGET_DEVICE to VLLM_DEVICE across CPU Docker image
- adjust vLLM command flag from --device-type to --device

## Testing
- `pre-commit run --files Dockerfile.gptoss docker-compose.cpu.yml` *(fails: KeyboardInterrupt)*
- `docker-compose -f docker-compose.cpu.yml build gptoss` *(fails: Error while fetching server API version: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory')))*

------
https://chatgpt.com/codex/tasks/task_e_68a203ad355c832d8e1c85e657cc6cb9