### PR TITLE
fix flake8 errors in bot

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -45,9 +45,10 @@ try:  # pragma: no cover - optional dependency
     import psutil  # type: ignore
 except ImportError as exc:  # allow missing psutil
     logging.getLogger("TradingBot").error("psutil import failed: %s", exc)
+    missing_exc = exc
 
     def _missing_psutil(*args, **kwargs):
-        raise ImportError("psutil is required for system metrics") from exc
+        raise ImportError("psutil is required for system metrics") from missing_exc
 
     psutil = types.SimpleNamespace(
         cpu_percent=_missing_psutil,

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -570,8 +570,6 @@ def should_trade(model_signal: str) -> bool:
 
 async def refresh_gpt_advice() -> None:
     """Fetch GPT analysis and update ``GPT_ADVICE``."""
-
-    global GPT_ADVICE
     try:
         strategy_code = (
             Path(__file__).with_name("strategy_optimizer.py").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- remove unused `global` statement in `refresh_gpt_advice`
- capture `ImportError` when psutil is missing to avoid undefined variable

## Testing
- `flake8 .`
- `pytest` *(fails: AttributeError: module 'httpx' has no attribute 'Response')*

------
https://chatgpt.com/codex/tasks/task_e_68a205ec3784832da7561eed6495fcda