### PR TITLE
chore: use public ubuntu base image for CI

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,8 +1,8 @@
 # syntax=docker/dockerfile:1
 
 # -------- Builder stage --------
-# Используем LTS-образ из GitHub Container Registry для сборки зависимостей
-FROM ghcr.io/averinaleks/ubuntu:noble AS builder
+# Используем публичный LTS-образ Ubuntu для сборки зависимостей
+FROM ubuntu:noble AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV PIP_BREAK_SYSTEM_PACKAGES=1


### PR DESCRIPTION
## Summary
- replace custom GHCR Ubuntu image with public `ubuntu:noble` in CI Dockerfile

## Testing
- `pre-commit run --files Dockerfile.ci` *(fails: module 'httpx' has no attribute 'Response')*

------
https://chatgpt.com/codex/tasks/task_e_68a2061d6674832db8d9379afa0e53d1