### PR TITLE
feat: install CPU-only vllm

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y libtbbmalloc2 cur
 ENV PYTHONUNBUFFERED=1 HF_HOME=/workspace/hf-cache
 ENV VLLM_DEVICE=cpu
 ENV PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu
-RUN pip install --no-cache-dir "vllm==0.10.0"
+RUN pip install --no-cache-dir "vllm-cpu==0.10.0"
 
 EXPOSE 8000
 


### PR DESCRIPTION
## Summary
- use vllm-cpu instead of GPU build in GPT-OSS Dockerfile

## Testing
- `pytest -q` *(fails: psutil.__spec__ is None)*
- `docker compose -f docker-compose.yml -f docker-compose.cpu.yml up` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68a20b1bccc0832d8d083b06ce80dc66