### PR TITLE
chore: add buildx setup and caching

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,6 +34,19 @@ jobs:
           username: ${{ secrets.AVERINALEKS }}
           password: ${{ secrets.TOKEN }}
 
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
## Summary
- configure Buildx for docker image publishing
- add GitHub Actions cache for Buildx layers

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68a20d862748832d818bbbf018ca1d8a