### PR TITLE
Log invalid environment variables in load_config

### DIFF
--- a/config.py
+++ b/config.py
@@ -208,6 +208,12 @@ def load_config(path: str = CONFIG_PATH) -> BotConfig:
             expected_type = type_hints.get(fdef.name, fdef.type)
             converted = _convert(env_val, expected_type)
             if isinstance(converted, str) and expected_type is not str:
+                expected_name = getattr(expected_type, "__name__", str(expected_type))
+                logger.warning(
+                    "Ignoring %s: expected value of type %s",
+                    fdef.name.upper(),
+                    expected_name,
+                )
                 continue
             cfg[fdef.name] = converted
     return BotConfig(**cfg)

--- a/tests/test_config_logging.py
+++ b/tests/test_config_logging.py
@@ -1,0 +1,9 @@
+import logging
+from bot.config import load_config
+
+
+def test_load_config_logs_invalid_env(monkeypatch, caplog):
+    monkeypatch.setenv("MAX_CONCURRENT_REQUESTS", "oops")
+    with caplog.at_level(logging.WARNING):
+        load_config()
+    assert "Ignoring MAX_CONCURRENT_REQUESTS: expected value of type int" in caplog.text


### PR DESCRIPTION
## Summary
- log and skip misformatted environment variables in `load_config`
- test that warnings include variable name and expected type

## Testing
- `python -c "import psutil, scipy, pytest, sys; sys.exit(pytest.main())"` *(fails: ValueError: sklearn.__spec__ is None)*

------
https://chatgpt.com/codex/tasks/task_e_68a20f354040832d9bb2f718a7eb904a