### PR TITLE
fix: use working vllm cpu version

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y libtbbmalloc2 cur
 ENV PYTHONUNBUFFERED=1 HF_HOME=/workspace/hf-cache
 ENV VLLM_DEVICE=cpu
 ENV PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu
-RUN pip install --no-cache-dir "vllm-cpu==0.10.0"
+RUN pip install --no-cache-dir "vllm-cpu==0.5.3"
 
 EXPOSE 8000
 


### PR DESCRIPTION
## Summary
- use `vllm-cpu==0.5.3` in Dockerfile.gptoss

## Testing
- `pytest` (fails: module 'httpx' has no attribute 'Response')
- `docker build -f Dockerfile.gptoss -t gptoss-image .` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a20f74a430832da0a7ea44447d1d76