### PR TITLE
Handle invalid GPT_OSS_TIMEOUT

### DIFF
--- a/gpt_client.py
+++ b/gpt_client.py
@@ -77,7 +77,14 @@ async def query_gpt_async(prompt: str) -> str:
         raise GPTClientNetworkError("GPT_OSS_API environment variable not set")
 
     _validate_api_url(api_url)
-    timeout = float(os.getenv("GPT_OSS_TIMEOUT", "5"))
+    timeout_env = os.getenv("GPT_OSS_TIMEOUT", "5")
+    try:
+        timeout = float(timeout_env)
+    except ValueError:
+        logger.warning(
+            "Invalid GPT_OSS_TIMEOUT value %r; defaulting to 5.0", timeout_env
+        )
+        timeout = 5.0
     url = api_url.rstrip("/") + "/v1/completions"
     try:
         async with httpx.AsyncClient(trust_env=False, timeout=timeout) as client:


### PR DESCRIPTION
## Summary
- Add validation for GPT_OSS_TIMEOUT env var with fallback to default

## Testing
- `pytest -q` *(fails: module 'httpx' has no attribute 'Response', ModuleNotFoundError: No module named 'bcrypt', ModuleNotFoundError: No module named 'fastapi', ModuleNotFoundError: No module named 'aiohttp')*


------
https://chatgpt.com/codex/tasks/task_e_68a2118e7f0c832d8cb2198eb0a7b6e0