### PR TITLE
Use regex to sanitize symbol names

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import json
+import re
 import pandas as pd
 import numpy as np
 import asyncio
@@ -694,7 +695,7 @@ async def check_dataframe_empty_async(df, context: str = "") -> bool:
 
 def sanitize_symbol(symbol: str) -> str:
     """Sanitize symbol string for safe filesystem usage."""
-    return symbol.replace("/", "_").replace(":", "_")
+    return re.sub(r'[^A-Za-z0-9._-]', '_', symbol)
 
 
 def filter_outliers_zscore(df, column="close", threshold=3.0):


### PR DESCRIPTION
## Summary
- add missing `re` import in utils
- sanitize symbols with regex replacement

## Testing
- `pytest` *(fails: AttributeError: module 'httpx' has no attribute 'Response')*

------
https://chatgpt.com/codex/tasks/task_e_68a21194e3cc832db9baeeb995fce392