### PR TITLE
feat: update CPU Dockerfile

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -1,13 +1,14 @@
-FROM python:3.12-slim
+FROM python:3.11-slim
 
 # Исправляем отсутствие libtbbmalloc.so.2, устанавливаем свежие патчи и ставим curl для health-check’а
 RUN apt-get update && apt-get upgrade -y && apt-get install -y libtbbmalloc2 curl \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONUNBUFFERED=1 HF_HOME=/workspace/hf-cache
-ENV VLLM_DEVICE=cpu
+ENV VLLM_TARGET_DEVICE=cpu
 ENV PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu
-RUN pip install --no-cache-dir "vllm-cpu>=0.5.3"
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir "vllm>=0.5.3"
 
 EXPOSE 8000
 


### PR DESCRIPTION
## Summary
- use python:3.11-slim base for GPT-OSS Dockerfile
- install vllm with pip upgrade and cpu extras
- set VLLM_TARGET_DEVICE env var

## Testing
- `pre-commit run --files Dockerfile.gptoss` *(fails: module 'httpx' has no attribute 'Response')*
- `docker build -f Dockerfile.gptoss .` *(not run: docker daemon not available)*

------
https://chatgpt.com/codex/tasks/task_e_68a219800290832d8b060ba67e6f0c93