### PR TITLE
feat: add service unavailability exception

### DIFF
--- a/tests/test_env_parsing.py
+++ b/tests/test_env_parsing.py
@@ -67,6 +67,6 @@ def test_check_services_invalid_env(monkeypatch):
             raise trading_bot.httpx.HTTPError("boom")
 
     monkeypatch.setattr(trading_bot.httpx, "AsyncClient", lambda *a, **k: DummyClient(), raising=False)
-    with pytest.raises(SystemExit):
+    with pytest.raises(trading_bot.ServiceUnavailableError):
         asyncio.run(trading_bot.check_services())
     assert calls["count"] == 3

--- a/tests/test_integration_services.py
+++ b/tests/test_integration_services.py
@@ -189,7 +189,7 @@ def test_check_services_failure(monkeypatch):
         monkeypatch.setenv('TRADE_MANAGER_URL', f'http://localhost:{tm_port}')
         monkeypatch.setenv('SERVICE_CHECK_RETRIES', '2')
         monkeypatch.setenv('SERVICE_CHECK_DELAY', '0.1')
-        with pytest.raises(SystemExit):
+        with pytest.raises(trading_bot.ServiceUnavailableError):
             asyncio.run(trading_bot.check_services())
 
 

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -30,6 +30,10 @@ GPT_ADVICE: dict[str, float | str | None] = {
 }
 
 
+class ServiceUnavailableError(Exception):
+    """Raised when required services are not reachable."""
+
+
 def safe_int(env_var: str, default: int) -> int:
     """Return int value of ``env_var`` or ``default`` on failure."""
     value = os.getenv(env_var)
@@ -196,7 +200,7 @@ async def check_services() -> None:
         elif result:
             errors.append(result)
     if errors:
-        raise SystemExit("; ".join(errors))
+        raise ServiceUnavailableError("; ".join(errors))
 
 
 
@@ -686,6 +690,8 @@ async def main_async() -> None:
         while True:
             await run_once_async()
             await asyncio.sleep(INTERVAL)
+    except ServiceUnavailableError as exc:
+        logger.error("Service availability check failed: %s", exc)
     except KeyboardInterrupt:
         logger.info('Stopping trading bot')
     finally:


### PR DESCRIPTION
## Summary
- add `ServiceUnavailableError` for service checks
- raise the new exception from `check_services`
- handle the exception in `main_async` and update tests

## Testing
- `pytest tests/test_env_parsing.py::test_check_services_invalid_env`
- `pytest -m integration tests/test_integration_services.py::test_check_services_success tests/test_integration_services.py::test_check_services_failure tests/test_integration_services.py::test_check_services_host_only`


------
https://chatgpt.com/codex/tasks/task_e_68a21a26d630832d9e8d8a0d5ffb8200