### PR TITLE
Check status code before parsing positions

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -424,10 +424,17 @@ async def monitor_positions(env: dict, interval: float = INTERVAL) -> None:
                 resp = await client.get(
                     f"{env['trade_manager_url']}/positions", timeout=5
                 )
+                if resp.status_code != 200:
+                    logger.error(
+                        "Failed to fetch positions: status code %s", resp.status_code
+                    )
+                    await asyncio.sleep(interval)
+                    continue
                 positions = resp.json().get("positions", [])
             except (httpx.HTTPError, ValueError) as exc:
                 logger.error("Failed to fetch positions: %s", exc)
-                positions = []
+                await asyncio.sleep(interval)
+                continue
             symbols: list[str] = []
             for pos in positions:
                 sym = pos.get("symbol")


### PR DESCRIPTION
## Summary
- verify HTTP status in monitor_positions before parsing JSON

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a21a309d9c832d9cf77251be3a4f2a