### PR TITLE
Remove unsafe literal_eval list parsing

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -4,6 +4,10 @@ This document lists all configuration parameters available for the trading bot.
 Each option corresponds to a field in `config.json` and the `BotConfig`
 dataclass.  Default values are shown for reference.
 
+List parameters supplied via environment variables must be provided either as
+JSON arrays (e.g. `["ws://a", "ws://b"]`) or as comma-separated values such as
+`ws://a,ws://b`.
+
 The GPT analysis service should return JSON with the following fields:
 `signal` ("buy"/"sell"/"hold"), `tp_mult` and `sl_mult` — multipliers applied
 to take‑profit and stop‑loss distances.

--- a/config.py
+++ b/config.py
@@ -6,7 +6,6 @@ This module defines the :class:`BotConfig` dataclass along with helpers to
 load configuration values from ``config.json`` and environment variables.
 """
 
-import ast
 import json
 import logging
 import os
@@ -190,10 +189,7 @@ def _convert(value: str, typ: type) -> Any:
         try:
             items = json.loads(value)
         except json.JSONDecodeError:
-            try:
-                items = ast.literal_eval(value)
-            except (ValueError, SyntaxError):
-                items = [v.strip().strip("'\"") for v in value.split(",") if v.strip()]
+            items = [v.strip().strip("'\"") for v in value.split(",") if v.strip()]
         if not isinstance(items, list):
             items = [items]
         converted = []

--- a/tests/test_config_list_parsing.py
+++ b/tests/test_config_list_parsing.py
@@ -1,0 +1,13 @@
+import config
+
+
+def test_env_list_parsing_json(monkeypatch):
+    monkeypatch.setenv("BACKUP_WS_URLS", '["ws://a", "ws://b"]')
+    cfg = config.load_config()
+    assert cfg.backup_ws_urls == ["ws://a", "ws://b"]
+
+
+def test_env_list_parsing_csv(monkeypatch):
+    monkeypatch.setenv("BACKUP_WS_URLS", 'ws://a,ws://b')
+    cfg = config.load_config()
+    assert cfg.backup_ws_urls == ["ws://a", "ws://b"]


### PR DESCRIPTION
## Summary
- drop `ast.literal_eval` fallback from list parsing and rely on JSON or comma-separated values
- document list formats in CONFIG.md
- add tests for JSON and CSV environment list parsing

## Testing
- `pytest tests/test_config_list_parsing.py`
- `pytest` *(fails: module 'httpx' has no attribute 'Response'; missing bcrypt, aiohttp)*

------
https://chatgpt.com/codex/tasks/task_e_68a21ac3e2cc832da31ece9f248be494