### PR TITLE
Use local client in reactive_trade

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -652,7 +652,7 @@ async def reactive_trade(symbol: str, env: dict | None = None) -> None:
             )
             tp, sl, trailing_stop = _resolve_trade_params(tp, sl, trailing_stop, price)
             await send_trade_async(
-                HTTP_CLIENT,
+                client,
                 symbol,
                 signal,
                 price,


### PR DESCRIPTION
## Summary
- Pass the locally scoped HTTP client to `send_trade_async` inside `reactive_trade`

## Testing
- `flake8 .`
- `pytest -m "not integration"` *(fails: Missing optional dependency 'pyarrow' and `shap_cache` assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68a22ac737ec832d941e56c2884b7107