### PR TITLE
refactor: move logging config to main

### DIFF
--- a/services/data_handler_service.py
+++ b/services/data_handler_service.py
@@ -6,10 +6,6 @@ import os
 from dotenv import load_dotenv
 
 load_dotenv()
-
-
-# Configure logging
-logging.basicConfig(level=logging.INFO)
 app = Flask(__name__)
 
 exchange = ccxt.bybit({
@@ -52,6 +48,7 @@ def handle_unexpected_error(exc: Exception) -> tuple:
     return jsonify({'error': 'internal server error'}), 500
 
 if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
     port = int(os.environ.get('PORT', '8000'))
     # По умолчанию слушаем только локальный интерфейс.
     host = os.environ.get('HOST', '127.0.0.1')

--- a/tests/test_data_handler_service_logging.py
+++ b/tests/test_data_handler_service_logging.py
@@ -1,0 +1,45 @@
+import logging
+import importlib
+import sys
+import types
+
+
+def test_data_handler_service_does_not_configure_logging_on_import(monkeypatch):
+    root = logging.getLogger()
+    for h in root.handlers[:]:
+        root.removeHandler(h)
+    root.setLevel(logging.WARNING)
+    assert root.handlers == []
+
+    ccxt = types.ModuleType('ccxt')
+    ccxt.bybit = lambda *a, **kw: types.SimpleNamespace()
+    monkeypatch.setitem(sys.modules, 'ccxt', ccxt)
+
+    flask = types.ModuleType('flask')
+
+    class DummyFlask:
+        def __init__(self, name):
+            pass
+
+        def route(self, *args, **kwargs):
+            def decorator(func):
+                return func
+            return decorator
+
+        def errorhandler(self, *args, **kwargs):
+            def decorator(func):
+                return func
+            return decorator
+
+        def run(self, *args, **kwargs):
+            pass
+
+    flask.Flask = DummyFlask
+    flask.jsonify = lambda obj: obj
+    monkeypatch.setitem(sys.modules, 'flask', flask)
+
+    monkeypatch.delitem(sys.modules, 'bot.services.data_handler_service', raising=False)
+    importlib.import_module('bot.services.data_handler_service')
+
+    assert root.level == logging.WARNING
+    assert root.handlers == []


### PR DESCRIPTION
## Summary
- remove global logging setup in `data_handler_service`
- configure logging only when running the service directly
- add test ensuring import does not reconfigure logging

## Testing
- `pre-commit run --files services/data_handler_service.py tests/test_data_handler_service_logging.py` *(fails: async def functions are not natively supported)*
- `pytest tests/test_data_handler_service_logging.py::test_data_handler_service_does_not_configure_logging_on_import -q`


------
https://chatgpt.com/codex/tasks/task_e_68a236220824832d8b28e9284c766917