### PR TITLE
Limit Flask payload size to 1MB with 413 handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,9 @@ These reference scripts expose the same HTTP routes as the full services but
 avoid heavy frameworks like TensorFlow and PyTorch, making them ideal for quick
 tests.
 
+Все Flask-сервисы ограничивают размер тела запроса 1 МБ. При превышении
+лимита клиент получает ответ 413 с JSON‑сообщением `{"error": "payload too large"}`.
+
 The model builder maintains separate models per trading pair.  POST JSON data
 of the form::
 

--- a/services/data_handler_service.py
+++ b/services/data_handler_service.py
@@ -11,6 +11,7 @@ load_dotenv()
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 app = Flask(__name__)
+app.config["MAX_CONTENT_LENGTH"] = 1 * 1024 * 1024  # 1 MB limit
 
 exchange = ccxt.bybit({
     'apiKey': os.getenv('BYBIT_API_KEY', ''),
@@ -44,6 +45,10 @@ def price(symbol: str):
 def ping():
     return jsonify({'status': 'ok'})
 
+
+@app.errorhandler(413)
+def too_large(_):
+    return jsonify({'error': 'payload too large'}), 413
 
 @app.errorhandler(Exception)
 def handle_unexpected_error(exc: Exception) -> tuple:

--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -15,6 +15,7 @@ from sklearn.linear_model import LogisticRegression
 load_dotenv()
 
 app = Flask(__name__)
+app.config["MAX_CONTENT_LENGTH"] = 1 * 1024 * 1024  # 1 MB limit
 
 MODEL_FILE = os.getenv('MODEL_FILE', 'model.pkl')
 _model = None
@@ -86,6 +87,10 @@ def predict() -> tuple:
 def ping() -> tuple:
     return jsonify({'status': 'ok'})
 
+
+@app.errorhandler(413)
+def too_large(_):
+    return jsonify({'error': 'payload too large'}), 413
 
 if __name__ == '__main__':
     port = int(os.environ.get('PORT', '8001'))

--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -16,6 +16,7 @@ logging.basicConfig(level=logging.INFO)
 load_dotenv()
 
 app = Flask(__name__)
+app.config["MAX_CONTENT_LENGTH"] = 1 * 1024 * 1024  # 1 MB limit
 
 exchange = ccxt.bybit({
     'apiKey': os.getenv('BYBIT_API_KEY', ''),
@@ -248,6 +249,10 @@ def ready():
     """Health check endpoint used by docker-compose."""
     return jsonify({'status': 'ok'})
 
+
+@app.errorhandler(413)
+def too_large(_):
+    return jsonify({'error': 'payload too large'}), 413
 
 @app.errorhandler(Exception)
 def handle_unexpected_error(exc: Exception) -> tuple:


### PR DESCRIPTION
## Summary
- limit request bodies to 1MB in all Flask services
- handle HTTP 413 with a JSON error
- document payload limit in README

## Testing
- `pre-commit run --files services/data_handler_service.py services/model_builder_service.py services/trade_manager_service.py README.md` *(failed: missing optional dependencies for parquet)*
- `pytest tests/test_service_scripts.py tests/test_integration_services.py -m integration`

------
https://chatgpt.com/codex/tasks/task_e_68a236315d20832da58a839066b5b297