### PR TITLE
Use combined Qwen model string in gptoss Dockerfile

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -12,4 +12,11 @@ RUN pip install --no-cache-dir --upgrade pip && \
 
 EXPOSE 8000
 
-CMD ["python", "-m", "vllm.entrypoints.openai.api_server", "--host", "0.0.0.0", "--port", "8000", "--model", "Qwen/Qwen2.5-0.5B-Instruct", "--device", "cpu", "--max-num-seqs", "4", "--enforce-eager", "--disable-async-output-proc"]
+CMD ["python", "-m", "vllm.entrypoints.openai.api_server",
+     "--host", "0.0.0.0",
+     "--port", "8000",
+     "--model", "Qwen/Qwen2.5-0.5B-Instruct",
+     "--device", "cpu",
+     "--max-num-seqs", "4",
+     "--enforce-eager",
+     "--disable-async-output-proc"]


### PR DESCRIPTION
## Summary
- ensure Dockerfile.gptoss uses the full `Qwen/Qwen2.5-0.5B-Instruct` model name in a single string
- reformat CMD to be multi-line for readability

## Testing
- `docker build -f Dockerfile.gptoss -t bot-gptoss-test .` *(fails: Cannot connect to the Docker daemon)*
- `VLLM_TARGET_DEVICE=cpu python -m vllm.entrypoints.openai.api_server --model Qwen/Qwen2.5-0.5B-Instruct --device cpu --max-num-seqs 4 --enforce-eager --disable-async-output-proc` *(fails: RuntimeError: Failed to infer device type)*
- `pytest -q` *(fails: psutil.__spec__ is None)*

------
https://chatgpt.com/codex/tasks/task_e_68a2364fb054832db0c453e5e49b543c