### PR TITLE
feat: upgrade gptoss docker base to python 3.12

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 # Исправляем отсутствие libtbbmalloc.so.2, устанавливаем свежие патчи и ставим curl для health-check’а
 RUN apt-get update && apt-get upgrade -y && apt-get install -y libtbbmalloc2 curl \


### PR DESCRIPTION
## Summary
- use python:3.12-slim as base image for gptoss Dockerfile

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `docker build -f Dockerfile.gptoss -t gptoss_test .` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68a23659c740832db500ed7853d465de