### PR TITLE
Ensure DataHandler callbacks execute before returning

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -1749,10 +1749,13 @@ class DataHandler:
                             idx, result.df.columns
                         ].to_numpy()
                         self.ohlcv_2h = base_df_2h
+            callbacks: list[Awaitable[Any]] = []
             if self.feature_callback:
-                asyncio.create_task(self.feature_callback(symbol))
+                callbacks.append(self.feature_callback(symbol))
             if self.trade_callback:
-                asyncio.create_task(self.trade_callback(symbol))
+                callbacks.append(self.trade_callback(symbol))
+            if callbacks:
+                await asyncio.gather(*callbacks)
             self.cache.save_cached_data(f"{timeframe}_{symbol}", timeframe, df)
         except (KeyError, ValueError, TypeError, IndexError) as e:
             logger.error(


### PR DESCRIPTION
## Summary
- wait for feature and trade callbacks to complete in `DataHandler.synchronize_and_update`

## Testing
- `flake8 .`
- `pytest tests/test_data_handler.py::test_trade_callback_invoked -vv` *(fails: ImportError: cannot import name 'AsyncRetrying' from 'tenacity')*

------
https://chatgpt.com/codex/tasks/task_e_68a23e46de40832db2a4ed33b0706177