### PR TITLE
fix: ensure Docker CMD parsed correctly

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -12,11 +12,11 @@ RUN pip install --no-cache-dir --upgrade pip && \
 
 EXPOSE 8000
 
-CMD ["python", "-m", "vllm.entrypoints.openai.api_server",
-     "--host", "0.0.0.0",
-     "--port", "8000",
-     "--model", "Qwen/Qwen2.5-0.5B-Instruct",
-     "--device", "cpu",
-     "--max-num-seqs", "4",
-     "--enforce-eager",
-     "--disable-async-output-proc"]
+CMD python -m vllm.entrypoints.openai.api_server \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --model Qwen/Qwen2.5-0.5B-Instruct \
+    --device cpu \
+    --max-num-seqs 4 \
+    --enforce-eager \
+    --disable-async-output-proc


### PR DESCRIPTION
## Summary
- convert CMD in Dockerfile.gptoss to shell form with line continuations for proper parsing

## Testing
- `docker build -f Dockerfile.gptoss .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68a23f9bcf6c832d8eacf91f90f50007