### PR TITLE
Pin package versions in Dockerfile.gptoss

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -1,7 +1,8 @@
 FROM python:3.12-slim
 
 # Исправляем отсутствие libtbbmalloc.so.2, устанавливаем свежие патчи и ставим curl для health-check’а
-RUN apt-get update && apt-get upgrade -y && apt-get install -y libtbbmalloc2 curl \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libtbbmalloc2=2021.8.0-2 curl=7.88.1-10+deb12u12 \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONUNBUFFERED=1 HF_HOME=/workspace/hf-cache


### PR DESCRIPTION
## Summary
- replace apt upgrade with pinned installs and skip recommended packages

## Testing
- `pytest` *(fails: module httpx has no attribute Response)*
- `podman build -f Dockerfile.gptoss -t test-gptoss .` *(fails: error mounting \"proc\" to rootfs: operation not permitted)*

------
https://chatgpt.com/codex/tasks/task_e_68a23fa304cc832da8c90238bde11730