### PR TITLE
Handle missing GPT-OSS config file

### DIFF
--- a/gptoss_check/main.py
+++ b/gptoss_check/main.py
@@ -10,7 +10,8 @@ from typing import Optional
 def _load_skip_flag(config_path: Path) -> bool:
     """Return True if the check should be skipped based on the config."""
     if not config_path.exists():
-        return True
+        logger.warning("Файл конфигурации %s не найден, проверка запущена", config_path)
+        return False
     for line in config_path.read_text().splitlines():
         line = line.strip()
         if not line or line.startswith("#"):

--- a/tests/test_gptoss_check.py
+++ b/tests/test_gptoss_check.py
@@ -1,5 +1,19 @@
 from pathlib import Path
 import logging
+import sys
+import types
+
+_fake_client = types.ModuleType("gpt_client")
+
+
+class _DummyError(Exception):
+    pass
+
+
+_fake_client.GPTClientError = _DummyError
+_fake_client.query_gpt = lambda *args, **kwargs: None
+
+sys.modules.setdefault("gpt_client", _fake_client)
 
 import gptoss_check.check_code as check_code
 from gptoss_check import main as gptoss_main
@@ -29,6 +43,24 @@ def test_run_message(caplog, tmp_path, monkeypatch):
         gptoss_main.main(config_path=cfg)
     assert "Running GPT-OSS check" in caplog.text
     assert "GPT-OSS check completed" in caplog.text
+    assert called
+
+
+def test_missing_config_triggers_check_and_warns(caplog, tmp_path, monkeypatch):
+    cfg = tmp_path / "gptoss_check.config"  # file deliberately not created
+
+    called = []
+
+    def fake_run():
+        called.append(True)
+
+    monkeypatch.setattr(check_code, "run", fake_run)
+    monkeypatch.setattr(check_code, "wait_for_api", lambda *args, **kwargs: None)
+    monkeypatch.setenv("GPT_OSS_API", "http://gptoss:8000")
+    with caplog.at_level(logging.INFO):
+        gptoss_main.main(config_path=cfg)
+    assert "не найден" in caplog.text
+    assert "Running GPT-OSS check" in caplog.text
     assert called
 
 


### PR DESCRIPTION
## Summary
- warn and run GPT-OSS check when configuration file is absent
- cover missing config scenario with dedicated test

## Testing
- `pre-commit run --files gptoss_check/main.py tests/test_gptoss_check.py` *(fails: errors during collection)*
- `pytest tests/test_gptoss_check.py -k test_missing_config_triggers_check_and_warns -q`

------
https://chatgpt.com/codex/tasks/task_e_68a23faa5d0c832d8adfaa8c28866d4d