### PR TITLE
feat: add Trivy report download retry

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -84,3 +84,21 @@ jobs:
         with:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}.txt
+
+      - name: Download Trivy report
+        shell: bash
+        run: |
+          for i in {1..5}; do
+            npx github:actions/download-artifact@v4 \
+              --name "${{ matrix.artifact }}" \
+              --path .
+            if [ $? -eq 0 ]; then
+              break
+            fi
+            echo "Attempt $i failed, retrying in 10 seconds..."
+            sleep 10
+            if [ $i -eq 5 ]; then
+              echo "Unable to download artifact after 5 attempts"
+              exit 1
+            fi
+          done


### PR DESCRIPTION
## Summary
- add step to download Trivy report artifact with retry loop

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68a24032a42c832d83ade6b06c3825ab