### PR TITLE
chore: pin ubuntu images and apply dist upgrade

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -2,13 +2,13 @@
 
 # -------- Builder stage --------
 # Используем публичный LTS-образ Ubuntu для сборки зависимостей
-FROM ubuntu:noble AS builder
+FROM ubuntu:noble-20250716 AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
 # Обновление linux-libc-dev устраняет CVE-2025-21976, а libgcrypt20 — CVE-2024-2236
-RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y --no-install-recommends \
     linux-libc-dev \
     libgcrypt20 \
     libpam0g \
@@ -38,13 +38,13 @@ COPY services services
 COPY tests tests
 
 # -------- Runtime stage --------
-FROM ubuntu:noble AS runtime
+FROM ubuntu:noble-20250716 AS runtime
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
 # Устанавливаем только необходимые пакеты выполнения
-RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y --no-install-recommends \
     libssl3t64 \
     python3.12-minimal \
     python3 \

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,8 +1,8 @@
-FROM ubuntu:noble AS builder
+FROM ubuntu:noble-20250716 AS builder
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Обновление linux-libc-dev устраняет CVE-2025-21976, а libgcrypt20 — CVE-2024-2236
-RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y --no-install-recommends \
     linux-libc-dev \
     libpam0g \
     libssl3t64 \
@@ -26,10 +26,10 @@ RUN python3 -m venv $VIRTUAL_ENV && \
     find $VIRTUAL_ENV -type d -name '__pycache__' -exec rm -rf {} + && \
     find $VIRTUAL_ENV -type f -name '*.pyc' -delete
 
-FROM ubuntu:noble
+FROM ubuntu:noble-20250716
 
 # Установка минимальных пакетов выполнения
-RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y --no-install-recommends \
     libssl3t64 \
     python3.12-minimal \
     curl \


### PR DESCRIPTION
## Summary
- pin Dockerfile.ci and Dockerfile.cpu to ubuntu:noble-20250716
- run `apt-get dist-upgrade` during package installation

## Testing
- `pre-commit run --files Dockerfile.ci Dockerfile.cpu` *(fails: ImportError: No module named 'tenacity')*
- `docker build -f Dockerfile.ci -t myapp:latest .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*
- `trivy image myapp:latest` *(fails: unable to find the specified image "myapp:latest"; Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68a240400f7c832db93cf3096d509054