### PR TITLE
Add URL validation to GPT client

### DIFF
--- a/gpt_client.py
+++ b/gpt_client.py
@@ -32,6 +32,8 @@ class GPTClientResponseError(GPTClientError):
 
 def _validate_api_url(api_url: str) -> None:
     parsed = urlparse(api_url)
+    if not parsed.scheme or not parsed.hostname:
+        raise GPTClientError("Invalid GPT_OSS_API URL")
     if parsed.scheme != "https" and parsed.hostname != "localhost":
         logger.critical("Insecure GPT_OSS_API URL: %s", api_url)
         raise GPTClientError("GPT_OSS_API must use HTTPS or be localhost")

--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -67,6 +67,18 @@ def test_query_gpt_insecure_url(monkeypatch):
         query_gpt("hi")
 
 
+def test_query_gpt_invalid_url(monkeypatch):
+    monkeypatch.setenv("GPT_OSS_API", "bad-url")
+    with pytest.raises(GPTClientError, match="Invalid GPT_OSS_API URL"):
+        query_gpt("hi")
+
+
+def test_query_gpt_invalid_url_no_host(monkeypatch):
+    monkeypatch.setenv("GPT_OSS_API", "https://")
+    with pytest.raises(GPTClientError, match="Invalid GPT_OSS_API URL"):
+        query_gpt("hi")
+
+
 def test_query_gpt_no_env(monkeypatch):
     monkeypatch.delenv("GPT_OSS_API", raising=False)
     with pytest.raises(GPTClientNetworkError):
@@ -155,6 +167,20 @@ async def test_query_gpt_async_missing_fields(monkeypatch):
 async def test_query_gpt_async_insecure_url(monkeypatch):
     monkeypatch.setenv("GPT_OSS_API", "http://example.com")
     with pytest.raises(GPTClientError):
+        await query_gpt_async("hi")
+
+
+@pytest.mark.asyncio
+async def test_query_gpt_async_invalid_url(monkeypatch):
+    monkeypatch.setenv("GPT_OSS_API", "bad-url")
+    with pytest.raises(GPTClientError, match="Invalid GPT_OSS_API URL"):
+        await query_gpt_async("hi")
+
+
+@pytest.mark.asyncio
+async def test_query_gpt_async_invalid_url_no_host(monkeypatch):
+    monkeypatch.setenv("GPT_OSS_API", "https://")
+    with pytest.raises(GPTClientError, match="Invalid GPT_OSS_API URL"):
         await query_gpt_async("hi")
 
 


### PR DESCRIPTION
## Summary
- validate API URLs for missing scheme or hostname in GPT client
- test invalid URL scenarios for sync and async clients

## Testing
- `pre-commit run --files gpt_client.py tests/test_gpt_client.py` (fails: ImportError: cannot import name 'AsyncRetrying' from 'tenacity')
- `pytest tests/test_gpt_client.py::test_query_gpt_invalid_url tests/test_gpt_client.py::test_query_gpt_invalid_url_no_host tests/test_gpt_client.py::test_query_gpt_async_invalid_url tests/test_gpt_client.py::test_query_gpt_async_invalid_url_no_host -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2c8a5188c832d8b3b268cbb5d12ae