### PR TITLE
Run data handler service with Gunicorn

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,9 +310,15 @@ testing.
 Run each script directly from the project root:
 
 ```bash
-python services/data_handler_service.py
+gunicorn services.data_handler_service:app
 python services/model_builder_service.py
 python services/trade_manager_service.py
+```
+
+Для альтернативы без зависимостей можно запустить сервис через Waitress:
+
+```bash
+waitress-serve services.data_handler_service:app
 ```
 
 `data_handler_service.py` fetches prices from Bybit using `ccxt` and exposes
@@ -364,7 +370,7 @@ with the scripts from the `services` directory:
 
 ```yaml
 data_handler:
-  command: python services/data_handler_service.py
+  command: gunicorn services.data_handler_service:app
 model_builder:
   command: python services/model_builder_service.py
 trade_manager:

--- a/scripts/run_data_handler_service.sh
+++ b/scripts/run_data_handler_service.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+# Запуск data_handler_service через Gunicorn.
+# Передаёт все аргументы командной строки непосредственно Gunicorn.
+
+exec gunicorn services.data_handler_service:app "$@"
+

--- a/services/data_handler_service.py
+++ b/services/data_handler_service.py
@@ -71,22 +71,3 @@ def handle_unexpected_error(exc: Exception) -> tuple:
     """Log unexpected errors and return a 500 response."""
     logging.exception("Unhandled error: %s", exc)
     return jsonify({'error': 'internal server error'}), 500
-
-if __name__ == '__main__':
-    logging.basicConfig(level=logging.INFO)
-    port = int(os.environ.get('PORT', '8000'))
-    # По умолчанию слушаем только локальный интерфейс.
-    host = os.environ.get('HOST', '127.0.0.1')
-    # Prevent binding to all interfaces.
-    if host.strip() == '0.0.0.0':  # nosec B104
-        raise ValueError('HOST=0.0.0.0 запрещён из соображений безопасности')
-    if host != '127.0.0.1':
-        logging.warning(
-            'Используется не локальный хост %s; убедитесь, что это намеренно',
-            host,
-        )
-    else:
-        logging.info('HOST не установлен, используется %s', host)
-    init_exchange()
-    logging.info('Запуск сервиса DataHandler на %s:%s', host, port)
-    app.run(host=host, port=port)  # nosec B104  # хост проверен выше


### PR DESCRIPTION
## Summary
- remove built-in app.run block from data_handler_service
- document running the service via Gunicorn or Waitress
- add helper script for launching data handler with Gunicorn

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'AsyncRetrying' from 'tenacity')*


------
https://chatgpt.com/codex/tasks/task_e_68a2c8aba11c832d8e2507f54bf1b250