### PR TITLE
chore: use official artifact download action

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -85,20 +85,7 @@ jobs:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}.txt
 
-      - name: Download Trivy report
-        shell: bash
-        run: |
-          for i in {1..5}; do
-            npx github:actions/download-artifact@v4 \
-              --name "${{ matrix.artifact }}" \
-              --path .
-            if [ $? -eq 0 ]; then
-              break
-            fi
-            echo "Attempt $i failed, retrying in 10 seconds..."
-            sleep 10
-            if [ $i -eq 5 ]; then
-              echo "Unable to download artifact after 5 attempts"
-              exit 1
-            fi
-          done
+      - uses: actions/download-artifact@v4
+        with:
+          name: trivy-report-ci
+          path: .


### PR DESCRIPTION
## Summary
- replace custom download-artifact loop with official action

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml` *(fails: ModuleNotFoundError: No module named 'tenacity')*


------
https://chatgpt.com/codex/tasks/task_e_68a2d09b2eb8832d91407e6cc7b90a55