### PR TITLE
feat: simplify gptoss_check setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -171,8 +171,8 @@ services:
         soft: 65536
         hard: 65536
   gptoss_check:
-    image: averinaleks/myapp:latest
-    command: python3 gptoss_check/main.py
+    image: python:3.11-slim
+    command: sh -c "pip install --no-cache-dir httpx tenacity && python3 gptoss_check/main.py"
     working_dir: /workspace
     volumes:
       - .:/workspace


### PR DESCRIPTION
## Summary
- run gptoss_check with python:3.11-slim
- install httpx and tenacity before executing check script

## Testing
- `pytest` *(fails: Module import errors and other dependency issues)*
- `docker compose -f docker-compose.yml -f docker-compose.cpu.yml up --exit-code-from gptoss_check gptoss gptoss_check` *(fails: Cannot connect to the Docker daemon)*


------
https://chatgpt.com/codex/tasks/task_e_68a2e04a4e70832db0954a49761c4a95