### PR TITLE
Add config to DummyFlask stub in logging test

### DIFF
--- a/tests/test_data_handler_service_logging.py
+++ b/tests/test_data_handler_service_logging.py
@@ -19,7 +19,7 @@ def test_data_handler_service_does_not_configure_logging_on_import(monkeypatch):
 
     class DummyFlask:
         def __init__(self, name):
-            pass
+            self.config = {}
 
         def route(self, *args, **kwargs):
             def decorator(func):


### PR DESCRIPTION
## Summary
- ensure DummyFlask stub exposes a `config` dictionary in its initializer

## Testing
- `pytest tests/test_data_handler_service_logging.py` *(fails: AttributeError: 'DummyFlask' object has no attribute 'before_first_request')*

------
https://chatgpt.com/codex/tasks/task_e_68a2e4672d5c832dbbaf94d682f5bbe0