### PR TITLE
chore: update gptoss dependencies

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -2,7 +2,7 @@ FROM python:3.12-slim
 
 # Исправляем отсутствие libtbbmalloc.so.2, устанавливаем свежие патчи и ставим curl для health-check’а
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libtbbmalloc2=2021.8.0-2 curl=7.88.1-10+deb12u12 \
+    libtbbmalloc2=2022.1.0-1 curl=8.14.1-2 \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONUNBUFFERED=1 HF_HOME=/workspace/hf-cache


### PR DESCRIPTION
## Summary
- update libtbbmalloc2 and curl versions in Dockerfile.gptoss

## Testing
- `docker build -f Dockerfile.gptoss -t gptoss-test .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f3e9127c832db315640ca3f69252