### PR TITLE
Add DummyFlask before_first_request decorator

### DIFF
--- a/tests/test_data_handler_service_logging.py
+++ b/tests/test_data_handler_service_logging.py
@@ -31,6 +31,11 @@ def test_data_handler_service_does_not_configure_logging_on_import(monkeypatch):
                 return func
             return decorator
 
+        def before_first_request(self, *args, **kwargs):
+            def decorator(func):
+                return func
+            return decorator
+
         def run(self, *args, **kwargs):
             pass
 


### PR DESCRIPTION
## Summary
- add before_first_request no-op decorator in DummyFlask for data handler service logging test

## Testing
- `pytest -m "not integration"` *(fails: ImportError: Unable to find a usable engine for parquet; 10 failed, 206 passed, 2 skipped, 17 deselected)*

------
https://chatgpt.com/codex/tasks/task_e_68a2fbcbd61c832d91badc978c6b101e