### PR TITLE
Ensure CPU execution for GPT-OSS docker compose

### DIFF
--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -11,7 +11,8 @@ services:
     environment:
       VLLM_LOGGING_LEVEL: DEBUG
       MODEL: ${MODEL:-openai/gpt-oss-20b}
-      VLLM_DEVICE: cpu
+      CUDA_VISIBLE_DEVICES: ""
+      VLLM_TARGET_DEVICE: cpu
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/v1/health"]
       interval: 5s


### PR DESCRIPTION
## Summary
- add CUDA_VISIBLE_DEVICES and VLLM_TARGET_DEVICE to CPU docker compose service

## Testing
- `docker-compose -f docker-compose.cpu.yml build` *(fails: Connection refused)*
- `docker-compose -f docker-compose.cpu.yml up -d` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a31522fa08832dafdd074ae17430cd