### PR TITLE
Init exchange on first request for TradeManagerService

### DIFF
--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -36,13 +36,19 @@ def init_exchange() -> None:
         raise RuntimeError("Invalid Bybit configuration") from exc
 
 
-@app.before_first_request
-def _startup() -> None:
-    if exchange is None:
-        init_exchange()
-
 # Expected API token for simple authentication
 API_TOKEN = os.getenv('TRADE_MANAGER_TOKEN')
+
+_exchange_initialized = False
+
+
+@app.before_request
+def _ensure_exchange() -> None:
+    """Initialize the exchange on the first request."""
+    global _exchange_initialized
+    if not _exchange_initialized:
+        init_exchange()
+        _exchange_initialized = True
 
 
 @app.before_request


### PR DESCRIPTION
## Summary
- remove deprecated `before_first_request` startup hook
- initialize ccxt exchange once via `before_request`

## Testing
- `pre-commit run --files services/trade_manager_service.py` *(fails: ModuleNotFoundError: No module named 'tenacity')*
- `pytest -m integration` *(fails: ModuleNotFoundError: No module named 'tenacity')*


------
https://chatgpt.com/codex/tasks/task_e_68a3160bd6c0832d939b0de044d9583a