### PR TITLE
test: stub flask request in logging test

### DIFF
--- a/tests/test_data_handler_service_logging.py
+++ b/tests/test_data_handler_service_logging.py
@@ -41,6 +41,7 @@ def test_data_handler_service_does_not_configure_logging_on_import(monkeypatch):
 
     flask.Flask = DummyFlask
     flask.jsonify = lambda obj: obj
+    flask.request = types.SimpleNamespace(endpoint='ping')
     monkeypatch.setitem(sys.modules, 'flask', flask)
 
     monkeypatch.delitem(sys.modules, 'bot.services.data_handler_service', raising=False)


### PR DESCRIPTION
## Summary
- stub flask.request in tests for data handler service logging

## Testing
- `pytest tests/test_data_handler_service_logging.py` *(fails: AttributeError: 'DummyFlask' object has no attribute 'before_request')*

------
https://chatgpt.com/codex/tasks/task_e_68a31e1c4e4c832d97a038b672435773