### PR TITLE
Use CPU vLLM server in docker-compose

### DIFF
--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.gptoss
-    command: []
+    command: python3 -m vllm.entrypoints.openai.api_server --host 0.0.0.0 --port 8000 --model ${MODEL:-openai/gpt-oss-20b} --device cpu --max-num-seqs 4 --enforce-eager --disable-async-output-proc
     ports:
       - "8003:8000"
     volumes:


### PR DESCRIPTION
## Summary
- Run vLLM OpenAI-compatible server on CPU in docker-compose

## Testing
- `pytest` *(fails: AttributeError: 'DummyFlask' object has no attribute 'before_request'; AssertionError: assert False)*

------
https://chatgpt.com/codex/tasks/task_e_68a3264f43ec832da37d4d5d756d6c3c