### PR TITLE
feat: build vLLM from source in gptoss image

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -1,7 +1,9 @@
 FROM python:3.12-slim
 
 # Исправляем отсутствие libtbbmalloc.so.2, устанавливаем свежие патчи и ставим curl для health-check’а
+# Дополнительно устанавливаем инструменты сборки и git для сборки vLLM
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential git cmake ninja-build \
     libtbbmalloc2=2022.1.0-1 curl=8.14.1-2 \
     && rm -rf /var/lib/apt/lists/*
 
@@ -9,15 +11,12 @@ ENV PYTHONUNBUFFERED=1 HF_HOME=/workspace/hf-cache
 ENV VLLM_TARGET_DEVICE=cpu
 ENV PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu
 RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir "vllm>=0.5.3"
+    git clone --depth=1 https://github.com/vllm-project/vllm.git /tmp/vllm && \
+    cd /tmp/vllm && \
+    pip install --no-cache-dir -r requirements-cpu.txt && \
+    VLLM_TARGET_DEVICE=cpu python setup.py install && \
+    rm -rf /tmp/vllm
 
 EXPOSE 8000
 
-CMD python -m vllm.entrypoints.openai.api_server \
-    --host 0.0.0.0 \
-    --port 8000 \
-    --model Qwen/Qwen2.5-0.5B-Instruct \
-    --device cpu \
-    --max-num-seqs 4 \
-    --enforce-eager \
-    --disable-async-output-proc
+CMD python -m vllm.entrypoints.openai.api_server --host 0.0.0.0 --port 8000 --model ${MODEL:-openai/gpt-oss-20b} --device cpu --max-num-seqs 4 --enforce-eager --disable-async-output-proc


### PR DESCRIPTION
## Summary
- install build tools and git for building vLLM
- build vLLM from source with CPU target in Dockerfile.gptoss
- default to openai/gpt-oss-20b model in server command

## Testing
- `pre-commit run --files Dockerfile.gptoss` *(fails: module 'httpx' has no attribute 'Response')*


------
https://chatgpt.com/codex/tasks/task_e_68a326525584832d9724ad4c5d9966c2