### PR TITLE
chore: bump vllm to 0.10.1 in gptoss Dockerfile

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -9,7 +9,7 @@ ENV PYTHONUNBUFFERED=1 HF_HOME=/workspace/hf-cache
 ENV VLLM_TARGET_DEVICE=cpu
 ENV PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu
 RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir "vllm>=0.5.3"
+    pip install --no-cache-dir "vllm>=0.10.1"
 
 EXPOSE 8000
 


### PR DESCRIPTION
## Summary
- update gptoss Dockerfile to install vllm>=0.10.1

## Testing
- `pytest` (fails: ModuleNotFoundError: No module named 'tenacity')
- `docker build -f Dockerfile.gptoss -t gptoss .` (fails: command not found: docker)
- `docker-compose down && docker-compose up -d` (fails: command not found: docker-compose)


------
https://chatgpt.com/codex/tasks/task_e_68a326556378832d8260044f5442b0d7