### PR TITLE
Add missing before_request stub in DummyFlask

### DIFF
--- a/tests/test_data_handler_service_logging.py
+++ b/tests/test_data_handler_service_logging.py
@@ -31,6 +31,11 @@ def test_data_handler_service_does_not_configure_logging_on_import(monkeypatch):
                 return func
             return decorator
 
+        def before_request(self, *args, **kwargs):
+            def decorator(func):
+                return func
+            return decorator
+
         def before_first_request(self, *args, **kwargs):
             def decorator(func):
                 return func


### PR DESCRIPTION
## Summary
- add DummyFlask.before_request to mirror other stubbed decorators
- ensure data_handler_service can be imported without configuring logging

## Testing
- `pytest tests/test_data_handler_service_logging.py::test_data_handler_service_does_not_configure_logging_on_import -q`


------
https://chatgpt.com/codex/tasks/task_e_68a32a6e7ea4832d89f8a63dab668624