### PR TITLE
Pin ubuntu noble base image

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -2,7 +2,7 @@
 
 # -------- Builder stage --------
 # Используем публичный LTS-образ Ubuntu для сборки зависимостей
-FROM ubuntu:noble AS builder
+FROM ubuntu:noble-20250716 AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
@@ -38,7 +38,7 @@ COPY services services
 COPY tests tests
 
 # -------- Runtime stage --------
-FROM ubuntu:noble AS runtime
+FROM ubuntu:noble-20250716 AS runtime
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV PIP_BREAK_SYSTEM_PACKAGES=1


### PR DESCRIPTION
## Summary
- pin CI Dockerfile to patched `ubuntu:noble-20250716`

## Testing
- `pre-commit run --files Dockerfile.ci` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `docker build -f Dockerfile.ci .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68a32efbcbfc832dbc4c836dc8fb5e4c