### PR TITLE
Pin Python 3.12 to latest Ubuntu patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 FROM nvidia/cuda:13.0.0-cudnn-devel-ubuntu24.04 AS builder
 ARG ZLIB_VERSION=1.3.1
 ARG ZLIB_SHA256=9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23
+ARG PYTHON_VERSION=3.12.3-1ubuntu0.7
+ARG PYTHON_META=3.12.3-0ubuntu2
 ENV OMP_NUM_THREADS=1
 ENV MKL_NUM_THREADS=1
 ENV DEBIAN_FRONTEND=noninteractive
@@ -15,10 +17,11 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     libgcrypt20 \
     libpam0g \
     libssl3t64 \
-    python3.12-minimal \
+    python3.12-minimal=${PYTHON_VERSION} \
+    python3.12=${PYTHON_VERSION} \
+    python3=${PYTHON_META} \
     build-essential \
     curl \
-    python3 \
     python3-dev \
     python3-venv \
     python3-pip \
@@ -56,6 +59,8 @@ RUN pip install --no-cache-dir 'pip>=24.0' 'setuptools<81' wheel && \
 
 # Этап выполнения (минимальный образ)
 FROM nvidia/cuda:13.0.0-cudnn-runtime-ubuntu24.04
+ARG PYTHON_VERSION=3.12.3-1ubuntu0.7
+ARG PYTHON_META=3.12.3-0ubuntu2
 ENV OMP_NUM_THREADS=1
 ENV MKL_NUM_THREADS=1
 ENV DEBIAN_FRONTEND=noninteractive
@@ -67,8 +72,9 @@ WORKDIR /app
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     tzdata \
     libssl3t64 \
-    python3.12-minimal \
-    python3 \
+    python3.12-minimal=${PYTHON_VERSION} \
+    python3.12=${PYTHON_VERSION} \
+    python3=${PYTHON_META} \
     zlib1g \
     tar \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
## Summary
- Pin python3.12 packages to 3.12.3-1ubuntu0.7 and python3 meta to 3.12.3-0ubuntu2

## Testing
- `python gptoss_check/main.py`
- `docker build -t bot .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68a32efcfc04832da07fcecb85fb3d05