### PR TITLE
Refactor vLLM build in Dockerfile.gptoss

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -13,8 +13,7 @@ ENV PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu
 RUN pip install --no-cache-dir --upgrade pip && \
     git clone --depth=1 https://github.com/vllm-project/vllm.git /tmp/vllm && \
     cd /tmp/vllm && \
-    pip install --no-cache-dir -r requirements-cpu.txt && \
-    VLLM_TARGET_DEVICE=cpu python setup.py install && \
+    VLLM_TARGET_DEVICE=cpu pip install --no-cache-dir . && \
     rm -rf /tmp/vllm
 
 EXPOSE 8000


### PR DESCRIPTION
## Summary
- simplify vLLM build by installing from repo without requirements-cpu.txt
- ensure CPU-only PyTorch index via PIP_EXTRA_INDEX_URL

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `docker build -f Dockerfile.gptoss -t vllm-test .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3389ad628832daec7b9053ea97f01