### PR TITLE
Handle conversion fallback in config

### DIFF
--- a/tests/test_config_logging.py
+++ b/tests/test_config_logging.py
@@ -6,4 +6,4 @@ def test_load_config_logs_invalid_env(monkeypatch, caplog):
     monkeypatch.setenv("MAX_CONCURRENT_REQUESTS", "oops")
     with caplog.at_level(logging.WARNING):
         load_config()
-    assert "Ignoring MAX_CONCURRENT_REQUESTS: expected value of type int" in caplog.text
+    assert "Failed to convert 'oops' to int" in caplog.text


### PR DESCRIPTION
## Summary
- avoid string leakage when env vars can't be converted
- fall back to defaults or raise if no fallback is available
- update config logging test

## Testing
- `pytest tests/test_config_logging.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas'; AttributeError: module 'httpx' has no attribute 'Response')*


------
https://chatgpt.com/codex/tasks/task_e_68a35122d324832da26bcafe6f78f6cf