### PR TITLE
Initialize FastAPI app and load model on startup

### DIFF
--- a/server.py
+++ b/server.py
@@ -2,8 +2,6 @@ import os
 import logging
 import asyncio
 from typing import List
-from contextlib import asynccontextmanager
-
 import torch
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
@@ -20,8 +18,8 @@ except Exception as exc:  # pragma: no cover - used for optional dependency
 tokenizer = None
 model = None
 device = "cuda" if torch.cuda.is_available() else "cpu"
-# Task responsible for loading the model asynchronously.
-_load_model_task: asyncio.Task | None = None
+
+app = FastAPI()
 
 
 def load_model() -> None:
@@ -75,6 +73,11 @@ def load_model() -> None:
 async def load_model_async() -> None:
     """Asynchronously load the model without blocking the event loop."""
     await asyncio.to_thread(load_model)
+
+
+@app.on_event("startup")
+async def startup_event() -> None:
+    await load_model_async()
 
 
 


### PR DESCRIPTION
## Summary
- instantiate FastAPI app before defining routes
- load model during startup via async helper

## Testing
- `pre-commit run --files server.py` *(fails: ModuleNotFoundError: No module named 'tenacity')*
- `pytest tests/test_server_request_validation.py` *(fails: ValueError: psutil.__spec__ is None)*

------
https://chatgpt.com/codex/tasks/task_e_68a352a64cc0832db38c3ae8e3613f99