### PR TITLE
Add libnuma-dev to GPT-OSS Dockerfile

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -5,6 +5,7 @@ FROM python:3.12-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential git cmake ninja-build \
     libtbbmalloc2=2022.1.0-1 curl=8.14.1-2 \
+    libnuma-dev \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONUNBUFFERED=1 HF_HOME=/workspace/hf-cache


### PR DESCRIPTION
## Summary
- install libnuma-dev in GPT-OSS Dockerfile

## Testing
- `pre-commit run --files Dockerfile.gptoss` *(fails: ModuleNotFoundError: No module named 'tenacity')*
- `docker build -f Dockerfile.gptoss .` *(fails: Cannot connect to the Docker daemon)*
- `docker compose -f docker-compose.yml -f docker-compose.cpu.yml up gptoss gptoss_check` *(not run: docker daemon unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68a3542369e8832db105d76d2bfae3f5