### PR TITLE
Ensure single FastAPI app instance

### DIFF
--- a/server.py
+++ b/server.py
@@ -23,8 +23,6 @@ tokenizer = None
 model = None
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
-app = FastAPI()
-
 
 def load_model() -> str:
     """Load the tokenizer and model into global variables.


### PR DESCRIPTION
## Summary
- define the FastAPI `app` only once after imports

## Testing
- `flake8 server.py`
- `pytest -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68a3556bdc7c832db4f6453c5e286dea