### PR TITLE
chore: upgrade packages during image build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -58,6 +58,10 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 
+      - name: Apply security upgrades in built image
+        run: |
+          docker run --rm ${{ matrix.tag }} bash -lc "apt-get update && apt-get upgrade -y && apt-get clean && rm -rf /var/lib/apt/lists/*"
+
       - name: Move Docker layer cache
         run: |
           rm -rf /tmp/.buildx-cache

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -2,7 +2,10 @@ FROM ubuntu:noble-20250716 AS builder
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Обновление linux-libc-dev устраняет CVE-2025-21976, а libgcrypt20 — CVE-2024-2236
-RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y --no-install-recommends \
+# Обновляем систему перед установкой зависимостей
+RUN apt-get update && apt-get dist-upgrade -y
+
+RUN apt-get install -y --no-install-recommends \
     linux-libc-dev \
     libpam0g \
     libssl3t64 \
@@ -28,8 +31,11 @@ RUN python3 -m venv $VIRTUAL_ENV && \
 
 FROM ubuntu:noble-20250716
 
+# Обновляем систему перед установкой зависимостей выполнения
+RUN apt-get update && apt-get dist-upgrade -y
+
 # Установка минимальных пакетов выполнения
-RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y --no-install-recommends \
+RUN apt-get install -y --no-install-recommends \
     libssl3t64 \
     python3.12-minimal \
     curl \


### PR DESCRIPTION
## Summary
- upgrade Ubuntu packages in Dockerfile.cpu before installing deps
- run apt-get upgrade on built images in docker publish workflow

## Testing
- `pre-commit run --files Dockerfile.cpu .github/workflows/docker-publish.yml` (fails: module 'httpx' has no attribute 'Response')
- `pytest` (fails: module 'httpx' has no attribute 'Response')
- `docker build -f Dockerfile.cpu .` (fails: Cannot connect to the Docker daemon)


------
https://chatgpt.com/codex/tasks/task_e_68a35651a39c832da5c6a13221b00188