### PR TITLE
Replace Ray commons-lang3 jar with 3.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Bump Requests dependency to >=2.32.4 to address CVE-2024-47081.
 - Update linux-libc-dev to 6.8.0-76.76 to mitigate CVE-2025-21976.
 - Update linux-libc-dev to a patched revision to close CVE-2025-21946.
+- Replace Ray's commons-lang3 JAR with version 3.18.0 to address vulnerabilities.

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,9 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 # Устанавливаем зависимости (pip >=24.0 и устраняет CVE-2023-32681)
 RUN pip install --no-cache-dir 'pip>=24.0' 'setuptools<81' wheel && \
     pip install --no-cache-dir -r requirements-core.txt -r requirements-gpu.txt && \
+    RAY_JARS_DIR=$($VIRTUAL_ENV/bin/python -c "import os, ray; print(os.path.join(os.path.dirname(ray.__file__), 'jars'))") && \
+    rm -f "$RAY_JARS_DIR"/commons-lang3-*.jar && \
+    curl -fsSL https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar -o "$RAY_JARS_DIR"/commons-lang3-3.18.0.jar && \
     find /app/venv -type d -name '__pycache__' -exec rm -rf {} + && \
     find /app/venv -type f -name '*.pyc' -delete
 

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -22,6 +22,9 @@ RUN python3 -m venv $VIRTUAL_ENV && \
     # pip >=24.0 и устраняет CVE-2023-32681
     $VIRTUAL_ENV/bin/pip install --no-cache-dir 'pip>=24.0' 'setuptools<81' wheel && \
     $VIRTUAL_ENV/bin/pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -r requirements-core.txt && \
+    RAY_JARS_DIR=$($VIRTUAL_ENV/bin/python -c "import os, ray; print(os.path.join(os.path.dirname(ray.__file__), 'jars'))") && \
+    rm -f "$RAY_JARS_DIR"/commons-lang3-*.jar && \
+    curl -fsSL https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar -o "$RAY_JARS_DIR"/commons-lang3-3.18.0.jar && \
     $VIRTUAL_ENV/bin/pip freeze | grep -i '^nvidia-' | cut -d= -f1 | xargs -r $VIRTUAL_ENV/bin/pip uninstall -y && \
     find $VIRTUAL_ENV -type d -name '__pycache__' -exec rm -rf {} + && \
     find $VIRTUAL_ENV -type f -name '*.pyc' -delete


### PR DESCRIPTION
## Summary
- replace Ray commons-lang3 jar with 3.18.0 in Docker build
- document commons-lang3 upgrade in changelog

## Testing
- `python3 -m pre_commit run --files Dockerfile Dockerfile.cpu CHANGELOG.md`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `docker build -f Dockerfile .` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68a3565b063c832d8d7a18987bddb3df