### PR TITLE
chore: update openai dependency

### DIFF
--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -224,7 +224,7 @@ nvidia-nvjitlink-cu12==12.6.85
     #   torch
 nvidia-nvtx-cu12==12.6.77
     # via torch
-openai==1.90.0
+openai==1.98.0
     # via vllm
 opencv-python-headless==4.12.0.88
     # via


### PR DESCRIPTION
## Summary
- bump openai package to 1.98.0

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `docker compose build gptoss` *(fails: command not found: docker)*
- `docker compose -f docker-compose.yml -f docker-compose.cpu.yml up --exit-code-from gptoss_check gptoss gptoss_check` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68a362522eec832d87bc13341abc61f6