### PR TITLE
Use monkeypatch for torch stubs in import tests

### DIFF
--- a/tests/test_model_builder_import.py
+++ b/tests/test_model_builder_import.py
@@ -19,10 +19,10 @@ def test_model_builder_requires_gymnasium(monkeypatch):
         torch_stub.nn = nn_stub
         torch_stub.utils = utils_stub
         utils_stub.data = data_stub
-        sys.modules['torch'] = torch_stub
-        sys.modules['torch.nn'] = nn_stub
-        sys.modules['torch.utils'] = utils_stub
-        sys.modules['torch.utils.data'] = data_stub
+        monkeypatch.setitem(sys.modules, 'torch', torch_stub)
+        monkeypatch.setitem(sys.modules, 'torch.nn', nn_stub)
+        monkeypatch.setitem(sys.modules, 'torch.utils', utils_stub)
+        monkeypatch.setitem(sys.modules, 'torch.utils.data', data_stub)
     monkeypatch.setitem(sys.modules, 'gymnasium', None)
     with pytest.raises(ImportError, match='gymnasium package is required'):
         importlib.import_module('model_builder')
@@ -42,10 +42,10 @@ def test_model_builder_imports_without_mlflow(monkeypatch):
         torch_stub.nn = nn_stub
         torch_stub.utils = utils_stub
         utils_stub.data = data_stub
-        sys.modules['torch'] = torch_stub
-        sys.modules['torch.nn'] = nn_stub
-        sys.modules['torch.utils'] = utils_stub
-        sys.modules['torch.utils.data'] = data_stub
+        monkeypatch.setitem(sys.modules, 'torch', torch_stub)
+        monkeypatch.setitem(sys.modules, 'torch.nn', nn_stub)
+        monkeypatch.setitem(sys.modules, 'torch.utils', utils_stub)
+        monkeypatch.setitem(sys.modules, 'torch.utils.data', data_stub)
     gym_stub = types.ModuleType('gymnasium')
     gym_stub.Env = object
     gym_stub.spaces = types.ModuleType('spaces')


### PR DESCRIPTION
## Summary
- replace direct `sys.modules` assignments with `monkeypatch.setitem` for PyTorch stubs in import tests

## Testing
- `pytest tests/test_model_builder.py tests/test_model_builder_import.py -m "not integration"`
- `pytest -m "not integration"` *(fails: ModuleNotFoundError: No module named 'pandas', AttributeError: module 'httpx' has no attribute 'Response')*

------
https://chatgpt.com/codex/tasks/task_e_68a363cb3168832daa30fab066faa0a5