### PR TITLE
chore: lighten PyPI workflow dependencies

### DIFF
--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -1,0 +1,27 @@
+name: Submit package to PyPI
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-ci.txt --no-deps
+      - name: Build package
+        run: python -m build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,0 +1,3 @@
+# Minimal CPU-only requirements for CI workflows
+build==1.2.1
+twine==5.1.1


### PR DESCRIPTION
## Summary
- add CPU-only requirements file
- update PyPI submission workflow to avoid heavy dependency installs

## Testing
- `pip install -r requirements-ci.txt --no-deps`
- `pip list | rg 'torch|nvidia' || true`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68a363e04094832d9a45c1de4ee9a938