### PR TITLE
chore: optimize pip cache in pypi workflow

### DIFF
--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -1,0 +1,37 @@
+name: Submit to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+            !~/.cache/pip/nvidia-*
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install dependencies
+        run: pip install --no-cache-dir -r requirements-core.txt
+      - name: Build package
+        run: python -m build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Purge pip cache
+        if: always()
+        run: pip cache purge


### PR DESCRIPTION
## Summary
- configure pip caching for PyPI submission workflow while excluding `nvidia-*`
- install dependencies without local cache and purge cache at job end

## Testing
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68a363e3938c832d85f9be203152cb3b