### PR TITLE
feat: install openai before building vllm

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -12,6 +12,7 @@ ENV PYTHONUNBUFFERED=1 HF_HOME=/workspace/hf-cache
 ENV VLLM_TARGET_DEVICE=cpu
 ENV PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu
 RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir openai==1.99.1 && \
     pip install --no-cache-dir "git+https://github.com/vllm-project/vllm.git"
 
 EXPOSE 8000


### PR DESCRIPTION
## Summary
- add openai dependency to gptoss Dockerfile before vLLM installation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `docker build -f Dockerfile.gptoss -t bot-gptoss .` *(fails: command not found: docker)*
- `python -m vllm.entrypoints.openai.api_server --help` *(fails: ModuleNotFoundError: No module named 'vllm')*

------
https://chatgpt.com/codex/tasks/task_e_68a3660b8654832d95a8efcf83666f20