### PR TITLE
ci: disable checkout creds and quiet git config

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -30,6 +30,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
+        with:
+          persist-credentials: false
       - name: Bandit Scan
         uses: shundor/python-bandit-scan@ab1d87dfccc5a0ffab88be3aaac6ffe35c10d6cd
         with: # optional arguments

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
+        with:
+          persist-credentials: false
       - name: Cleanup git submodules
         run: >
-          git submodule foreach --recursive sh -c "git config --local gc.auto 0 || :" || :
+          git submodule foreach --recursive sh -c "git config --quiet --local gc.auto 0 || :" || :
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
@@ -46,9 +48,11 @@ jobs:
     needs: unit
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
+        with:
+          persist-credentials: false
       - name: Cleanup git submodules
         run: >
-          git submodule foreach --recursive sh -c "git config --local gc.auto 0 || :" || :
+          git submodule foreach --recursive sh -c "git config --quiet --local gc.auto 0 || :" || :
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,6 +15,8 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: github/codeql-action/init@v3
         with:
           languages: python

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
+        with:
+          persist-credentials: false
       - name: Run Dependabot
         run: scripts/run_dependabot.sh
         env:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Освободить место на диске
         uses: jlumbroso/free-disk-space@main
         with:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -32,6 +32,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.x'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
+        with:
+          persist-credentials: false
 
       - name: Build an image from Dockerfile.ci
         run: |


### PR DESCRIPTION
## Summary
- silence `git config` in submodule cleanup
- avoid persisting checkout credentials across workflows

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/dependabot.yml .github/workflows/codeql.yml .github/workflows/trivy.yml .github/workflows/gptoss_review.yml .github/workflows/docker-publish.yml .github/workflows/bandit.yml .github/workflows/semgrep.yml` *(fails: module 'torch' has no attribute 'device')*


------
https://chatgpt.com/codex/tasks/task_e_68a363e65830832db2410b84ce91368f