### PR TITLE
Install flake8 during test dependency setup

### DIFF
--- a/scripts/install-test-deps.sh
+++ b/scripts/install-test-deps.sh
@@ -6,3 +6,4 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 # Install all requirements from the unified requirements.txt.
 python -m pip install -r "$REPO_ROOT/requirements.txt"
+python -m pip install flake8


### PR DESCRIPTION
## Summary
- ensure flake8 is installed by test dependency script

## Testing
- `./scripts/install-test-deps.sh`
- `python -m flake8 --version`
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68a36952d214832daf8676b6baf5aee7