### PR TITLE
Ensure async tasks shut down cleanly

### DIFF
--- a/tests/test_run_async.py
+++ b/tests/test_run_async.py
@@ -19,3 +19,33 @@ async def test_run_async_logs_exception(caplog):
     messages = [record.getMessage() for record in caplog.records]
     assert any("run_async task failed" in m for m in messages)
     assert not trading_bot._TASKS
+
+
+@pytest.mark.asyncio
+async def test_shutdown_async_tasks_completes_pending_tasks():
+    done = False
+
+    async def coro():
+        nonlocal done
+        await asyncio.sleep(0)
+        done = True
+
+    trading_bot.run_async(coro())
+    await trading_bot.shutdown_async_tasks()
+    assert done
+    assert not trading_bot._TASKS
+
+
+@pytest.mark.asyncio
+async def test_close_http_client_shuts_down_tasks():
+    done = False
+
+    async def coro():
+        nonlocal done
+        await asyncio.sleep(0)
+        done = True
+
+    trading_bot.run_async(coro())
+    await trading_bot.close_http_client()
+    assert done
+    assert not trading_bot._TASKS

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -113,6 +113,13 @@ def run_async(coro: Awaitable[None]) -> None:
         _TASKS.add(task)
         task.add_done_callback(_task_done)
 
+
+async def shutdown_async_tasks() -> None:
+    """Wait for all scheduled tasks to complete."""
+    if _TASKS:
+        await asyncio.gather(*_TASKS, return_exceptions=True)
+        _TASKS.clear()
+
 # Threshold for slow trade confirmations
 CONFIRMATION_TIMEOUT = safe_float("ORDER_CONFIRMATION_TIMEOUT", 5.0)
 
@@ -151,6 +158,7 @@ def get_http_client() -> httpx.AsyncClient:
 
 async def close_http_client() -> None:
     """Close the module-level HTTP client if it exists."""
+    await shutdown_async_tasks()
     if HTTP_CLIENT is not None:
         await HTTP_CLIENT.aclose()
 


### PR DESCRIPTION
## Summary
- add `shutdown_async_tasks` utility to wait for all scheduled async tasks
- invoke `shutdown_async_tasks` from `close_http_client`
- test task cleanup and shutdown behavior

## Testing
- `pytest tests/test_run_async.py`

------
https://chatgpt.com/codex/tasks/task_e_68a369d50964832d87f474d078f7f7a4