### PR TITLE
build(ci): pin pip 25.2 in Dockerfile

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get dist-upgrade -y && apt-get i
     python3-venv \
     python3-pip \
     && python3 -m venv /venv \
-    && /venv/bin/pip install --no-cache-dir --upgrade --break-system-packages --ignore-installed 'pip>=24.0' \
+    && /venv/bin/python -m pip install --no-cache-dir --upgrade --break-system-packages pip==25.2 \
     && find / -xdev -type l -lname "*..*" -print \
     && apt-get purge -y --auto-remove build-essential \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
## Summary
- pin CI Dockerfile to use `python -m pip install ... pip==25.2`

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*
- `docker build -f Dockerfile.ci -t bot-ci-test .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68a36a9f8630832d9d3de4134257a99f