### PR TITLE
Add OpenAI requirement

### DIFF
--- a/requirements-core.in
+++ b/requirements-core.in
@@ -36,3 +36,4 @@ polars>=0.20.16
 httpx>=0.27.0
 cryptography>=42.0.0
 bcrypt>=4.2.0
+openai<1.100


### PR DESCRIPTION
## Summary
- add OpenAI dependency to core requirements

## Testing
- `pip-compile requirements-core.in requirements-gpu.in -o requirements.txt` *(no output)*
- `docker compose build gptoss` *(command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a36a82d120832d8ad19a7629817b84