### PR TITLE
Expose SafeHTMLParser fed byte count via property

### DIFF
--- a/safe_html_parser.py
+++ b/safe_html_parser.py
@@ -35,6 +35,10 @@ class SafeHTMLParser(HTMLParser):
         self._max_feed_size = max_feed_size
         self._fed = 0
 
+    @property
+    def fed_bytes(self) -> int:
+        return self._fed
+
     def feed(self, data: str) -> None:  # type: ignore[override]
         """Feed data to the parser, enforcing ``max_feed_size``.
 

--- a/tests/test_safe_html_parser.py
+++ b/tests/test_safe_html_parser.py
@@ -13,7 +13,7 @@ def test_small_input_parses():
     parser = SafeHTMLParser()
     parser.feed("<div>ok</div>")
     # No exception should be raised and parser should have consumed input.
-    assert parser._fed == len("<div>ok</div>")
+    assert parser.fed_bytes == len("<div>ok</div>")
 
 
 def test_large_input_raises():
@@ -38,7 +38,7 @@ def test_counts_bytes_not_chars():
     parser = SafeHTMLParser(max_feed_size=4)
     # emoji is four bytes in UTF-8
     parser.feed("😀")
-    assert parser._fed == len("😀".encode("utf-8"))
+    assert parser.fed_bytes == len("😀".encode("utf-8"))
     with pytest.raises(ValueError):
         parser.feed("😀")
 
@@ -47,7 +47,7 @@ def test_multilingual_input_counts_bytes():
     parser = SafeHTMLParser(max_feed_size=10)
     multilingual = "ä漢字"  # mix of 2-byte and 3-byte characters
     parser.feed(multilingual)
-    assert parser._fed == len(multilingual.encode("utf-8"))
+    assert parser.fed_bytes == len(multilingual.encode("utf-8"))
     with pytest.raises(ValueError):
         parser.feed("😀")
 
@@ -58,4 +58,4 @@ def test_close_resets_counter():
     parser.close()
     # After closing, parser should be reusable without raising.
     parser.feed("abcde")
-    assert parser._fed == 5
+    assert parser.fed_bytes == 5


### PR DESCRIPTION
## Summary
- expose fed byte count via new `fed_bytes` property on `SafeHTMLParser`
- adjust tests to use the new property

## Testing
- `pytest tests/test_safe_html_parser.py`
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68a36aa2a720832da639f6bcfb9539cd