### PR TITLE
Initialize logger once in utils

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,7 @@
 """Miscellaneous helper utilities for the trading bot."""
 
 import logging
+logger = logging.getLogger("TradingBot")
 import os
 import json
 import re
@@ -400,7 +401,6 @@ class BybitSDKAsync:
         return await asyncio.to_thread(_sync)
 
 
-logger = logging.getLogger("TradingBot")
 level_name = os.getenv("LOG_LEVEL", "INFO").upper()
 logger.setLevel(getattr(logging, level_name, logging.INFO))
 


### PR DESCRIPTION
## Summary
- define global TradingBot logger near imports
- remove redundant logger reinitialization

## Testing
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68a36aa6515c832db7a308ccf052583e