### PR TITLE
chore: remove version pins for curl and libtbbmalloc2

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -4,7 +4,7 @@ FROM python:3.12-slim
 # Дополнительно устанавливаем инструменты сборки и git для сборки vLLM
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential git cmake ninja-build \
-    libtbbmalloc2=2022.1.0-1 curl=8.14.1-2 \
+    libtbbmalloc2 curl \
     libnuma-dev \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- drop curl/libtbbmalloc2 version pins so image uses Ubuntu 24.04 defaults

## Testing
- `pre-commit run --files Dockerfile.gptoss` *(fails: ImportError: cannot import name 'psutil' from 'bot.utils')*

------
https://chatgpt.com/codex/tasks/task_e_68a370e3d3cc832da606833c29f26ff2