### PR TITLE
Use pip-compile dry-run for dependency check in PyPI workflow

### DIFF
--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -18,6 +18,17 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-ci.txt --no-deps
+      - name: Check dependencies
+        run: |
+          set +e
+          pip-compile --dry-run -o requirements.out requirements.txt
+          status=$?
+          if [ $status -eq 0 ]; then
+            echo "Dependency check passed."
+          else
+            echo "Dependency check failed."
+          fi
+          exit $status
       - name: Build package
         run: python -m build
       - name: Publish to PyPI


### PR DESCRIPTION
## Summary
- use single pip-compile dry run in PyPI submission workflow
- report dependency check result based on exit code

## Testing
- `pre-commit run --files .github/workflows/submit-pypi.yml` *(fails: ImportError: cannot import name 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_68a370fe4284832d9f38fa559583db4b