### PR TITLE
Use released vllm and CPU mode

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -13,7 +13,7 @@ ENV VLLM_TARGET_DEVICE=cpu
 ENV PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir openai==1.99.1 && \
-    pip install --no-cache-dir "git+https://github.com/vllm-project/vllm.git"
+    pip install --no-cache-dir vllm==0.10.0
 
 EXPOSE 8000
 


### PR DESCRIPTION
## Summary
- Use official `vllm` release instead of installing from GitHub
- Ensure `VLLM_TARGET_DEVICE=cpu` is set in Dockerfile for CPU execution

## Testing
- `pytest` *(fails: module 'httpx' has no attribute 'Response')*


------
https://chatgpt.com/codex/tasks/task_e_68a370e07100832d89219f37998dae9e