### PR TITLE
chore: pin python version in semgrep workflow

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -36,7 +36,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: '3.x'
+          python-version-file: .python-version
       - name: Install Semgrep
         run: pip install semgrep
       - name: Semgrep scan (SARIF)


### PR DESCRIPTION
## Summary
- use `.python-version` to set Python version in semgrep workflow

## Testing
- `pre-commit run --files .github/workflows/semgrep.yml .python-version` *(fails: ImportError: cannot import name 'psutil' from 'bot.utils')*

------
https://chatgpt.com/codex/tasks/task_e_68a37103d248832db91f4c3ddf8e48c4