### PR TITLE
Remove unused vision/audio/triton dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@
    ./scripts/install-test-deps.sh
    ```
    В CI применяются только стандартные колёса PyTorch без поддержки CUDA.
-   Если вам нужна GPU‑сборка с CUDA 12.4, установите PyTorch и torchvision
+   Если вам нужна GPU‑сборка с CUDA 12.4, установите PyTorch
    отдельно, указав дополнительный индекс:
 
    ```bash
-   pip install torch>=2.7.1 torchvision>=0.22.1 --extra-index-url https://download.pytorch.org/whl/cu124
+   pip install torch>=2.7.1 --extra-index-url https://download.pytorch.org/whl/cu124
    ```
    Эта команда ставит версии с поддержкой CUDA 12.4. Выполните её до
    `python -m pip install -r requirements-core.txt -r requirements-gpu.txt` (или вместо него, если
@@ -736,7 +736,6 @@ The test suite relies on the following packages:
 - numpy
 - pandas
 - torch
-- torchvision
 - ccxt
 - ccxtpro
 - pybit

--- a/requirements-core.in
+++ b/requirements-core.in
@@ -1,7 +1,6 @@
 numpy>=1.26.4  # core numeric library
 pandas>=2.2.2
 torch==2.7.1
-torchvision==0.22.1
 ccxt>=4.3.85
 ccxtpro>=0.9.0
 python-telegram-bot>=20.7

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -292,7 +292,6 @@ numpy==2.2.6
     #   tensorboardx
     #   tensorflow
     #   torchmetrics
-    #   torchvision
     #   transformers
 nvidia-cublas-cu12==12.6.4.1
     # via
@@ -384,7 +383,6 @@ pillow==11.3.0
     # via
     #   matplotlib
     #   tensorboard
-    #   torchvision
 plotly==6.3.0
     # via -r requirements-core.in
 pluggy==1.6.0
@@ -567,11 +565,8 @@ torch==2.7.1
     #   pytorch-lightning
     #   stable-baselines3
     #   torchmetrics
-    #   torchvision
 torchmetrics==1.8.1
     # via pytorch-lightning
-torchvision==0.22.1
-    # via -r requirements-core.in
 tqdm==4.67.1
     # via
     #   catalyst
@@ -582,7 +577,6 @@ tqdm==4.67.1
     #   transformers
 transformers==4.55.2
     # via -r requirements-core.in
-triton==3.3.1
     # via torch
 typing-extensions==4.14.1
     # via

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -183,7 +183,6 @@ numpy==2.2.6
     #   scipy
     #   soundfile
     #   soxr
-    #   torchvision
     #   transformers
     #   vllm
     #   xformers
@@ -243,7 +242,6 @@ partial-json-parser==0.2.1.1.post6
 pillow==11.3.0
     # via
     #   mistral-common
-    #   torchvision
     #   vllm
 prometheus-client==0.22.1
     # via
@@ -375,15 +373,9 @@ tokenizers==0.21.4
 torch==2.7.1
     # via
     #   compressed-tensors
-    #   torchaudio
-    #   torchvision
     #   vllm
     #   xformers
     #   xgrammar
-torchaudio==2.7.1
-    # via vllm
-torchvision==0.22.1
-    # via vllm
 tqdm==4.67.1
     # via
     #   gguf
@@ -395,10 +387,6 @@ transformers==4.55.2
     # via
     #   compressed-tensors
     #   vllm
-    #   xgrammar
-triton==3.3.1
-    # via
-    #   torch
     #   xgrammar
 typer==0.16.0
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -367,7 +367,6 @@ numpy==2.2.6
     #   tensorboardx
     #   tensorflow
     #   torchmetrics
-    #   torchvision
     #   transformers
     #   vllm
     #   xformers
@@ -471,7 +470,6 @@ pillow==11.3.0
     #   matplotlib
     #   mistral-common
     #   tensorboard
-    #   torchvision
     #   vllm
 polars==1.32.3
     # via -r requirements-core.in
@@ -717,20 +715,12 @@ torch==2.7.1
     #   compressed-tensors
     #   pytorch-lightning
     #   stable-baselines3
-    #   torchaudio
     #   torchmetrics
-    #   torchvision
     #   vllm
     #   xformers
     #   xgrammar
-torchaudio==2.7.1
-    # via vllm
 torchmetrics==1.8.1
     # via pytorch-lightning
-torchvision==0.22.1
-    # via
-    #   -r requirements-core.in
-    #   vllm
 tqdm==4.67.1
     # via
     #   catalyst
@@ -747,10 +737,6 @@ transformers==4.55.2
     #   -r requirements-core.in
     #   compressed-tensors
     #   vllm
-    #   xgrammar
-triton==3.3.1
-    # via
-    #   torch
     #   xgrammar
 typer==0.16.0
     # via


### PR DESCRIPTION
## Summary
- drop torchvision, torchaudio and triton from all requirement files
- update README to install only PyTorch for CUDA builds

## Testing
- `pre-commit run --files README.md requirements-core.in requirements-core.txt requirements-gpu.txt requirements.txt` *(failed: ImportError in tests/test_cache.py)*
- `pytest` *(failed: ImportError: cannot import name 'psutil' from 'bot.utils')*

------
https://chatgpt.com/codex/tasks/task_e_68a370e14c38832d900b17daa0a01bb3