### PR TITLE
fix: define numpy for volume profile

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -40,6 +40,10 @@ except ImportError as exc:  # pragma: no cover - allow missing numba package
     def prange(*args):  # type: ignore
         raise ImportError("numba is required for prange") from _numba_exc
 
+try:
+    import numpy as np  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency
+    np = None  # type: ignore[assignment]
 
 import httpx
 


### PR DESCRIPTION
## Summary
- ensure `np` is defined for JIT volume profile helpers

## Testing
- `flake8 .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas', then later missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a37737acf4832da90682966be3cde3