### PR TITLE
Use prebuilt gpt-oss image for CPU

### DIFF
--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -1,9 +1,6 @@
 services:
   gptoss:
-    build:
-      context: .
-      dockerfile: Dockerfile.gptoss
-    command: python3 -m vllm.entrypoints.openai.api_server --host 0.0.0.0 --port 8000 --model ${MODEL:-openai/gpt-oss-20b} --device cpu --max-num-seqs 4 --enforce-eager --disable-async-output-proc
+    image: vllm/vllm-openai:latest
     ports:
       - "8003:8000"
     volumes:


### PR DESCRIPTION
## Summary
- Switch docker-compose.cpu.yml to use vllm/vllm-openai:latest image.
- Retain CPU targeting via VLLM_TARGET_DEVICE environment variable and existing ports/volume.

## Testing
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68a377738154832d8818ae9230888fa5