### PR TITLE
Guard volume profile calculation on missing numpy

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -41,9 +41,9 @@ except ImportError as exc:  # pragma: no cover - allow missing numba package
         raise ImportError("numba is required for prange") from _numba_exc
 
 try:
-    import numpy as np  # type: ignore
-except ImportError:  # pragma: no cover - optional dependency
-    np = None  # type: ignore[assignment]
+    import numpy as np
+except ImportError:
+    np = None
 
 import httpx
 
@@ -753,6 +753,8 @@ def filter_outliers_zscore(df, column="close", threshold=3.0):
 
 @jit(nopython=True, parallel=True)
 def _calculate_volume_profile(prices, volumes, bins=50):
+    if np is None:
+        raise RuntimeError("NumPy требуется для расчёта профиля объёма")
     if len(prices) != len(volumes) or len(prices) < 2:
         return np.zeros(bins)
     min_price = np.min(prices)


### PR DESCRIPTION
## Summary
- ensure numpy import falls back to `None`
- raise runtime error when numpy is unavailable in volume profile calculation

## Testing
- `flake8 .`
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a38cdd5ff0832da09a657f31cc3fcd