### PR TITLE
Log invalid trade parameters

### DIFF
--- a/tests/test_trading_bot.py
+++ b/tests/test_trading_bot.py
@@ -3,6 +3,7 @@ import asyncio
 import time
 import types
 import pytest
+import logging
 
 
 @pytest.mark.asyncio
@@ -689,11 +690,14 @@ def test_run_once_ignores_invalid_env(monkeypatch):
     }
 
 
-def test_parse_trade_params_invalid_strings():
-    tp, sl, ts = trading_bot._parse_trade_params("bad", "5", "x")
+def test_parse_trade_params_invalid_strings(caplog):
+    with caplog.at_level(logging.WARNING):
+        tp, sl, ts = trading_bot._parse_trade_params("bad", "5", "x")
     assert tp is None
     assert sl == 5.0
     assert ts is None
+    assert "bad" in caplog.text
+    assert "x" in caplog.text
 
 
 @pytest.mark.parametrize(

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -551,7 +551,8 @@ def _parse_trade_params(
     def _parse(value: float | str | None) -> float | None:
         try:
             return float(value) if value is not None else None
-        except (TypeError, ValueError):
+        except (TypeError, ValueError) as exc:
+            logger.warning("Invalid trade parameter %r: %s", value, exc)
             return None
 
     return _parse(tp), _parse(sl), _parse(trailing_stop)


### PR DESCRIPTION
## Summary
- warn on invalid trade parameter values in `trading_bot._parse_trade_params`
- test warning when invalid trade parameters are provided

## Testing
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68a392468990832d85c41c39d66249f8