### PR TITLE
Fix registry proxy env assignment in Dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -20,8 +20,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.TOKEN }}
       - name: Load registry proxy config
         run: |
-          echo "GITHUB_REGISTRIES_PROXY=$(cat .github/registries-proxy.json)" \
-            >> "$GITHUB_ENV"
+          echo "GITHUB_REGISTRIES_PROXY=$(jq -c . .github/registries-proxy.json)" >> "$GITHUB_ENV"
       - name: Dependabot Action
         if: github.actor == 'dependabot[bot]'
         uses: github/dependabot-action@8a8ecd4a2ccff00ad1680d32caef59634c31d3c0


### PR DESCRIPTION
## Summary
- fix registry proxy env assignment to avoid multiline JSON issues

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml` *(fails: async def functions are not natively supported)*


------
https://chatgpt.com/codex/tasks/task_e_68a393702800832db22cbdf2db840e68