### PR TITLE
Add asyncio marker for async tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,4 +2,5 @@
 addopts = -m "not integration"
 markers =
     integration: marks tests that require external services or slower integration steps
+    asyncio: mark test as asyncio-based
 


### PR DESCRIPTION
## Summary
- add `asyncio` marker to pytest configuration to silence warnings

## Testing
- `pytest -m "not integration"`


------
https://chatgpt.com/codex/tasks/task_e_68a393b9c42c832db6163e983adc51ab