### PR TITLE
ci: install pip-tools before dependency check

### DIFF
--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -36,6 +36,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-ci.txt --no-deps
+      - name: Install pip-tools
+        run: pip install pip-tools
       - name: Check dependencies
         run: |
           set +e


### PR DESCRIPTION
## Summary
- ensure pip-compile is available in PyPI submit workflow by installing pip-tools first

## Testing
- `python -m pip install --upgrade pip`
- `pip install -r requirements-ci.txt --no-deps`
- `pip install pip-tools`
- ⚠️ `pip-compile --dry-run -o requirements.out requirements.txt` (did not complete within allotted time)


------
https://chatgpt.com/codex/tasks/task_e_68a393e418c0832db52f35033894eeef