### PR TITLE
Add CPU target env for gptoss_check service

### DIFF
--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -19,6 +19,10 @@ services:
     networks:
       - gptoss_net
 
+  gptoss_check:
+    environment:
+      VLLM_TARGET_DEVICE: cpu
+
 networks:
   gptoss_net:
     name: gptoss_net


### PR DESCRIPTION
## Summary
- specify `VLLM_TARGET_DEVICE=cpu` for `gptoss_check` in CPU docker-compose override

## Testing
- `SKIP=pytest pre-commit run --files docker-compose.cpu.yml`
- `pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a39575b514832db8c522fe6f9d5f25