### PR TITLE
Ensure CI checkout uses merge commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           persist-credentials: false
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          fetch-depth: 0
       - name: Cleanup git submodules
         run: >
           git submodule foreach --recursive sh -c "git config --quiet --local gc.auto 0 || :" || :
@@ -68,6 +70,8 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           persist-credentials: false
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          fetch-depth: 0
       - name: Cleanup git submodules
         run: >
           git submodule foreach --recursive sh -c "git config --quiet --local gc.auto 0 || :" || :


### PR DESCRIPTION
## Summary
- checkout merge commit in CI workflows

## Testing
- `pytest -m "not integration"` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68a41cff7194832dadd6fbcf1f6833dd