### PR TITLE
chore: use jq for registry proxy config

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -20,7 +20,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.TOKEN }}
       - name: Load registry proxy config
         run: |
-          echo "GITHUB_REGISTRIES_PROXY=$(jq -c . .github/registries-proxy.json)" >> "$GITHUB_ENV"
+          echo "GITHUB_REGISTRIES_PROXY=$(jq -c '.' .github/registries-proxy.json)" >> "$GITHUB_ENV"
       - name: Dependabot Action
         if: github.actor == 'dependabot[bot]'
         uses: github/dependabot-action@8a8ecd4a2ccff00ad1680d32caef59634c31d3c0


### PR DESCRIPTION
## Summary
- load registries proxy config with `jq -c` in Dependabot workflow

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml --hook-stage manual`
- `pytest -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68a41e21ec74832dbaa53a25dabaf18b