### PR TITLE
Add explicit CPU command to gptoss service

### DIFF
--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -5,6 +5,15 @@ services:
       - "8003:8000"
     volumes:
       - gptoss_workspace:/workspace
+    command:
+      - --model
+      - openai/gpt-oss-20b
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8000"
+      - --device
+      - cpu
     environment:
       VLLM_LOGGING_LEVEL: DEBUG
       MODEL: ${MODEL:-openai/gpt-oss-20b}


### PR DESCRIPTION
## Summary
- specify command for gptoss in CPU compose file to bind model, host, port, and CPU device

## Testing
- `pytest`
- `docker-compose -f docker-compose.yml -f docker-compose.cpu.yml up gptoss` *(fails: Connection refused to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68a4286bc0c4832da4aaa741c37eb09f