### PR TITLE
refactor: replace target device env

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -8,7 +8,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONUNBUFFERED=1 HF_HOME=/workspace/hf-cache
-ENV VLLM_TARGET_DEVICE=cpu
 
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir openai==1.99.1 && \
@@ -22,7 +21,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONUNBUFFERED=1 HF_HOME=/workspace/hf-cache
-ENV VLLM_TARGET_DEVICE=cpu
 ENV PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu
 
 COPY --from=builder /usr/local /usr/local

--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -9,7 +9,7 @@ services:
       VLLM_LOGGING_LEVEL: DEBUG
       MODEL: ${MODEL:-openai/gpt-oss-20b}
       CUDA_VISIBLE_DEVICES: ""
-      VLLM_TARGET_DEVICE: cpu
+      VLLM_DEVICE: cpu
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/v1/health"]
       interval: 5s
@@ -21,7 +21,7 @@ services:
 
   gptoss_check:
     environment:
-      VLLM_TARGET_DEVICE: cpu
+      VLLM_DEVICE: cpu
 
 networks:
   gptoss_net:


### PR DESCRIPTION
## Summary
- replace VLLM_TARGET_DEVICE with VLLM_DEVICE in CPU compose config
- drop obsolete device env from gptoss Dockerfile

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*
- `docker build -f Dockerfile.gptoss -t gptoss-cpu .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*
- `dockerd` *(fails: failed to register "bridge" driver: iptables permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68a4286d8668832d82e61488da42b542