### PR TITLE
Inline registry proxy config in Dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -19,8 +19,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.TOKEN }}
       - name: Load registry proxy config
-        run: |
-          echo "GITHUB_REGISTRIES_PROXY=$(jq -c '.' .github/registries-proxy.json)" >> "$GITHUB_ENV"
+        run: echo "GITHUB_REGISTRIES_PROXY=$(jq -c . .github/registries-proxy.json)" >> "$GITHUB_ENV"
       - name: Dependabot Action
         if: github.actor == 'dependabot[bot]'
         uses: github/dependabot-action@8a8ecd4a2ccff00ad1680d32caef59634c31d3c0


### PR DESCRIPTION
## Summary
- inline registry proxy JSON when exporting `GITHUB_REGISTRIES_PROXY`

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml` *(fails: KeyboardInterrupt)*
- `pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a45501ccc0832db3f68193c714c41f