### PR TITLE
Use heredoc for registry proxy config

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -19,7 +19,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.TOKEN }}
       - name: Load registry proxy config
-        run: echo "GITHUB_REGISTRIES_PROXY=$(jq -c . .github/registries-proxy.json)" >> "$GITHUB_ENV"
+        run: |
+          cat <<'EOF' >> "$GITHUB_ENV"
+          GITHUB_REGISTRIES_PROXY=$(jq -c . .github/registries-proxy.json)
+          EOF
       - name: Dependabot Action
         if: github.actor == 'dependabot[bot]'
         uses: github/dependabot-action@8a8ecd4a2ccff00ad1680d32caef59634c31d3c0


### PR DESCRIPTION
## Summary
- ensure registry proxy config is written to `$GITHUB_ENV` via heredoc in dependabot workflow

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml`
- `gh workflow run dependabot.yml` *(fails: command not found: gh)*

------
https://chatgpt.com/codex/tasks/task_e_68a45af1b528832d8c25b62968e0b45c