### PR TITLE
chore: update cpu compose image

### DIFF
--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -1,6 +1,6 @@
 services:
   gptoss:
-    image: vllm/vllm-openai:latest
+    image: vllm/vllm-openai:latest-cpu
     ports:
       - "8003:8000"
     volumes:


### PR DESCRIPTION
## Summary
- use CPU-specific vLLM image for `gptoss` service

## Testing
- `pytest`
- `docker-compose -f docker-compose.yml -f docker-compose.cpu.yml up --build gptoss gptoss_check` *(fails: ConnectionRefusedError: [Errno 111] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a474427ef0832d87ae976f20c2081d