### PR TITLE
Enable OIDC token for PyPI publish

### DIFF
--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Free disk space


### PR DESCRIPTION
## Summary
- allow GitHub Actions to request an OIDC token and read repo contents when publishing to PyPI

## Testing
- `pre-commit run --files .github/workflows/submit-pypi.yml`
- `pytest`
- `gh workflow run submit-pypi.yml` *(fails: authentication required)*

------
https://chatgpt.com/codex/tasks/task_e_68a474db38a0832d8c8481b734bdd427