### PR TITLE
docs: clarify OIDC permissions for PyPI publish workflow

### DIFF
--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-22.04
+    # Explicit permissions for OIDC-based publishing
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## Summary
- clarify OIDC permission block in PyPI publish workflow

## Testing
- `pre-commit run --files .github/workflows/submit-pypi.yml` *(failed: KeyboardInterrupt)*
- `act workflow_dispatch -W .github/workflows/submit-pypi.yml -j publish -s PYPI_API_TOKEN=dummy` *(failed: no Docker available)*

------
https://chatgpt.com/codex/tasks/task_e_68a47a2f2cd4832dbbc865db8c1c2373