### PR TITLE
Read timeout from env in GPT client

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@
     - `GPT_OSS_WAIT_TIMEOUT` — время ожидания запуска сервера GPT OSS в
       секундах (по умолчанию `30`).
     - `GPT_OSS_TIMEOUT` — таймаут запроса к GPT OSS API в секундах (по
-      умолчанию `5`). Используется функцией `query_gpt_async`.
+      умолчанию `5`). Используется функциями `query_gpt` и `query_gpt_async`.
 
      В `docker-compose.yml` теперь есть сервис `gptoss`,
      запускающий образ `ghcr.io/openaccess-ai-collective/gpt-oss:cpu-latest` на порту `8003`

--- a/gpt_client.py
+++ b/gpt_client.py
@@ -58,9 +58,9 @@ def _validate_api_url(api_url: str) -> None:
     wait=wait_exponential(min=1, max=10),
     reraise=True,
 )
-def _post_with_retry(url: str, prompt: str) -> httpx.Response:
+def _post_with_retry(url: str, prompt: str, timeout: float) -> httpx.Response:
     """POST helper that retries on network failures."""
-    with httpx.Client(trust_env=False, timeout=5) as client:
+    with httpx.Client(trust_env=False, timeout=timeout) as client:
         response = client.post(url, json={"prompt": prompt})
         response.raise_for_status()
         return response
@@ -70,7 +70,8 @@ def query_gpt(prompt: str) -> str:
     """Send *prompt* to the GPT OSS API and return the first completion text.
 
     The API endpoint is read from the ``GPT_OSS_API`` environment variable. If
-    it is not set a :class:`GPTClientNetworkError` is raised. Network errors are
+    it is not set a :class:`GPTClientNetworkError` is raised. Request timeout is
+    read from ``GPT_OSS_TIMEOUT`` (seconds, default ``5``). Network errors are
     retried up to three times with exponential backoff between one and ten
     seconds before giving up.
     """
@@ -80,9 +81,17 @@ def query_gpt(prompt: str) -> str:
         raise GPTClientNetworkError("GPT_OSS_API environment variable not set")
 
     _validate_api_url(api_url)
+    timeout_env = os.getenv("GPT_OSS_TIMEOUT", "5")
+    try:
+        timeout = float(timeout_env)
+    except ValueError:
+        logger.warning(
+            "Invalid GPT_OSS_TIMEOUT value %r; defaulting to 5.0", timeout_env
+        )
+        timeout = 5.0
     url = api_url.rstrip("/") + "/v1/completions"
     try:
-        response = _post_with_retry(url, prompt)
+        response = _post_with_retry(url, prompt, timeout)
     except httpx.HTTPError as exc:  # pragma: no cover - network errors
         logger.exception("Error querying GPT OSS API: %s", exc)
         raise GPTClientNetworkError("Failed to query GPT OSS API") from exc


### PR DESCRIPTION
## Summary
- Allow configuring synchronous GPT client timeout via GPT_OSS_TIMEOUT
- Pass timeout through `_post_with_retry` and `httpx.Client`
- Mention timeout env in docs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a48a8aee08832da49f13b5c0ba1d2d