### PR TITLE
Refactor Dockerfile.gptoss CMD formatting

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -27,4 +27,11 @@ COPY --from=builder /usr/local /usr/local
 
 EXPOSE 8000
 
-CMD python -m vllm.entrypoints.openai.api_server --host 0.0.0.0 --port 8000 --model ${MODEL:-openai/gpt-oss-20b} --device cpu --max-num-seqs 4 --enforce-eager --disable-async-output-proc
+CMD python -m vllm.entrypoints.openai.api_server \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --model ${MODEL:-openai/gpt-oss-20b} \
+    --device cpu \
+    --max-num-seqs 4 \
+    --enforce-eager \
+    --disable-async-output-proc


### PR DESCRIPTION
## Summary
- break long CMD line in `Dockerfile.gptoss` into multiple lines with continuations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a48dbde764832d9c368e1bcf034d2d