### PR TITLE
feat: set GitHub API version for Dependabot

### DIFF
--- a/scripts/run_dependabot.sh
+++ b/scripts/run_dependabot.sh
@@ -8,6 +8,7 @@ for ecosystem in pip github-actions; do
   curl -X POST \
     -H "Authorization: Bearer ${token}" \
     -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
     https://api.github.com/repos/${repo}/dependabot/updates \
     -d "{\"package-ecosystem\":\"${ecosystem}\",\"directory\":\"/\"}"
 done


### PR DESCRIPTION
## Summary
- include X-GitHub-Api-Version header in Dependabot curl requests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4ae2020d4832d91ba9a4ba2933021