### PR TITLE
Handle generic list types in config parser

### DIFF
--- a/config.py
+++ b/config.py
@@ -10,7 +10,7 @@ import json
 import logging
 import os
 from dataclasses import MISSING, dataclass, field, fields, asdict
-from typing import Any, Dict, List, get_type_hints, Optional
+from typing import Any, Dict, List, Optional, get_args, get_origin, get_type_hints
 
 
 logger = logging.getLogger(__name__)
@@ -187,9 +187,10 @@ def _convert(value: str, typ: type, fallback: Any | None = None) -> Any:
             if fallback is not None:
                 return fallback
             raise
-    if typ is list or typ == List[str] or getattr(typ, "__origin__", None) is list:
-        subtype = getattr(typ, "__args__", (str,))
-        subtype = subtype[0] if subtype else str
+    origin = get_origin(typ)
+    if typ is list or origin is list:
+        subtypes = get_args(typ)
+        subtype = subtypes[0] if subtypes else str
         try:
             items = json.loads(value)
         except json.JSONDecodeError:

--- a/tests/test_config_list_parsing.py
+++ b/tests/test_config_list_parsing.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import config
 
 
@@ -11,3 +13,18 @@ def test_env_list_parsing_csv(monkeypatch):
     monkeypatch.setenv("BACKUP_WS_URLS", 'ws://a,ws://b')
     cfg = config.load_config()
     assert cfg.backup_ws_urls == ["ws://a", "ws://b"]
+
+
+def test_convert_list_int():
+    assert config._convert("[1, 2, 3]", List[int]) == [1, 2, 3]
+    assert config._convert("1,2,3", List[int]) == [1, 2, 3]
+
+
+def test_convert_list_float():
+    assert config._convert("[1.1, 2.2]", List[float]) == [1.1, 2.2]
+    assert config._convert("1.1,2.2", List[float]) == [1.1, 2.2]
+
+
+def test_convert_list_bool():
+    assert config._convert("[true, false, true]", List[bool]) == [True, False, True]
+    assert config._convert("true,false", List[bool]) == [True, False]


### PR DESCRIPTION
## Summary
- use `typing.get_origin` and `get_args` to detect and extract list subtypes in `_convert`
- parse lists of arbitrary element types, not only `str`
- extend tests to cover int, float and bool list parsing

## Testing
- `pytest tests/test_config_list_parsing.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4aecb6d44832db21b714131b8a593