### PR TITLE
Preserve metadata in numba jit stub

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -92,3 +92,19 @@ def test_logging_not_duplicated_on_reimport(monkeypatch, tmp_path, capsys):
     utils_mod.logger.info("second")
     captured = capsys.readouterr()
     assert captured.err.count("second") == 1
+
+
+def test_jit_stub_preserves_metadata(monkeypatch):
+    if not hasattr(utils, "_numba_missing"):
+        pytest.skip("numba is installed")
+
+    @utils.jit(nopython=True)
+    def sample_func(x):
+        """example docstring"""
+        return x
+
+    assert sample_func.__name__ == "sample_func"
+    assert sample_func.__doc__ == "example docstring"
+
+    with pytest.raises(ImportError):
+        sample_func(1)

--- a/utils.py
+++ b/utils.py
@@ -10,6 +10,7 @@ import time
 import inspect
 import threading
 import warnings
+from functools import wraps
 from typing import Dict, List, Optional
 import gzip
 import shutil
@@ -30,8 +31,9 @@ except ImportError as exc:  # pragma: no cover - allow missing numba package
 
     def jit(*a, **k):
         def wrapper(_f):
+            @wraps(_f)
             def inner(*args, **kwargs):
-                return _numba_missing()
+                return _numba_missing(*args, **kwargs)
 
             return inner
 


### PR DESCRIPTION
## Summary
- use functools.wraps in numba jit stub to keep function metadata
- forward arguments to missing numba handler
- test that stubbed jit preserves name and docstring

## Testing
- `pytest tests/test_utils.py::test_jit_stub_preserves_metadata -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4aeccc29c832d9dc12d5ba3a895a8