### PR TITLE
refactor: reuse http client for telegram alerts

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -70,15 +70,15 @@ async def send_telegram_alert(message: str) -> None:
     if not token or not chat_id:
         return
     url = f"https://api.telegram.org/bot{token}/sendMessage"
+    client = get_http_client()
     max_attempts = safe_int("TELEGRAM_ALERT_RETRIES", 3)
     delay = 1
     for attempt in range(1, max_attempts + 1):
         try:
-            async with httpx.AsyncClient(trust_env=False) as client:
-                response = await client.post(
-                    url, data={"chat_id": chat_id, "text": message}, timeout=5
-                )
-                response.raise_for_status()
+            response = await client.post(
+                url, data={"chat_id": chat_id, "text": message}, timeout=5
+            )
+            response.raise_for_status()
             return
         except httpx.HTTPError as exc:  # pragma: no cover - network errors
             logger.warning(


### PR DESCRIPTION
## Summary
- reuse shared HTTP client for Telegram notifications
- add test ensuring alerts use global client

## Testing
- `pytest tests/test_trading_bot.py::test_send_telegram_alert_reuses_client -q`
- `pytest tests/test_trading_bot.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4aece10d4832d873c4779f17f7bd7