### PR TITLE
Normalize API URL scheme and add test

### DIFF
--- a/gpt_client.py
+++ b/gpt_client.py
@@ -44,7 +44,8 @@ def _validate_api_url(api_url: str) -> None:
             return False
         return ip.is_loopback or ip.is_private
 
-    if parsed.scheme != "https" and not _is_allowed(parsed.hostname):
+    scheme = parsed.scheme.lower()
+    if scheme != "https" and not _is_allowed(parsed.hostname):
         logger.critical("Insecure GPT_OSS_API URL: %s", api_url)
         raise GPTClientError("GPT_OSS_API must use HTTPS or be a private address")
 

--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -68,6 +68,16 @@ def test_query_gpt_insecure_url(monkeypatch):
         query_gpt("hi")
 
 
+def test_query_gpt_uppercase_scheme(monkeypatch):
+    monkeypatch.setenv("GPT_OSS_API", "HTTPS://example.com")
+
+    def fake_post(self, *args, **kwargs):
+        return DummyResponse(json_data={"choices": [{"text": "ok"}]})
+
+    monkeypatch.setattr(httpx.Client, "post", fake_post)
+    assert query_gpt("hi") == "ok"
+
+
 @pytest.mark.parametrize("ip", [
     "127.0.0.1",
     "10.0.0.1",


### PR DESCRIPTION
## Summary
- Normalize scheme to lowercase in API URL validation
- Add test ensuring uppercase HTTPS URL passes validation

## Testing
- `pytest tests/test_gpt_client.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a4b602c93c832d81caf754004151f9