### PR TITLE
Validate trade side in trade payload

### DIFF
--- a/tests/test_trading_bot.py
+++ b/tests/test_trading_bot.py
@@ -66,6 +66,14 @@ async def test_send_trade_timeout_env(monkeypatch):
     assert result is True
 
 
+@pytest.mark.parametrize("side", ["hold", "BUY", ""])
+def test_build_trade_payload_invalid_side(side):
+    with pytest.raises(ValueError, match="'buy' or 'sell'"):
+        trading_bot._build_trade_payload(
+            "BTCUSDT", side, 1.0, None, None, None
+        )
+
+
 def test_load_env_uses_host(monkeypatch):
     monkeypatch.delenv('DATA_HANDLER_URL', raising=False)
     monkeypatch.delenv('MODEL_BUILDER_URL', raising=False)

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -383,6 +383,9 @@ def _build_trade_payload(
 ) -> tuple[dict, dict, float]:
     """Return payload, headers and timeout for trade requests."""
 
+    if side not in {"buy", "sell"}:
+        raise ValueError("side must be 'buy' or 'sell'")
+
     payload = {"symbol": symbol, "side": side, "price": price}
     if tp is not None:
         payload["tp"] = tp


### PR DESCRIPTION
## Summary
- ensure `_build_trade_payload` only accepts `buy` or `sell`
- test that invalid trade sides are rejected

## Testing
- `pre-commit run --files trading_bot.py tests/test_trading_bot.py`
- `pytest tests/test_trading_bot.py::test_build_trade_payload_invalid_side -q`

------
https://chatgpt.com/codex/tasks/task_e_68a4b6000668832d9d1edb3af31a9720