### PR TITLE
Warn and default on non-positive floats

### DIFF
--- a/tests/test_env_parsing.py
+++ b/tests/test_env_parsing.py
@@ -17,6 +17,13 @@ def test_safe_float_invalid(monkeypatch, caplog):
     assert "Invalid X_FLOAT" in caplog.text
 
 
+def test_safe_float_non_positive(monkeypatch, caplog):
+    monkeypatch.setenv("X_FLOAT", "0")
+    with caplog.at_level("WARNING"):
+        assert trading_bot.safe_float("X_FLOAT", 3.5) == 3.5
+    assert "Non-positive X_FLOAT" in caplog.text
+
+
 @pytest.mark.asyncio
 async def test_send_trade_timeout_invalid_env(monkeypatch):
     called = {}

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -50,12 +50,18 @@ def safe_int(env_var: str, default: int) -> int:
 
 
 def safe_float(env_var: str, default: float) -> float:
-    """Return float value of ``env_var`` or ``default`` on failure."""
+    """Return float value of ``env_var`` or ``default`` on failure or non-positive value."""
     value = os.getenv(env_var)
     if value is None:
         return default
     try:
-        return float(value)
+        result = float(value)
+        if result <= 0:
+            logger.warning(
+                "Non-positive %s value '%s', using default %s", env_var, value, default
+            )
+            return default
+        return result
     except ValueError:
         logger.warning(
             "Invalid %s value '%s', using default %s", env_var, value, default


### PR DESCRIPTION
## Summary
- warn and default when environment floats are non-positive
- test non-positive values handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4b5ff1190832d9f4f5b177f5a9ef5