### PR TITLE
Handle Dependabot update errors

### DIFF
--- a/scripts/run_dependabot.sh
+++ b/scripts/run_dependabot.sh
@@ -5,10 +5,13 @@ repo="${GITHUB_REPOSITORY}"
 token="${GITHUB_TOKEN}"
 
 for ecosystem in pip github-actions; do
-  curl -X POST \
+  if ! curl -f -S -s -X POST \
     -H "Authorization: Bearer ${token}" \
     -H "Accept: application/vnd.github+json" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
     https://api.github.com/repos/${repo}/dependabot/updates \
-    -d "{\"package-ecosystem\":\"${ecosystem}\",\"directory\":\"/\"}"
+    -d "{\"package-ecosystem\":\"${ecosystem}\",\"directory\":\"/\"}"; then
+    echo "Failed to trigger Dependabot for ${ecosystem}" >&2
+    exit 1
+  fi
 done


### PR DESCRIPTION
## Summary
- add failure handling for Dependabot trigger curl calls

## Testing
- `pre-commit run --files scripts/run_dependabot.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a4b932a598832d85a1c745a644da7f