### PR TITLE
chore: add permissions for dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -9,6 +9,10 @@ name: Dependabot
 jobs:
   update:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v4


### PR DESCRIPTION
## Summary
- add explicit write permissions for dependabot workflow

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a4b93474b8832d80921ca626534084