### PR TITLE
Restrict disk buffer paths to buffer directory

### DIFF
--- a/tests/test_data_handler.py
+++ b/tests/test_data_handler.py
@@ -204,6 +204,19 @@ async def test_load_from_disk_buffer_loop(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_disk_buffer_path_escape(tmp_path):
+    cfg = BotConfig(cache_dir=str(tmp_path))
+    dh = DataHandler(cfg, None, None, exchange=DummyExchange({'BTCUSDT': 1.0}))
+
+    outside = tmp_path.parent / "outside.json"
+    outside.write_text("{}", encoding="utf-8")
+    dh.disk_buffer.put_nowait(str(outside))
+
+    with pytest.raises(ValueError):
+        await dh.load_from_disk_buffer()
+
+
+@pytest.mark.asyncio
 async def test_cleanup_old_data_recovery(monkeypatch, cfg_factory):
     cfg = cfg_factory(data_cleanup_interval=0)
     dh = DataHandler(cfg, None, None, exchange=DummyExchange({'BTCUSDT': 1.0}))


### PR DESCRIPTION
## Summary
- ensure buffer directory uses resolved Path and verify candidate paths remain inside it
- add test guarding against path traversal when loading from disk buffer

## Testing
- `pytest tests/test_data_handler.py::test_load_from_disk_buffer_loop -q`
- `pytest tests/test_data_handler.py::test_disk_buffer_path_escape -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4b99b4d14832d9ee3dc1ff60c75ee