### PR TITLE
feat: parametrize tar version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Этап сборки
+ARG TAR_VERSION=1.35+dfsg-3build1
 FROM nvidia/cuda:13.0.0-cudnn-devel-ubuntu24.04 AS builder
+ARG TAR_VERSION
 ARG ZLIB_VERSION=1.3.1
 ARG ZLIB_SHA256=9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23
 ENV OMP_NUM_THREADS=1
@@ -58,6 +60,7 @@ RUN pip install --no-cache-dir 'pip>=24.0' 'setuptools<81' wheel && \
 
 # Этап выполнения (минимальный образ)
 FROM nvidia/cuda:13.0.0-cudnn-runtime-ubuntu24.04
+ARG TAR_VERSION
 ARG PYTHON_VERSION=3.12.3-1ubuntu0.7
 ARG PYTHON_META=3.12.3-0ubuntu2
 ENV OMP_NUM_THREADS=1


### PR DESCRIPTION
## Summary
- add TAR_VERSION build arg and reuse in runtime stage

## Testing
- `pre-commit run --files Dockerfile`
- `docker build .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68a4bce22638832db519f231733fa855