### PR TITLE
Pin coreutils and libpam0g versions and enforce Trivy scan

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -70,6 +70,7 @@ jobs:
           ignore-unfixed: true
           # ignore-unlikely-affected: true  # enable once Trivy >= v0.66 is available
           limit-severities-for-sarif: CRITICAL
+          exit-code: 1
 
       - name: Show Trivy scan results
         run: cat trivy-results.sarif

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 # Этап сборки
+ARG COREUTILS_VERSION=9.4-3ubuntu6
+ARG LIBPAM0G_VERSION=1.5.3-5ubuntu5.4
 FROM nvidia/cuda:13.0.0-cudnn-devel-ubuntu24.04 AS builder
+ARG COREUTILS_VERSION
+ARG LIBPAM0G_VERSION
 ARG ZLIB_VERSION=1.3.1
 ARG ZLIB_SHA256=9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23
 ENV OMP_NUM_THREADS=1
@@ -11,9 +15,10 @@ ENV TZ=Etc/UTC
 # Обновление linux-libc-dev устраняет CVE-2024-50217 и CVE-2025-21976, а libgcrypt20 — CVE-2024-2236
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     tzdata \
+    coreutils=${COREUTILS_VERSION} \
     linux-libc-dev \
     libgcrypt20 \
-    libpam0g \
+    libpam0g=${LIBPAM0G_VERSION} \
     libssl3t64 \
     build-essential \
     curl \
@@ -58,6 +63,8 @@ RUN pip install --no-cache-dir 'pip>=24.0' 'setuptools<81' wheel && \
 
 # Этап выполнения (минимальный образ)
 FROM nvidia/cuda:13.0.0-cudnn-runtime-ubuntu24.04
+ARG COREUTILS_VERSION
+ARG LIBPAM0G_VERSION
 ARG PYTHON_VERSION=3.12.3-1ubuntu0.7
 ARG PYTHON_META=3.12.3-0ubuntu2
 ENV OMP_NUM_THREADS=1
@@ -70,6 +77,8 @@ WORKDIR /app
 # Установка минимальных пакетов выполнения
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     tzdata \
+    coreutils=${COREUTILS_VERSION} \
+    libpam0g=${LIBPAM0G_VERSION} \
     libssl3t64 \
     zlib1g \
     tar=${TAR_VERSION} \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -2,16 +2,21 @@
 
 # -------- Builder stage --------
 # Используем публичный LTS-образ Ubuntu для сборки зависимостей
+ARG COREUTILS_VERSION=9.4-3ubuntu6
+ARG LIBPAM0G_VERSION=1.5.3-5ubuntu5.4
 FROM ubuntu:noble-20250716 AS builder
 
+ARG COREUTILS_VERSION
+ARG LIBPAM0G_VERSION
 ARG DEBIAN_FRONTEND=noninteractive
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
 # Обновление linux-libc-dev устраняет CVE-2025-21976, а libgcrypt20 — CVE-2024-2236
 RUN apt-get update && apt-get upgrade -y && apt-get dist-upgrade -y && apt-get install -y --no-install-recommends \
+    coreutils=${COREUTILS_VERSION} \
     linux-libc-dev \
     libgcrypt20 \
-    libpam0g \
+    libpam0g=${LIBPAM0G_VERSION} \
     libssl3t64 \
     python3.12-minimal \
     zlib1g-dev \
@@ -40,11 +45,15 @@ COPY tests tests
 # -------- Runtime stage --------
 FROM ubuntu:noble-20250716 AS runtime
 
+ARG COREUTILS_VERSION
+ARG LIBPAM0G_VERSION
 ARG DEBIAN_FRONTEND=noninteractive
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
 # Устанавливаем только необходимые пакеты выполнения
 RUN apt-get update && apt-get upgrade -y && apt-get dist-upgrade -y && apt-get install -y --no-install-recommends \
+    coreutils=${COREUTILS_VERSION} \
+    libpam0g=${LIBPAM0G_VERSION} \
     libssl3t64 \
     python3.12-minimal \
     python3 \


### PR DESCRIPTION
## Summary
- pin coreutils and libpam0g patch versions in Dockerfile and Dockerfile.ci
- make Trivy scan fail on vulnerabilities in CI

## Testing
- `pre-commit run --files Dockerfile Dockerfile.ci .github/workflows/trivy.yml`
- `trivy fs --exit-code 0 --severity HIGH,CRITICAL --ignore-unfixed .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a4bce91690832db334cd3d8bc7e0f8