### PR TITLE
Handle non-positive integers from env

### DIFF
--- a/tests/test_env_parsing.py
+++ b/tests/test_env_parsing.py
@@ -10,6 +10,13 @@ def test_safe_int_invalid(monkeypatch, caplog):
     assert "Invalid X_INT" in caplog.text
 
 
+def test_safe_int_non_positive(monkeypatch, caplog):
+    monkeypatch.setenv("X_INT", "-1")
+    with caplog.at_level("WARNING"):
+        assert trading_bot.safe_int("X_INT", 7) == 7
+    assert "Non-positive X_INT" in caplog.text
+
+
 def test_safe_float_invalid(monkeypatch, caplog):
     monkeypatch.setenv("X_FLOAT", "bad")
     with caplog.at_level("WARNING"):

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -41,7 +41,13 @@ def safe_int(env_var: str, default: int) -> int:
     if value is None:
         return default
     try:
-        return int(value)
+        result = int(value)
+        if result <= 0:
+            logger.warning(
+                "Non-positive %s value '%s', using default %s", env_var, value, default
+            )
+            return default
+        return result
     except ValueError:
         logger.warning(
             "Invalid %s value '%s', using default %s", env_var, value, default


### PR DESCRIPTION
## Summary
- warn and fall back to default when env int is non-positive
- cover safe_int negative case in tests

## Testing
- `pre-commit run --files trading_bot.py tests/test_env_parsing.py`
- `pytest tests/test_env_parsing.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4be045494832d826ae58e9678f4c1