### PR TITLE
chore: обновить права для Dependabot

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -13,6 +13,7 @@ jobs:
       contents: write
       pull-requests: write
       security-events: write
+      dependabot: write
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v4
@@ -21,7 +22,8 @@ jobs:
       - name: Run Dependabot
         run: scripts/run_dependabot.sh
         env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+          # PAT must include repo and security_events scopes
       - name: Load registry proxy config
         run: |
           cat <<'EOF' >> "$GITHUB_ENV"
@@ -32,7 +34,8 @@ jobs:
         uses: github/dependabot-action@8a8ecd4a2ccff00ad1680d32caef59634c31d3c0
         # v2.28.0
         env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+          # PAT must include repo and security_events scopes
           GITHUB_DEPENDABOT_JOB_TOKEN: >-
             ${{ secrets.GITHUB_DEPENDABOT_JOB_TOKEN }}
           GITHUB_DEPENDABOT_CRED_TOKEN: >-


### PR DESCRIPTION
## Summary
- добавить `dependabot: write`
- использовать PAT c правами `repo` и `security_events`

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml` *(fails: Failed: DID NOT RAISE <class 'RuntimeError'>)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c86bd100832da94142ef32531b2d