### PR TITLE
Add Content-Type header to Dependabot script

### DIFF
--- a/scripts/run_dependabot.sh
+++ b/scripts/run_dependabot.sh
@@ -8,6 +8,7 @@ for ecosystem in pip github-actions; do
   if ! curl -f -S -s -X POST \
     -H "Authorization: Bearer ${token}" \
     -H "Accept: application/vnd.github+json" \
+    -H "Content-Type: application/json" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
     https://api.github.com/repos/${repo}/dependabot/updates \
     -d "{\"package-ecosystem\":\"${ecosystem}\",\"directory\":\"/\"}"; then


### PR DESCRIPTION
## Summary
- include Content-Type header in Dependabot curl request

## Testing
- `pre-commit run --files scripts/run_dependabot.sh` *(fails: tests/test_server_model_loading.py::test_load_model_async_raises_runtime_error)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c86b4208832da3a8b32800fb3796