### PR TITLE
fix: store pv loop file on root partition

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -48,7 +48,7 @@ jobs:
           temp-reserve-mb: 100
           swap-size-mb: 4096
           build-mount-path: /mnt
-          pv-loop-path: /mnt/pv.img
+          pv-loop-path: /root-pv.img
           tmp-pv-loop-path: /mnt/tmp-pv.img
       - name: Bandit Scan
         uses: shundor/python-bandit-scan@ab1d87dfccc5a0ffab88be3aaac6ffe35c10d6cd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           temp-reserve-mb: 100
           swap-size-mb: 4096
           build-mount-path: /mnt
-          pv-loop-path: /mnt/pv.img
+          pv-loop-path: /root-pv.img
           tmp-pv-loop-path: /mnt/tmp-pv.img
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
@@ -89,7 +89,7 @@ jobs:
           temp-reserve-mb: 100
           swap-size-mb: 4096
           build-mount-path: /mnt
-          pv-loop-path: /mnt/pv.img
+          pv-loop-path: /root-pv.img
           tmp-pv-loop-path: /mnt/tmp-pv.img
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -44,7 +44,7 @@ jobs:
           temp-reserve-mb: 100
           swap-size-mb: 4096
           build-mount-path: /mnt
-          pv-loop-path: /mnt/pv.img
+          pv-loop-path: /root-pv.img
           tmp-pv-loop-path: /mnt/tmp-pv.img
 
       - name: Log in to GitHub Container Registry

--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -36,7 +36,7 @@ jobs:
           temp-reserve-mb: 100
           swap-size-mb: 4096
           build-mount-path: /mnt
-          pv-loop-path: /mnt/pv.img
+          pv-loop-path: /root-pv.img
           tmp-pv-loop-path: /mnt/tmp-pv.img
       - name: Move Docker data-root to /mnt
         run: |

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -50,7 +50,7 @@ jobs:
           temp-reserve-mb: 100
           swap-size-mb: 4096
           build-mount-path: /mnt
-          pv-loop-path: /mnt/pv.img
+          pv-loop-path: /root-pv.img
           tmp-pv-loop-path: /mnt/tmp-pv.img
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:

--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -31,7 +31,7 @@ jobs:
           temp-reserve-mb: 100
           swap-size-mb: 4096
           build-mount-path: /mnt
-          pv-loop-path: /mnt/pv.img
+          pv-loop-path: /root-pv.img
           tmp-pv-loop-path: /mnt/tmp-pv.img
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -46,7 +46,7 @@ jobs:
           temp-reserve-mb: 100
           swap-size-mb: 4096
           build-mount-path: /mnt
-          pv-loop-path: /mnt/pv.img
+          pv-loop-path: /root-pv.img
           tmp-pv-loop-path: /mnt/tmp-pv.img
       - name: Build an image from Dockerfile.ci
         run: |


### PR DESCRIPTION
## Summary
- keep pv loop file on root filesystem for maximize-build-space action

## Testing
- `pre-commit run --files .github/workflows/bandit.yml .github/workflows/ci.yml .github/workflows/docker-publish.yml .github/workflows/gptoss_review.yml .github/workflows/semgrep.yml .github/workflows/submit-pypi.yml .github/workflows/trivy.yml` *(fails: tests/test_server_model_loading.py:23 Failed: DID NOT RAISE <class 'RuntimeError'>)*
- `act -j bandit -W .github/workflows/bandit.yml` *(fails: requires selecting a large base image requiring ~75GB)*
- `fallocate -l 1M /root-pv.img && ls -lh /root-pv.img`

------
https://chatgpt.com/codex/tasks/task_e_68a4c9e01338832d80162d386626d7e4