### PR TITLE
chore: drop vllm install from gptoss Dockerfile

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -10,9 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV PYTHONUNBUFFERED=1 HF_HOME=/workspace/hf-cache
 
 RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir openai==1.99.1 \
-    && pip install --no-cache-dir vllm==0.10.0 \
-        --extra-index-url https://download.pytorch.org/whl/cpu
+    && pip install --no-cache-dir openai==1.99.1
 
 FROM python:3.12-slim
 
@@ -22,7 +20,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONUNBUFFERED=1 HF_HOME=/workspace/hf-cache
-ENV PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu
 
 COPY --from=builder /usr/local /usr/local
 


### PR DESCRIPTION
## Summary
- remove vllm installation from gptoss Dockerfile
- drop unused PIP_EXTRA_INDEX_URL var

## Testing
- `pre-commit run --files Dockerfile.gptoss` *(fails: tests/test_server_model_loading.py::test_load_model_async_raises_runtime_error)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c9d686dc832dbce9e7d6180295df