### PR TITLE
chore: drop dependabot workflow permission

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -13,7 +13,6 @@ jobs:
       contents: write
       pull-requests: write
       security-events: write
-      dependabot: write
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v4


### PR DESCRIPTION
## Summary
- remove unused dependabot permission from Dependabot workflow

## Testing
- `yamllint .github/workflows/dependabot.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a4d4c4b5ec832dac3c78b5d0c82acd