### PR TITLE
chore: clean trivy cache before scan

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -57,6 +57,9 @@ jobs:
         with:
           version: v0.65.0
 
+      - name: Clean Trivy cache
+        run: rm -rf /tmp/trivy-cache || true
+
       - name: Run Trivy vulnerability scanner
         env:
           TRIVY_CACHE_DIR: /tmp/trivy-cache


### PR DESCRIPTION
## Summary
- clean Trivy cache before running Trivy scanner
- ensure Trivy cache directory uses /tmp

## Testing
- `SKIP=pytest pre-commit run --files .github/workflows/trivy.yml`

------
https://chatgpt.com/codex/tasks/task_e_68a564a9d700832da25a627cc88c284b