### PR TITLE
Install torch, vLLM, and openai in Dockerfile.gptoss

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -10,6 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV PYTHONUNBUFFERED=1 HF_HOME=/workspace/hf-cache
 
 RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch==2.3.1 \
+    && pip install --no-cache-dir vllm==0.6.2.post1 \
     && pip install --no-cache-dir openai==1.99.1
 
 FROM python:3.12-slim


### PR DESCRIPTION
## Summary
- Install torch 2.3.1 from PyTorch CPU index
- Install vLLM 0.6.2.post1
- Install openai 1.99.1

## Testing
- `pre-commit run --files Dockerfile.gptoss`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a565eff9e8832d9c5bb212d27fad7e