### PR TITLE
chore: add explicit tags for docker publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -74,7 +74,9 @@ jobs:
           file: ${{ matrix.file }}
           push: true
           load: true
-          tags: ${{ matrix.tag }}
+          tags: |
+            ghcr.io/<org>/myapp:latest
+            ghcr.io/<org>/myapp:${{ github.sha }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 


### PR DESCRIPTION
## Summary
- set fixed `ghcr.io/<org>/myapp` tags for docker publish

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a565f34be4832d929a2be01b0f3729