### PR TITLE
refactor: parameterize docker image tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,10 +17,10 @@ jobs:
       matrix:
         include:
           - file: Dockerfile.cpu
-            tag: ghcr.io/averinaleks/myapp:latest
+            image: ghcr.io/averinaleks/myapp
             artifact: trivy-report-cpu
           - file: Dockerfile.ci
-            tag: ghcr.io/averinaleks/myapp-ci:latest
+            image: ghcr.io/averinaleks/myapp-ci
             artifact: trivy-report-ci
 
     steps:
@@ -75,14 +75,14 @@ jobs:
           push: true
           load: true
           tags: |
-            ghcr.io/<org>/myapp:latest
-            ghcr.io/<org>/myapp:${{ github.sha }}
+            ${{ matrix.image }}:latest
+            ${{ matrix.image }}:${{ github.sha }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 
       - name: Apply security upgrades in built image
         run: |
-          docker run --rm ${{ matrix.tag }} bash -lc "apt-get update && apt-get upgrade -y && apt-get clean && rm -rf /var/lib/apt/lists/*"
+          docker run --rm ${{ matrix.image }}:latest bash -lc "apt-get update && apt-get upgrade -y && apt-get clean && rm -rf /var/lib/apt/lists/*"
 
       - name: Move Docker layer cache
         run: |
@@ -98,7 +98,7 @@ jobs:
         uses: aquasecurity/trivy-action@0.32.0
         with:
           version: v0.65.0
-          image-ref: ${{ matrix.tag }}
+          image-ref: ${{ matrix.image }}:latest
           format: table
           output: ${{ matrix.artifact }}.txt
 


### PR DESCRIPTION
## Summary
- replace `tag` with `image` in docker publish matrix
- use `matrix.image` for build, security upgrade, and scanning steps

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml`

------
https://chatgpt.com/codex/tasks/task_e_68a5aa5a2628832d89c9a92fffcb8005