### PR TITLE
Check for GITHUB_TOKEN before running Dependabot

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Run Dependabot
         run: scripts/run_dependabot.sh
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT }}
-          # PAT must include repo and security_events scopes
+          GITHUB_TOKEN: ${{ github.token }}
+          # GITHUB_TOKEN must have repo and security_events scopes
       - name: Load registry proxy config
         run: |
           cat <<'EOF' >> "$GITHUB_ENV"

--- a/scripts/run_dependabot.sh
+++ b/scripts/run_dependabot.sh
@@ -2,6 +2,11 @@
 set -euo pipefail
 
 repo="${GITHUB_REPOSITORY}"
+
+if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+    echo "GITHUB_TOKEN is not set; cannot trigger Dependabot" >&2
+    exit 1
+fi
 token="${GITHUB_TOKEN}"
 
 for ecosystem in pip github-actions; do


### PR DESCRIPTION
## Summary
- validate that `GITHUB_TOKEN` is defined before triggering Dependabot
- use `${{ github.token }}` for Dependabot workflow run step

## Testing
- `SKIP=pytest pre-commit run --files scripts/run_dependabot.sh .github/workflows/dependabot.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5aa87c638832d8598a40c15868ac3