### PR TITLE
Ensure Dependabot token fallback and validation

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Run Dependabot
         run: scripts/run_dependabot.sh
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT }}
+          GITHUB_TOKEN: ${{ secrets.PAT || github.token }}
           # PAT must include repo and security_events scopes
       - name: Load registry proxy config
         run: |
@@ -33,7 +33,7 @@ jobs:
         uses: github/dependabot-action@8a8ecd4a2ccff00ad1680d32caef59634c31d3c0
         # v2.28.0
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT }}
+          GITHUB_TOKEN: ${{ secrets.PAT || github.token }}
           # PAT must include repo and security_events scopes
           GITHUB_DEPENDABOT_JOB_TOKEN: >-
             ${{ secrets.GITHUB_DEPENDABOT_JOB_TOKEN }}

--- a/scripts/run_dependabot.sh
+++ b/scripts/run_dependabot.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 repo="${GITHUB_REPOSITORY}"
 token="${GITHUB_TOKEN}"
 
+if [[ -z "${token}" ]]; then
+  echo "GITHUB_TOKEN is required" >&2
+  exit 1
+fi
+
 for ecosystem in pip github-actions; do
   if ! curl -f -S -s -X POST \
     -H "Authorization: Bearer ${token}" \


### PR DESCRIPTION
## Summary
- fallback to `github.token` when `secrets.PAT` is absent in Dependabot workflow
- validate `GITHUB_TOKEN` before invoking Dependabot API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5aae0ed24832d9f345d0da07ffe60