### PR TITLE
chore: unify gptoss image matrix

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,7 +23,7 @@ jobs:
             image: myapp-ci
             artifact: trivy-report-ci
           - file: Dockerfile.gptoss
-            tag: ghcr.io/averinaleks/myapp:latest
+            image: myapp
             artifact: trivy-report-gptoss
 
     steps:
@@ -77,7 +77,7 @@ jobs:
           file: ${{ matrix.file }}
           push: true
           load: true
-          tags: |
+          tags: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 


### PR DESCRIPTION
## Summary
- replace `tag` with `image` for GPT-OSS build configuration
- ensure docker build tags use `matrix.image`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a60916a740832dac1a8507ff7849f9