### PR TITLE
Сокращение очистки диска в Trivy workflow

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -33,11 +33,7 @@ jobs:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@main
         with:
-          tool-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
+          docker-images: true
           swap-storage: true
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10


### PR DESCRIPTION
## Summary
- уменьшена очистка диска в триви-воркфлоу, оставлены только docker-images и swap-storage

## Testing
- `pre-commit run --files .github/workflows/trivy.yml`
- `python -m flake8`
- `pytest`
- ⚠️ `act -n` (недоступно: не установлен Docker)


------
https://chatgpt.com/codex/tasks/task_e_68a6086d1f14832da00bb3e5f2bf8ae1