### PR TITLE
ci: clean caches before tests and redirect pyc to /mnt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
   push:
   pull_request:
 
+env:
+  PYTHONPYCACHEPREFIX: /mnt/pycache
+
 jobs:
   unit:
     name: Unit tests
@@ -41,6 +44,8 @@ jobs:
           build-mount-path: /mnt
           pv-loop-path: /root-pv.img
           tmp-pv-loop-path: /mnt/tmp-pv.img
+      - name: Prepare pycache directory
+        run: mkdir -p /mnt/pycache
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
@@ -58,6 +63,11 @@ jobs:
           ./scripts/install-test-deps.sh
       - name: Run flake8
         run: flake8 .
+      - name: Remove test caches
+        run: |
+          rm -rf .pytest_cache .cache
+          find . -type d -name '__pycache__' -exec rm -rf {} +
+          find . -name '*.pyc' -delete
       - name: Run unit tests
         run: pytest -m "not integration"
 
@@ -91,6 +101,8 @@ jobs:
           build-mount-path: /mnt
           pv-loop-path: /root-pv.img
           tmp-pv-loop-path: /mnt/tmp-pv.img
+      - name: Prepare pycache directory
+        run: mkdir -p /mnt/pycache
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
@@ -106,5 +118,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           ./scripts/install-test-deps.sh
+      - name: Remove test caches
+        run: |
+          rm -rf .pytest_cache .cache
+          find . -type d -name '__pycache__' -exec rm -rf {} +
+          find . -name '*.pyc' -delete
       - name: Run integration tests
         run: pytest -m integration


### PR DESCRIPTION
## Summary
- clean test caches before running pytest
- set PYTHONPYCACHEPREFIX to /mnt/pycache and prepare directory in CI

## Testing
- `python -m flake8 .`
- `PYTHONPYCACHEPREFIX=/mnt/pycache pytest -m "not integration"`


------
https://chatgpt.com/codex/tasks/task_e_68a60991173c832d9c00e0770c3c1d7e