### PR TITLE
chore: add pip cache dirs to submit-pypi workflow

### DIFF
--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -36,13 +36,23 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      - name: Prepare pip dirs
+        run: |
+          rm -rf /mnt/pip-cache /mnt/pip-tmp
+          mkdir -p /mnt/pip-cache /mnt/pip-tmp
       - name: Install dependencies
+        env:
+          PIP_CACHE_DIR: /mnt/pip-cache
+          TMPDIR: /mnt/pip-tmp
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-ci.txt --no-deps
       - name: Install pip-tools
         run: pip install pip-tools
       - name: Check dependencies
+        env:
+          PIP_CACHE_DIR: /mnt/pip-cache
+          TMPDIR: /mnt/pip-tmp
         run: |
           set +e
           pip-compile --dry-run -o requirements.out requirements.txt


### PR DESCRIPTION
## Summary
- prepare dedicated pip cache and tmp directories in submit-pypi workflow
- reuse pip cache for dependency installation and checks

## Testing
- `pre-commit run --files .github/workflows/submit-pypi.yml`

------
https://chatgpt.com/codex/tasks/task_e_68a60b07fe18832d8fe6b9fa29d6d5ae