### PR TITLE
ci: pin free-disk-space action to commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,9 @@ jobs:
         run: >
           git submodule foreach --recursive sh -c "git config --quiet --local gc.auto 0 || :" || :
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        timeout-minutes: 5
+        continue-on-error: true
         with:
           tool-cache: true
           android: true
@@ -74,7 +76,9 @@ jobs:
         run: >
           git submodule foreach --recursive sh -c "git config --quiet --local gc.auto 0 || :" || :
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        timeout-minutes: 5
+        continue-on-error: true
         with:
           tool-cache: true
           android: true


### PR DESCRIPTION
## Summary
- pin jlumbroso/free-disk-space to commit 54081f138730dfa15788a46383842cd2f914a1be
- set timeout-minutes and continue-on-error on free-disk-space step

## Testing
- `pre-commit run --files .github/workflows/ci.yml --hook-stage commit`


------
https://chatgpt.com/codex/tasks/task_e_68a608d64920832d92eea28fb82f71b8