### PR TITLE
Handle Dependabot 404 without failing

### DIFF
--- a/scripts/run_dependabot.sh
+++ b/scripts/run_dependabot.sh
@@ -10,13 +10,18 @@ fi
 token="${GITHUB_TOKEN}"
 
 for ecosystem in pip github-actions; do
-  if ! curl -f -S -s -X POST \
+  if ! curl --fail-with-body -S -s -X POST \
     -H "Authorization: Bearer ${token}" \
     -H "Accept: application/vnd.github+json" \
     -H "Content-Type: application/json" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
     https://api.github.com/repos/${repo}/dependabot/updates \
     -d "{\"package-ecosystem\":\"${ecosystem}\",\"directory\":\"/\"}"; then
+    code=${PIPESTATUS[0]}
+    if [[ $code -eq 22 ]]; then
+      echo "Dependabot endpoint returned 404 for ${ecosystem}; skipping" >&2
+      continue
+    fi
     echo "Failed to trigger Dependabot for ${ecosystem}" >&2
     exit 1
   fi


### PR DESCRIPTION
## Summary
- show API response body on Dependabot trigger failures
- skip Dependabot triggers that return HTTP 404

## Testing
- `GITHUB_TOKEN=bogus GITHUB_REPOSITORY=foo/bar bash scripts/run_dependabot.sh`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a60af5c364832d9605155cb37c63c6