### PR TITLE
ci: add build tools install step in submit-pypi workflow

### DIFF
--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -36,6 +36,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      - name: Upgrade pip and install build tools
         run: |
           python -m pip install --upgrade pip
           pip install build twine


### PR DESCRIPTION
## Summary
- add explicit step to upgrade pip and install build tools in submit-pypi workflow

## Testing
- `pre-commit run --files .github/workflows/submit-pypi.yml`
- `pytest`
- `act -W .github/workflows/submit-pypi.yml` *(fail: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a610fa66e0832dbb84dc76defeb378