### PR TITLE
Add Docker Hub push test and TOKEN-based Dependabot auth

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Run Dependabot
         run: scripts/run_dependabot.sh
         env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
-          # GITHUB_TOKEN must have repo and security_events scopes
+          TOKEN: ${{ secrets.TOKEN }}
+          # TOKEN must have repo and security_events scopes
       - name: Load registry proxy config
         run: |
           cat <<'EOF' >> "$GITHUB_ENV"

--- a/scripts/run_dependabot.sh
+++ b/scripts/run_dependabot.sh
@@ -3,11 +3,11 @@ set -euo pipefail
 
 repo="${GITHUB_REPOSITORY}"
 
-if [[ -z "${GITHUB_TOKEN:-}" ]]; then
-    echo "GITHUB_TOKEN is not set; cannot trigger Dependabot" >&2
+if [[ -z "${TOKEN:-}" ]]; then
+    echo "TOKEN is not set; cannot trigger Dependabot" >&2
     exit 1
 fi
-token="${GITHUB_TOKEN}"
+token="${TOKEN}"
 
 for ecosystem in pip github-actions; do
   if ! curl --fail-with-body -S -s -X POST \

--- a/tests/test_dockerhub_push.py
+++ b/tests/test_dockerhub_push.py
@@ -1,0 +1,21 @@
+import os
+import shutil
+import subprocess
+
+import pytest
+
+
+@pytest.mark.skipif(shutil.which("docker") is None, reason="Docker is not installed")
+@pytest.mark.skipif(not os.getenv("AVERINALEKS") or not os.getenv("BOT"), reason="Docker Hub credentials are not configured")
+def test_build_and_push(tmp_path):
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text("FROM alpine:3.18\nRUN echo test > /test.txt\n")
+    image = f"{os.environ['AVERINALEKS']}/bot-test-image:latest"
+
+    subprocess.run(["docker", "build", "-t", image, str(tmp_path)], check=True)
+    subprocess.run(
+        ["docker", "login", "-u", os.environ["AVERINALEKS"], "--password-stdin"],
+        input=os.environ["BOT"].encode(),
+        check=True,
+    )
+    subprocess.run(["docker", "push", image], check=True)


### PR DESCRIPTION
## Summary
- adjust Dependabot workflow and script to use TOKEN env variable
- add test that builds and pushes Docker image to Docker Hub

## Testing
- `pytest tests/test_dockerhub_push.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a6138b2cc4832da9c7e5d10834abef