### PR TITLE
ci: add pip cache key to workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Cache pip
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
         with:
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements-ci.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-${{ hashFiles('requirements-ci.txt') }}-
             ${{ runner.os }}-pip-
@@ -107,6 +108,7 @@ jobs:
       - name: Cache pip
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
         with:
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements-ci.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-${{ hashFiles('requirements-ci.txt') }}-
             ${{ runner.os }}-pip-


### PR DESCRIPTION
## Summary
- cache pip dependencies using a stable key in CI workflow

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a612414004832d8a36fd6d2bbc622d