### PR TITLE
Add disable_async_output_proc flag for gptoss CPU compose

### DIFF
--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -5,7 +5,7 @@ services:
     volumes:
       - gptoss_workspace:/workspace
     command: >
-      python -m vllm.entrypoints.openai.api_server --host 0.0.0.0 --port 8000 --model ${MODEL_ID:-TinyLlama/TinyLlama-1.1B-Chat-v1.0} --device cpu --dtype float32
+      python -m vllm.entrypoints.openai.api_server --host 0.0.0.0 --port 8000 --model ${MODEL_ID:-TinyLlama/TinyLlama-1.1B-Chat-v1.0} --device cpu --dtype float32 --disable_async_output_proc
     environment:
       - VLLM_DEVICE=cpu
       - VLLM_LOGGING_LEVEL=DEBUG


### PR DESCRIPTION
## Summary
- add `--disable_async_output_proc` to gptoss service command in docker-compose.cpu.yml

## Testing
- `docker compose build gptoss` *(fails: Cannot connect to the Docker daemon)*
- `docker compose up --exit-code-from gptoss_check gptoss gptoss_check` *(fails: cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68a613d148cc832d978ae5142b88a8bc