### PR TITLE
Skip complexity validation during password verification

### DIFF
--- a/password_utils.py
+++ b/password_utils.py
@@ -37,6 +37,5 @@ def verify_password(password: str, stored_hash: str) -> bool:
         raise ValueError("Password too short")
     if len(password) > MAX_PASSWORD_LENGTH:
         raise ValueError("Password exceeds maximum length")
-    validate_password_complexity(password)
     return bcrypt.checkpw(password.encode(), stored_hash.encode())
 

--- a/tests/test_password_utils.py
+++ b/tests/test_password_utils.py
@@ -1,4 +1,5 @@
 import pytest
+import bcrypt
 
 from password_utils import (
     BCRYPT_ROUNDS,
@@ -68,8 +69,7 @@ def test_hash_password_rejects_weak_passwords(weak_password):
 
 
 @pytest.mark.parametrize("weak_password", WEAK_PASSWORDS)
-def test_verify_password_rejects_weak_passwords(weak_password):
-    hashed = hash_password(VALID_PASSWORD)
-    with pytest.raises(ValueError):
-        verify_password(weak_password, hashed)
+def test_verify_password_accepts_existing_weak_hashes(weak_password):
+    stored_hash = bcrypt.hashpw(weak_password.encode(), bcrypt.gensalt()).decode()
+    assert verify_password(weak_password, stored_hash)
 


### PR DESCRIPTION
## Summary
- Remove password complexity validation during password verification
- Add tests ensuring weak previously hashed passwords still verify

## Testing
- `pytest tests/test_password_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a61432d090832da1a26224d8c69c76