### PR TITLE
fix: separate setup-python step in submit workflow

### DIFF
--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -33,10 +33,11 @@ jobs:
           build-mount-path: /mnt
           pv-loop-path: /root-pv.img
           tmp-pv-loop-path: /mnt/tmp-pv.img
-      - uses: actions/setup-python@v5
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - name: Upgrade pip and install build tools
+      - name: Install build tools
         run: |
           python -m pip install --upgrade pip
           pip install build twine


### PR DESCRIPTION
## Summary
- explicitly name Python setup step
- install build tools in a standalone step

## Testing
- `pre-commit run --files .github/workflows/submit-pypi.yml`

------
https://chatgpt.com/codex/tasks/task_e_68a619ca4150832d89fe9efca20af126