### PR TITLE
ci: run only on workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,7 @@ permissions:
 # include the correlation ID from the run's raw logs.
 
 on:
-  push:
-  pull_request:
+  workflow_dispatch:
 
 env:
   PYTHONPYCACHEPREFIX: /mnt/pycache


### PR DESCRIPTION
## Summary
- trigger CI only via workflow_dispatch

## Testing
- `pytest -m "not integration"`


------
https://chatgpt.com/codex/tasks/task_e_68a61d7dc8b0832dbf6809b56447cb73