### PR TITLE
Install CI dependencies in test deps script

### DIFF
--- a/scripts/install-test-deps.sh
+++ b/scripts/install-test-deps.sh
@@ -4,6 +4,8 @@ set -e
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 
+python -m pip install --no-cache-dir -r "$REPO_ROOT/requirements-ci.txt"
+
 # Install GPU requirements only when explicitly requested.
 if [ "${INSTALL_GPU_DEPS:-0}" -eq 1 ]; then
   python -m pip install --no-cache-dir -r "$REPO_ROOT/requirements-gpu.txt"


### PR DESCRIPTION
## Summary
- Ensure install-test-deps script installs CI requirements

## Testing
- `bash scripts/install-test-deps.sh`
- `pytest tests/test_password_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a62b3e289c832d8ac72f4b9537eaf1