### PR TITLE
fix semgrep path and version check

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -59,8 +59,12 @@ jobs:
         run: |
           export PIP_CACHE_DIR=/mnt/pip-cache
           pip install --no-cache-dir --target /mnt/pip semgrep
+          export PATH="/mnt/pip/bin:$PATH"
+          echo "/mnt/pip/bin" >> "$GITHUB_PATH"
       - name: Run Semgrep
-        run: semgrep --config=p/ci --sarif --output=semgrep.sarif
+        run: |
+          semgrep --version
+          semgrep --config=p/ci --sarif --output=semgrep.sarif
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@d6c5e1b140009be28958d3837ed3be3fb637d8c0 # v3
         with:


### PR DESCRIPTION
## Summary
- ensure semgrep install adds binary path to PATH and persists it
- verify semgrep version before running analysis

## Testing
- `pre-commit run --files .github/workflows/semgrep.yml`

------
https://chatgpt.com/codex/tasks/task_e_68a62bb2b5cc832dbb4098b9fe5def8c