### PR TITLE
Use array-form CMD for GPT-OSS image

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -14,12 +14,5 @@ RUN pip install --no-cache-dir --upgrade pip \
 
 EXPOSE 8000
 
-CMD python -m vllm.entrypoints.openai.api_server \
-    --host 0.0.0.0 \
-    --port 8000 \
-    --model ${MODEL:-openai/gpt-oss-20b} \
-    --device cpu \
-    --max-num-seqs 4 \
-    --enforce-eager \
-    --disable-async-output-proc
+CMD ["vllm", "serve", "openai/gpt-oss-20b", "--host", "0.0.0.0", "--port", "8000", "--device", "cpu", "--max-num-seqs", "4", "--enforce-eager", "--disable-async-output-proc"]
 

--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -4,8 +4,6 @@ services:
       - "8003:8000"
     volumes:
       - gptoss_workspace:/workspace
-    command: >
-      python -m vllm.entrypoints.openai.api_server --host 0.0.0.0 --port 8000 --model ${MODEL_ID:-TinyLlama/TinyLlama-1.1B-Chat-v1.0} --device cpu --dtype float32 --disable_async_output_proc
     environment:
       - VLLM_DEVICE=cpu
       - VLLM_LOGGING_LEVEL=DEBUG

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.gptoss
-    command:
-      - --model
-      - openai/gpt-oss-20b
-      - --host
-      - 0.0.0.0
-      - --port
-      - "8000"
     ports:
       - "8003:8000"
     environment:


### PR DESCRIPTION
## Summary
- switch GPT-OSS Dockerfile to exec-form CMD running `vllm serve`
- drop docker-compose overrides that passed command as strings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6c5f395ec832d89469416246de11a