### PR TITLE
ci: isolate pip-compile workspace

### DIFF
--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -46,8 +46,13 @@ jobs:
       - name: Copy project to /mnt
         run: rsync -a . /mnt/project
       - name: Check dependencies
+        working-directory: /mnt/project
+        env:
+          PIP_CACHE_DIR: /mnt/pip-cache
+          TMPDIR: /mnt/tmp
         run: |
           set +e
+          mkdir -p "$PIP_CACHE_DIR" "$TMPDIR"
           pip-compile --dry-run -o requirements.out requirements.txt
           status=$?
           if [ $status -eq 0 ]; then


### PR DESCRIPTION
## Summary
- ensure pip-compile runs in an isolated directory with cache and tmp paths

## Testing
- `pre-commit run --files .github/workflows/submit-pypi.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6ca2e3be0832da57774aa4b562f16