### PR TITLE
Mark integration service tests as integration

### DIFF
--- a/tests/test_integration_services.py
+++ b/tests/test_integration_services.py
@@ -10,6 +10,8 @@ import pytest
 
 from tests.helpers import get_free_port, service_process
 
+pytestmark = pytest.mark.integration
+
 if sys.platform == "win32":
     multiprocessing.set_start_method("spawn", force=True)
 ctx = multiprocessing.get_context("spawn")

--- a/tests/test_service_scripts.py
+++ b/tests/test_service_scripts.py
@@ -7,6 +7,8 @@ from unittest.mock import patch
 
 from tests.helpers import get_free_port, service_process
 
+pytestmark = pytest.mark.integration
+
 TOKEN_HEADERS = {"Authorization": "Bearer test-token"}
 
 ctx = multiprocessing.get_context("spawn")


### PR DESCRIPTION
## Summary
- mark tests/test_integration_services.py as integration
- mark tests/test_service_scripts.py as integration

## Testing
- `pytest -m "not integration"`
- `pytest -m "not integration" tests/test_integration_services.py tests/test_service_scripts.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6eb6c6e24832d830e741ce0bd5d13