### PR TITLE
chore: keep google-cloud-cli on runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,8 @@ jobs:
           android: true
           dotnet: true
           haskell: true
-          large-packages: true
+          # avoid removing large packages such as google-cloud-cli
+          large-packages: false
           swap-storage: true
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
@@ -89,7 +90,8 @@ jobs:
           android: true
           dotnet: true
           haskell: true
-          large-packages: true
+          # avoid removing large packages such as google-cloud-cli
+          large-packages: false
           swap-storage: true
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10


### PR DESCRIPTION
## Summary
- skip removal of large packages in free-disk-space steps
- keep cleanup step resilient with timeout and continue-on-error

## Testing
- `./bin/act workflow_dispatch -W .github/workflows/ci.yml -j unit -P ubuntu-24.04=ghcr.io/catthehacker/ubuntu:act-24.04` *(fails: Cannot connect to the Docker daemon)*


------
https://chatgpt.com/codex/tasks/task_e_68a6f52150e4832d976c5b5293141547