### PR TITLE
ci: adjust disk space step in docker workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,12 +33,14 @@ jobs:
           persist-credentials: false
       - name: Free disk space
         uses: jlumbroso/free-disk-space@main
+        timeout-minutes: 10
+        continue-on-error: true
         with:
           tool-cache: true
           android: true
           dotnet: true
           haskell: true
-          large-packages: true
+          large-packages: false
           swap-storage: true
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10


### PR DESCRIPTION
## Summary
- tune free disk space step to avoid large package removal and set timeout

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml`

------
https://chatgpt.com/codex/tasks/task_e_68a76176b004832d9d12aa158824885b