### PR TITLE
chore: handle disk space step errors in trivy

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -32,6 +32,7 @@ jobs:
           persist-credentials: false
       - name: Free disk space
         uses: jlumbroso/free-disk-space@main
+        continue-on-error: true
         with:
           docker-images: true
           swap-storage: true


### PR DESCRIPTION
## Summary
- allow Trivy workflow to continue even if the free-disk-space action fails

## Testing
- `pytest -q`
- `docker info` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68a7617d21a4832da9552af5d6a9fd1b