### PR TITLE
Add pyarrow to CI dependencies

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -4,6 +4,7 @@ bcrypt>=4.2.0
 flake8==7.3.0
 httpx>=0.27.0
 pandas>=2.0.0,<3.0.0
+pyarrow>=16.1.0
 pytest==8.4.1
 pytest-asyncio>=1.1
 tenacity>=8.5,<10


### PR DESCRIPTION
## Summary
- add pyarrow to CI requirements for DataFrame support

## Testing
- `pre-commit run --files requirements-ci.txt`
- `pytest tests/test_cache.py::test_save_and_load_roundtrip -q`


------
https://chatgpt.com/codex/tasks/task_e_68a761e5c810832db7817bfd449f48d7