### PR TITLE
Increase free disk space timeout in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           git submodule foreach --recursive sh -c "git config --quiet --local gc.auto 0 || :" || :
       - name: Free disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
-        timeout-minutes: 5
+        timeout-minutes: 10
         continue-on-error: true
         with:
           tool-cache: true
@@ -85,7 +85,7 @@ jobs:
           git submodule foreach --recursive sh -c "git config --quiet --local gc.auto 0 || :" || :
       - name: Free disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
-        timeout-minutes: 5
+        timeout-minutes: 10
         continue-on-error: true
         with:
           tool-cache: true


### PR DESCRIPTION
## Summary
- extend Free disk space step timeout to 10 minutes in unit and integration jobs

## Testing
- `pre-commit run flake8 --files .github/workflows/ci.yml`
- `pytest`
- `./bin/act -j unit` *(fails: Couldn't get a valid docker connection)*

------
https://chatgpt.com/codex/tasks/task_e_68a7679c9748832daa9d5a5cc87100ce