### PR TITLE
chore: adjust docker build space paths

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,17 +42,21 @@ jobs:
           haskell: true
           large-packages: false
           swap-storage: true
-      - name: Clean Docker dir
-        run: sudo rm -rf /var/lib/docker/*
+      - name: Prepare build mount dir
+        run: |
+          sudo mkdir -p /mnt
+          sudo rm -rf /mnt/*
+      - name: Install LVM
+        run: sudo apt-get update && sudo apt-get install -y lvm2
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:
           root-reserve-mb: 1024
           temp-reserve-mb: 100
           swap-size-mb: 4096
-          build-mount-path: /var/lib/docker
+          build-mount-path: /mnt
           pv-loop-path: /root-pv.img
-          tmp-pv-loop-path: /var/lib/docker/tmp-pv.img
+          tmp-pv-loop-path: /mnt/tmp-pv.img
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -74,10 +78,10 @@ jobs:
         with:
           driver: docker-container
 
-      - name: Verify /var/lib/docker mount
+      - name: Verify /mnt mount
         run: |
-          mount | grep '/var/lib/docker'
-          df -h /var/lib/docker
+          mount | grep '/mnt'
+          df -h /mnt
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6


### PR DESCRIPTION
## Summary
- install LVM in docker publish workflow
- switch build space to /mnt and update related paths

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7681d4930832dbc1a326fd09e6944