### PR TITLE
ci: allow free disk cleanup to continue on apt errors

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -22,12 +22,13 @@ jobs:
           persist-credentials: false
       - name: Освободить место на диске
         uses: jlumbroso/free-disk-space@main
+        continue-on-error: true
         with:
           tool-cache: true
           android: true
           dotnet: true
           haskell: true
-          large-packages: true
+          large-packages: false
           swap-storage: true
       - name: Clean Docker dir
         run: sudo rm -rf /var/lib/docker/*


### PR DESCRIPTION
## Summary
- avoid removing large packages during disk cleanup
- ignore apt-get remove failures in free disk space step

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a7684bd954832d9ec1b310ee29e9a4