### PR TITLE
Limit df output and archive review logs

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -55,9 +55,15 @@ jobs:
           password: ${{ secrets.BOT }}
       - name: Показать свободное место
         run: |
-          df -h
+          df -h /
           docker system df || true
       - name: Run gptoss review (CPU)
         run: |
-          docker compose -f docker-compose.yml -f docker-compose.cpu.yml up --exit-code-from gptoss_check gptoss gptoss_check
+          set -o pipefail
+          docker compose -f docker-compose.yml -f docker-compose.cpu.yml up --exit-code-from gptoss_check gptoss gptoss_check | tee gptoss_review.log
+      - name: Upload review logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: gptoss-review-log
+          path: gptoss_review.log
 


### PR DESCRIPTION
## Summary
- reduce disk usage report verbosity in GPT-OSS review workflow
- capture gptoss review logs and upload as artifact

## Testing
- `pre-commit run --files .github/workflows/gptoss_review.yml`

------
https://chatgpt.com/codex/tasks/task_e_68a7683d7d0c832dace287ad04d1df0f