### PR TITLE
chore: use Python 3.11 in submit workflow

### DIFF
--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.11'
       - name: Install build tools
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- use Python 3.11 in submit-pypi workflow

## Testing
- `pre-commit run --files .github/workflows/submit-pypi.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a769afbb38832db78798720af25b7b