### PR TITLE
refactor dependency check in submit workflow

### DIFF
--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -53,16 +53,9 @@ jobs:
           PIP_CACHE_DIR: /mnt/pip-cache
           TMPDIR: /mnt/tmp
         run: |
-          set +e
           mkdir -p "$PIP_CACHE_DIR" "$TMPDIR"
-          pip-compile --dry-run -o requirements.out requirements.txt
-          status=$?
-          if [ $status -eq 0 ]; then
-            echo "Dependency check passed."
-          else
-            echo "Dependency check failed."
-          fi
-          exit $status
+          pip install -r requirements.txt
+          pip check
       - name: Return generated files
         if: always()
         run: |


### PR DESCRIPTION
## Summary
- replace pip-compile dry run with pip install and pip check in submit workflow

## Testing
- `pre-commit run --files .github/workflows/submit-pypi.yml` *(fails: Interrupted (KeyboardInterrupt))*

------
https://chatgpt.com/codex/tasks/task_e_68a769afd81c832db3a699043ff2d200