### PR TITLE
fix: install semgrep before maximizing build space

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -45,6 +45,13 @@ jobs:
           swap-storage: true
       - name: Clean Docker dir
         run: sudo rm -rf /var/lib/docker/*
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version-file: .python-version
+      - name: Install Semgrep
+        run: |
+          export PIP_CACHE_DIR=/mnt/pip-cache
+          pip install --no-cache-dir semgrep
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:
@@ -54,13 +61,6 @@ jobs:
           build-mount-path: /mnt
           pv-loop-path: /root-pv.img
           tmp-pv-loop-path: /mnt/tmp-pv.img
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version-file: .python-version
-      - name: Install Semgrep
-        run: |
-          export PIP_CACHE_DIR=/mnt/pip-cache
-          pip install --no-cache-dir semgrep
       - name: Run Semgrep
         run: |
           semgrep --version


### PR DESCRIPTION
## Summary
- install Semgrep before running maximize-build-space to prevent disk exhaustion

## Testing
- `pre-commit run --files .github/workflows/semgrep.yml`

------
https://chatgpt.com/codex/tasks/task_e_68a76dfba49c832d96fe4755d4e50618