### PR TITLE
chore: configure Trivy cache directory

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -108,8 +108,11 @@ jobs:
         with:
           version: v0.65.0
 
+      - run: rm -rf /mnt/trivy-cache || true
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.32.0
+        env:
+          TRIVY_CACHE_DIR: /mnt/trivy-cache
         with:
           version: v0.65.0
           image-ref: ${{ secrets.AVERINALEKS }}/${{ matrix.image }}:latest


### PR DESCRIPTION
## Summary
- clean Trivy cache before scan
- use /mnt for Trivy cache storage

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml` *(fails: tests/test_telegram_logger.py::test_worker_thread_stops_after_shutdown)*
- `pytest` *(fails: tests/test_telegram_logger.py::test_worker_thread_stops_after_shutdown)*
- `gh workflow run docker-publish.yml` *(fails: To get started with GitHub CLI, please run:  gh auth login)*

------
https://chatgpt.com/codex/tasks/task_e_68a76e056f04832db87425327b465624