### PR TITLE
Use external disk venv and trim heavy dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,16 +51,13 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
-      - name: Cache pip
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
-        with:
-          key: Linux-pip-${{ hashFiles('requirements.txt') }}
-          path: ~/.cache/pip
-          restore-keys: Linux-pip-
-      - name: Install dependencies
+      - name: Set up virtual environment
         run: |
-          python -m pip install --no-cache-dir --upgrade pip
-          ./scripts/install-test-deps.sh
+          python -m venv /mnt/venv
+          echo "/mnt/venv/bin" >> $GITHUB_PATH
+          source /mnt/venv/bin/activate
+          pip install --no-cache-dir -r requirements.txt
+          pip install --no-cache-dir -r requirements-ci.txt
       - name: Run flake8
         run: flake8 .
       - name: Remove test caches
@@ -109,16 +106,13 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
-      - name: Cache pip
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
-        with:
-          key: Linux-pip-${{ hashFiles('requirements.txt') }}
-          path: ~/.cache/pip
-          restore-keys: Linux-pip-
-      - name: Install dependencies
+      - name: Set up virtual environment
         run: |
-          python -m pip install --no-cache-dir --upgrade pip
-          ./scripts/install-test-deps.sh
+          python -m venv /mnt/venv
+          echo "/mnt/venv/bin" >> $GITHUB_PATH
+          source /mnt/venv/bin/activate
+          pip install --no-cache-dir -r requirements.txt
+          pip install --no-cache-dir -r requirements-ci.txt
       - name: Remove test caches
         run: |
           rm -rf .pytest_cache .cache

--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -1,0 +1,2 @@
+# Optional heavy dependencies
+opencv-python-headless==4.12.0.88

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@
 #
 #    pip-compile --output-file=requirements.txt --strip-extras requirements-core.in
 #
+torch==2.8.0 --index-url https://download.pytorch.org/whl/cpu
 a2wsgi==1.10.10
     # via -r requirements-core.in
 absl-py==2.3.1
@@ -343,7 +344,6 @@ numpy==2.2.6
     #   ml-dtypes
     #   mlflow
     #   numba
-    #   opencv-python-headless
     #   optuna
     #   pandas
     #   patsy
@@ -367,9 +367,6 @@ openai==1.90.0
     # via
     #   -r requirements-core.in
     #   vllm
-opencv-python-headless==4.12.0.88
-    # via
-    #   mistral-common
     #   vllm
 opentelemetry-api==1.36.0
     # via


### PR DESCRIPTION
## Summary
- create virtualenv on `/mnt/venv` in CI and install dependencies without cache
- swap GPU Torch for CPU wheel and move opencv to optional extras

## Testing
- `SKIP=pytest pre-commit run --files .github/workflows/ci.yml requirements.txt requirements-extras.txt`
- `pytest -m "not integration"`


------
https://chatgpt.com/codex/tasks/task_e_68a77452f46c832d8b262c8b367b5225