### PR TITLE
Conditionally download Trivy report artifact

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -132,6 +132,7 @@ jobs:
           path: ${{ matrix.artifact }}.txt
 
       - uses: actions/download-artifact@v5
+        if: matrix.artifact == 'trivy-report-ci'
         with:
           name: trivy-report-ci
           path: .


### PR DESCRIPTION
## Summary
- download trivy-report-ci artifact only when building that matrix entry

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml`

------
https://chatgpt.com/codex/tasks/task_e_68a77503b370832db889b7f913034b96