### PR TITLE
Adjust docker workflow env placement

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,9 +13,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-24.04
-    env:
-      DOCKERHUB_USERNAME: ${{ secrets.AVERINALEKS }}
-      DOCKERHUB_TOKEN: ${{ secrets.BOT }}
     strategy:
       matrix:
         include:
@@ -28,6 +25,9 @@ jobs:
           - file: Dockerfile.gptoss
             image: myapp
             artifact: trivy-report-gptoss
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.AVERINALEKS }}
+      DOCKERHUB_TOKEN: ${{ secrets.BOT }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- move strategy before env in docker publish workflow
- ensure Docker Hub credentials come from secrets

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml` (fails: Interrupted by KeyboardInterrupt)`

------
https://chatgpt.com/codex/tasks/task_e_68a776c60548832d84b875bdfc9210dd