### PR TITLE
ci: install only minimal dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,6 @@ jobs:
           python -m venv /mnt/venv
           echo "/mnt/venv/bin" >> $GITHUB_PATH
           source /mnt/venv/bin/activate
-          pip install --no-cache-dir -r requirements.txt
           pip install --no-cache-dir -r requirements-ci.txt
       - name: Run flake8
         run: flake8 .
@@ -111,7 +110,6 @@ jobs:
           python -m venv /mnt/venv
           echo "/mnt/venv/bin" >> $GITHUB_PATH
           source /mnt/venv/bin/activate
-          pip install --no-cache-dir -r requirements.txt
           pip install --no-cache-dir -r requirements-ci.txt
       - name: Remove test caches
         run: |


### PR DESCRIPTION
## Summary
- install only requirements-ci.txt in CI to reduce disk usage

## Testing
- `pytest -m "not integration"` *(fails: AssertionError: shap cache file not created)*

------
https://chatgpt.com/codex/tasks/task_e_68a7790bc658832db92436ba225bcc76