### PR TITLE
Use minimal deps in PyPI workflow

### DIFF
--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -54,7 +54,9 @@ jobs:
           TMPDIR: /mnt/tmp
         run: |
           mkdir -p "$PIP_CACHE_DIR" "$TMPDIR"
-          pip install -r requirements.txt
+          # Install only the minimal set of dependencies required for
+          # building and verifying the package to keep the workflow light.
+          pip install --no-cache-dir -r requirements-ci.txt
           pip check
       - name: Return generated files
         if: always()


### PR DESCRIPTION
## Summary
- use requirements-ci.txt with no pip cache in PyPI workflow

## Testing
- `pre-commit run --files .github/workflows/submit-pypi.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a77e8ad28c832da2b4b0a8d38babaf