### PR TITLE
Validate SHAP cache save and move to subdirectory

### DIFF
--- a/tests/test_shap_cache.py
+++ b/tests/test_shap_cache.py
@@ -89,4 +89,4 @@ async def test_shap_cache_file_safe_symbol(tmp_path, monkeypatch):
     shap_stub = types.SimpleNamespace(GradientExplainer=DummyExplainer)
     monkeypatch.setattr(model_builder, "shap", shap_stub)
     await mb.compute_shap_values("BTC/USDT:PERP", model, X)
-    assert (tmp_path / "shap_BTC_USDT_PERP.pkl").exists()
+    assert (tmp_path / "shap" / "shap_BTC_USDT_PERP.pkl").exists()


### PR DESCRIPTION
## Summary
- Save SHAP caches under a dedicated `shap/` subdirectory
- Verify SHAP cache file creation and log successful writes
- Update SHAP cache tests for new path

## Testing
- `pytest tests/test_shap_cache.py tests/test_model_builder_cache.py`

------
https://chatgpt.com/codex/tasks/task_e_68a77e978f78832da037680476c507c0