### PR TITLE
feat: use /mnt space for docker build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -61,6 +61,9 @@ jobs:
           pv-loop-path: /root-pv.img
           tmp-pv-loop-path: /mnt/tmp-pv.img
 
+      - name: Copy repository to /mnt
+        run: sudo rsync -a $GITHUB_WORKSPACE /mnt/
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -85,11 +88,12 @@ jobs:
         run: |
           mount | grep '/mnt'
           df -h /mnt
+        working-directory: /mnt/bot
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
-          context: .
+          context: /mnt/bot
           file: ${{ matrix.file }}
           push: true
           load: true
@@ -100,11 +104,13 @@ jobs:
       - name: Apply security upgrades in built image
         run: |
           docker run --rm ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.image }}:latest bash -lc "apt-get update && apt-get upgrade -y && apt-get clean && rm -rf /var/lib/apt/lists/*"
+        working-directory: /mnt/bot
 
       - name: Move Docker layer cache
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+        working-directory: /mnt/bot
 
       - name: Set up Trivy
         uses: aquasecurity/setup-trivy@v0.2.3
@@ -112,6 +118,7 @@ jobs:
           version: v0.65.0
 
       - run: rm -rf /mnt/trivy-cache || true
+        working-directory: /mnt/bot
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.32.0
         env:
@@ -120,19 +127,20 @@ jobs:
           version: v0.65.0
           image-ref: ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.image }}:latest
           format: table
-          output: ${{ matrix.artifact }}.txt
+          output: /mnt/bot/${{ matrix.artifact }}.txt
 
       - name: Show Trivy scan results
         run: cat ${{ matrix.artifact }}.txt
+        working-directory: /mnt/bot
 
       - name: Upload Trivy report artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}
-          path: ${{ matrix.artifact }}.txt
+          path: /mnt/bot/${{ matrix.artifact }}.txt
 
       - uses: actions/download-artifact@v5
         if: matrix.artifact == 'trivy-report-ci'
         with:
           name: trivy-report-ci
-          path: .
+          path: /mnt/bot


### PR DESCRIPTION
## Summary
- copy repository to /mnt after maximizing build space
- build docker images from /mnt/bot and use that path for later steps

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml` *(fails: KeyboardInterrupt)*
- `pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a77eac2994832db9b383a961125593