### PR TITLE
Pin CPU vllm version for GPT OSS image

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -9,7 +9,7 @@ ENV VLLM_DEVICE=cpu VLLM_LOGGING_LEVEL=DEBUG
 
 RUN pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch==2.3.1 \
-    && pip install --no-cache-dir 'vllm>=0.10.0' \
+    && pip install --no-cache-dir vllm==0.6.3 \
     && pip install --no-cache-dir openai==1.99.1
 
 EXPOSE 8000


### PR DESCRIPTION
## Summary
- pin `vllm` to CPU-only 0.6.3 in `Dockerfile.gptoss` to avoid GPU dependencies

## Testing
- `pytest`
- :x: `docker build -f Dockerfile.gptoss -t gptoss-test .` *(daemon unavailable)*
- :x: `pip install --no-cache-dir vllm==0.6.3` *(Python 3.12 wheel missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a77ead3e70832db22a2e01a651fa9c