### PR TITLE
fix: expand docker build space

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -54,12 +54,19 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:
-          root-reserve-mb: 1024
+          root-reserve-mb: 4096
           temp-reserve-mb: 100
           swap-size-mb: 4096
           build-mount-path: /mnt
           pv-loop-path: /root-pv.img
           tmp-pv-loop-path: /mnt/tmp-pv.img
+
+      - name: Relocate Docker storage to /mnt
+        run: |
+          sudo systemctl stop docker
+          sudo mv /var/lib/docker /mnt/docker
+          sudo ln -s /mnt/docker /var/lib/docker
+          sudo systemctl start docker
 
       - name: Copy repository to /mnt
         run: sudo rsync -a $GITHUB_WORKSPACE /mnt/

--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -10,7 +10,8 @@ ENV VLLM_DEVICE=cpu VLLM_LOGGING_LEVEL=DEBUG
 RUN pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch==2.3.1 \
     && pip install --no-cache-dir vllm==0.6.3 \
-    && pip install --no-cache-dir openai==1.99.1
+    && pip install --no-cache-dir openai==1.99.1 \
+    && rm -rf /root/.cache/pip
 
 EXPOSE 8000
 


### PR DESCRIPTION
## Summary
- reserve 4GB on root and move docker storage to /mnt during workflow
- clean pip cache in gptoss image build

## Testing
- `pre-commit run --hook-stage manual --files .github/workflows/docker-publish.yml Dockerfile.gptoss`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a8570c07e0832dbece9b9bf3b23ef8