### PR TITLE
fix: install pyairports for vllm

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -9,6 +9,7 @@ ENV VLLM_DEVICE=cpu VLLM_LOGGING_LEVEL=DEBUG
 
 RUN pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch==2.3.1 \
+    && pip install --no-cache-dir git+https://github.com/NICTA/pyairports \
     && pip install --no-cache-dir vllm==0.6.3 \
     && pip install --no-cache-dir openai==1.99.1 \
     && rm -rf /root/.cache/pip


### PR DESCRIPTION
## Summary
- install pyairports from GitHub to satisfy vllm's outlines dependency

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a862aa1670832dbb9568694731cec5