### PR TITLE
Include git in GPT OSS Docker image

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -1,7 +1,7 @@
 FROM python:3.11-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libtbbmalloc2 libnuma1 curl \
+    libtbbmalloc2 libnuma1 curl git \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONUNBUFFERED=1 HF_HOME=/workspace/hf-cache


### PR DESCRIPTION
## Summary
- Add git to GPT OSS Docker image so that git-based `pip install` commands work.

## Testing
- `pytest`
- `pip install git+https://github.com/NICTA/pyairports`
- `docker build -f Dockerfile.gptoss -t test-gptoss .` *(fails: failed to start daemon: Error initializing network controller: operation not permitted)*

------
https://chatgpt.com/codex/tasks/task_e_68a86bce8fc0832d8270fa3a4772da41