### PR TITLE
Use real joblib module during tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,10 +188,13 @@ def _stub_modules():
     sys.modules.setdefault("tenacity", tenacity_mod)
 
 
-    joblib_mod = types.ModuleType("joblib")
-    joblib_mod.dump = lambda *a, **k: None
-    joblib_mod.load = lambda *a, **k: {}
-    sys.modules.setdefault("joblib", joblib_mod)
+    try:  # use real joblib when available
+        import joblib  # noqa: F401
+    except Exception:  # pragma: no cover - optional dependency
+        joblib_mod = types.ModuleType("joblib")
+        joblib_mod.dump = lambda *a, **k: None
+        joblib_mod.load = lambda *a, **k: {}
+        sys.modules.setdefault("joblib", joblib_mod)
 
     dotenv_mod = types.ModuleType("dotenv")
     dotenv_mod.load_dotenv = lambda *a, **k: None


### PR DESCRIPTION
## Summary
- use real `joblib` if available instead of stubbing it in test fixtures

## Testing
- `pre-commit run --files tests/conftest.py`
- `pytest tests/test_shap_cache.py`
- `pytest -m "not integration"`


------
https://chatgpt.com/codex/tasks/task_e_68a86dfb9240832d96c668923461b7fd