### PR TITLE
chore: disable attestations for PyPI publish

### DIFF
--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -71,3 +71,4 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
+          attestations: false


### PR DESCRIPTION
## Summary
- disable attestations in Publish to PyPI workflow

## Testing
- `scripts/install-test-deps.sh`
- `python -m flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a86e11f5f4832db6b03ea0062d09df