### PR TITLE
chore: skip PyPI publish when token missing

### DIFF
--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -67,8 +67,12 @@ jobs:
       - name: Build package
         run: python -m build
       - name: Publish to PyPI
+        if: secrets.PYPI_API_TOKEN != ''
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
           attestations: false
+      - name: Skip PyPI publish (missing token)
+        if: secrets.PYPI_API_TOKEN == ''
+        run: echo "PYPI_API_TOKEN not set; skipping publish."


### PR DESCRIPTION
## Summary
- skip PyPI publish job when PYPI_API_TOKEN secret is absent

## Testing
- `pre-commit run flake8 --files .github/workflows/submit-pypi.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a991a7855c832d81af96105239ee04