### PR TITLE
Ensure SHAP cache path handled as string

### DIFF
--- a/model_builder.py
+++ b/model_builder.py
@@ -1459,7 +1459,7 @@ class ModelBuilder:
             model.to(current_device)
             try:
                 cache_file.parent.mkdir(parents=True, exist_ok=True)
-                joblib.dump(values, cache_file)
+                joblib.dump(values, str(cache_file))
                 if not cache_file.exists():
                     raise RuntimeError(
                         f"Файл {cache_file} не создан после сохранения SHAP"


### PR DESCRIPTION
## Summary
- convert `cache_file` to str when dumping SHAP values
- ensure SHAP cache directory exists and file creation verified

## Testing
- `pytest tests/test_shap_cache.py::test_shap_cache_file_safe_symbol -q`


------
https://chatgpt.com/codex/tasks/task_e_68a99697bd24832d9ebb62d79fb8c61e