### PR TITLE
ci: cleanup before Trivy scan

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -124,7 +124,13 @@ jobs:
         with:
           version: v0.65.0
 
-      - run: rm -rf /mnt/trivy-cache || true
+      - name: Cleanup before Trivy scan
+        run: |
+          docker system prune -af || true
+          sudo rm -rf /tmp/* || true
+          sudo rm -rf /mnt/trivy-cache || true
+          rm -rf ~/.cache/trivy || true
+          mkdir -p /mnt/trivy-cache
         working-directory: /mnt/bot
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.32.0
@@ -135,6 +141,7 @@ jobs:
           image-ref: ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.image }}:latest
           format: table
           output: /mnt/bot/${{ matrix.artifact }}.txt
+          scanners: vuln
 
       - name: Show Trivy scan results
         run: cat ${{ matrix.artifact }}.txt

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -56,8 +56,12 @@ jobs:
         with:
           version: v0.65.0
 
-      - name: Clean Trivy cache
-        run: rm -rf /mnt/trivy-cache || true
+      - name: Cleanup before Trivy scan
+        run: |
+          docker system prune -af || true
+          sudo rm -rf /tmp/* || true
+          sudo rm -rf /mnt/trivy-cache /mnt/trivy-temp || true
+          rm -rf ~/.cache/trivy || true
 
       - name: Create Trivy directories
         run: |
@@ -79,6 +83,7 @@ jobs:
           ignore-unfixed: true
           # ignore-unlikely-affected: true  # enable once Trivy >= v0.66 is available
           limit-severities-for-sarif: CRITICAL
+          scanners: vuln
 
       - name: Show Trivy scan results
         run: cat trivy-results.sarif


### PR DESCRIPTION
## Summary
- clean disk and cache before Trivy scans
- run Trivy only for vulnerabilities

## Testing
- `pre-commit run --files .github/workflows/trivy.yml .github/workflows/docker-publish.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a996d70efc832d984cf8a89c1c54be