### PR TITLE
chore: prune buildx after workflows

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -71,4 +71,6 @@ jobs:
           # skips: # optional, default is DEFAULT
           # path to a .bandit file that supplies command line arguments
           ini_path: .bandit
+      - name: Cleanup buildx
+        run: docker buildx prune -af || true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
           find . -name '*.pyc' -delete
       - name: Run unit tests
         run: pytest -m "not integration"
+      - name: Cleanup buildx
+        run: docker buildx prune -af || true
 
   integration:
     name: Integration tests
@@ -118,3 +120,5 @@ jobs:
           find . -name '*.pyc' -delete
       - name: Run integration tests
         run: pytest -m integration
+      - name: Cleanup buildx
+        run: docker buildx prune -af || true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,3 +23,5 @@ jobs:
           build-mode: none
           config-file: .github/codeql.yml
       - uses: github/codeql-action/analyze@v3
+      - name: Cleanup buildx
+        run: docker buildx prune -af || true

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -35,3 +35,5 @@ jobs:
           GITHUB_DEPENDABOT_CRED_TOKEN: >-
             ${{ secrets.GITHUB_DEPENDABOT_CRED_TOKEN }}
           DEPENDABOT_ENABLE_CONNECTIVITY_CHECK: 1
+      - name: Cleanup buildx
+        run: docker buildx prune -af || true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -151,3 +151,5 @@ jobs:
         with:
           name: trivy-report-ci
           path: /mnt/bot
+      - name: Cleanup buildx
+        run: docker buildx prune -af || true

--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -66,3 +66,5 @@ jobs:
       - name: Run gptoss review (CPU)
         run: |
 
+      - name: Cleanup buildx
+        run: docker buildx prune -af || true

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -73,3 +73,5 @@ jobs:
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
         run: semgrep ci --config p/ci
+      - name: Cleanup buildx
+        run: docker buildx prune -af || true

--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -76,3 +76,5 @@ jobs:
       - name: Skip PyPI publish (missing token)
         if: secrets.PYPI_API_TOKEN == ''
         run: echo "PYPI_API_TOKEN not set; skipping publish."
+      - name: Cleanup buildx
+        run: docker buildx prune -af || true

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -99,3 +99,5 @@ jobs:
 
       - name: Free disk space
         run: docker system prune -af
+      - name: Cleanup buildx
+        run: docker buildx prune -af || true


### PR DESCRIPTION
## Summary
- prune buildx cache at the end of each workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a996d9a1c8832db64b583475b73bf9