### PR TITLE
refactor: use env token for PyPI submit

### DIFF
--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-24.04
+    env:
+      TOKENPYPI: ${{ secrets.TOKENPYPI }}
     # Explicit permissions for OIDC-based publishing
     permissions:
       id-token: write
@@ -67,14 +69,14 @@ jobs:
       - name: Build package
         run: python -m build
       - name: Publish to PyPI
-        if: secrets.TOKENPYPI != ''
+        if: env.TOKENPYPI != ''
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.TOKENPYPI }}
           attestations: false
       - name: Skip PyPI publish (missing token)
-        if: secrets.TOKENPYPI == ''
+        if: env.TOKENPYPI == ''
         run: echo "TOKENPYPI not set; skipping publish."
       - name: Cleanup buildx
         run: docker buildx prune -af || true


### PR DESCRIPTION
## Summary
- add job-level TOKENPYPI env for submit workflow
- check token via env conditions before publishing to PyPI

## Testing
- `pre-commit run --files .github/workflows/submit-pypi.yml`

------
https://chatgpt.com/codex/tasks/task_e_68a99bda2b20832d94c4a1f6ec01281f