### PR TITLE
chore: expand build space reserve

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -37,11 +37,11 @@ jobs:
         uses: easimon/maximize-build-space@v10
         timeout-minutes: 15
         with:
-          root-reserve-mb: 1024
+          root-reserve-mb: 8192
           temp-reserve-mb: 100
           swap-size-mb: 4096
           build-mount-path: /mnt
-          pv-loop-path: /root-pv.img
+          pv-loop-path: /mnt/root-pv.img
           tmp-pv-loop-path: /mnt/tmp-pv.img
       - name: Move Docker data-root to /mnt
         run: |


### PR DESCRIPTION
## Summary
- increase root partition reserve to 8192 MB
- store root-pv.img under /mnt

## Testing
- `pre-commit run --files .github/workflows/gptoss_review.yml` *(fails: pytest step hung and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a99cae8ed8832da7e52fae5326570f