### PR TITLE
Validate SafeHTMLParser max_feed_size

### DIFF
--- a/safe_html_parser.py
+++ b/safe_html_parser.py
@@ -21,8 +21,8 @@ class SafeHTMLParser(HTMLParser):
     ----------
     max_feed_size: int, optional
         Maximum total size in **bytes** of data that can be fed to the parser
-        before a :class:`ValueError` is raised. Defaults to
-        ``DEFAULT_MAX_FEED``.
+        before a :class:`ValueError` is raised. Must be a positive integer and
+        defaults to ``DEFAULT_MAX_FEED``.
 
     Notes
     -----
@@ -31,6 +31,8 @@ class SafeHTMLParser(HTMLParser):
     """
 
     def __init__(self, *args, max_feed_size: int = DEFAULT_MAX_FEED, **kwargs):
+        if max_feed_size <= 0:
+            raise ValueError("max_feed_size must be positive")
         super().__init__(*args, **kwargs)
         self._max_feed_size = max_feed_size
         self._fed = 0

--- a/tests/test_safe_html_parser.py
+++ b/tests/test_safe_html_parser.py
@@ -34,6 +34,12 @@ def test_massive_default_input_raises():
         parser.feed(massive)
 
 
+@pytest.mark.parametrize("invalid_size", [0, -1])
+def test_non_positive_max_feed_size_raises(invalid_size):
+    with pytest.raises(ValueError):
+        SafeHTMLParser(max_feed_size=invalid_size)
+
+
 def test_counts_bytes_not_chars():
     parser = SafeHTMLParser(max_feed_size=4)
     # emoji is four bytes in UTF-8


### PR DESCRIPTION
## Summary
- ensure `max_feed_size` is positive in SafeHTMLParser
- document requirement for positive limit
- test zero and negative `max_feed_size`

## Testing
- `pytest tests/test_safe_html_parser.py`


------
https://chatgpt.com/codex/tasks/task_e_68a99cfec5bc832d996bde9225774bd8