### PR TITLE
refactor: centralize TF log level config

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -2917,6 +2917,9 @@ def ping():
 
 
 if __name__ == "__main__":
+    from bot.utils import configure_logging
+
+    configure_logging()
     load_dotenv()
     port = int(os.environ.get("PORT", "8000"))
     # По умолчанию слушаем только локальный интерфейс.

--- a/model_builder.py
+++ b/model_builder.py
@@ -15,8 +15,6 @@ from pathlib import Path
 from bot.config import BotConfig
 from collections import deque
 
-os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "3")
-
 if os.getenv("TEST_MODE") == "1":
     import types
     import sys
@@ -1968,6 +1966,9 @@ def ping():
 
 
 if __name__ == "__main__":
+    from bot.utils import configure_logging
+
+    configure_logging()
     load_dotenv()
     _load_model()
     port = int(os.environ.get("PORT", "8001"))

--- a/scripts/measure_rate.py
+++ b/scripts/measure_rate.py
@@ -43,4 +43,7 @@ async def measure(n=1000, seconds=1.0):
         print('rate', rate)
 
 if __name__ == '__main__':
+    from bot.utils import configure_logging
+
+    configure_logging()
     asyncio.run(measure())

--- a/scripts/run_simulation.py
+++ b/scripts/run_simulation.py
@@ -43,4 +43,7 @@ async def main() -> None:
     await sim.run(start_ts, end_ts, args.speed)
 
 if __name__ == "__main__":
+    from bot.utils import configure_logging
+
+    configure_logging()
     asyncio.run(main())

--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -120,6 +120,9 @@ def too_large(_):
     return jsonify({'error': 'payload too large'}), 413
 
 if __name__ == '__main__':
+    from bot.utils import configure_logging
+
+    configure_logging()
     port = int(os.environ.get('PORT', '8001'))
     # По умолчанию слушаем только локальный интерфейс.
     host = os.environ.get('HOST', '127.0.0.1')

--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -290,6 +290,9 @@ def handle_unexpected_error(exc: Exception) -> tuple:
 
 
 if __name__ == '__main__':
+    from bot.utils import configure_logging
+
+    configure_logging()
     port = int(os.environ.get('PORT', '8002'))
     # По умолчанию слушаем только локальный интерфейс.
     host = os.environ.get('HOST', '127.0.0.1')

--- a/tests/test_tf_logging.py
+++ b/tests/test_tf_logging.py
@@ -1,0 +1,10 @@
+import importlib
+import os
+import sys
+
+
+def test_import_does_not_set_tf_log_level(monkeypatch):
+    monkeypatch.delenv("TF_CPP_MIN_LOG_LEVEL", raising=False)
+    monkeypatch.delitem(sys.modules, "bot.utils", raising=False)
+    importlib.import_module("bot.utils")
+    assert "TF_CPP_MIN_LOG_LEVEL" not in os.environ

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -1995,6 +1995,9 @@ def ready() -> tuple:
 
 
 if __name__ == "__main__":
+    from bot.utils import configure_logging
+
+    configure_logging()
     setup_multiprocessing()
     load_dotenv()
     port = int(os.environ.get("PORT", "8002"))

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -819,4 +819,7 @@ def main() -> None:
 
 
 if __name__ == '__main__':
+    from bot.utils import configure_logging
+
+    configure_logging()
     main()

--- a/utils.py
+++ b/utils.py
@@ -16,8 +16,13 @@ import gzip
 import shutil
 from io import StringIO, BytesIO
 
-# Hide verbose TensorFlow logs and Numba performance warnings
-os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "3")
+
+def configure_logging() -> None:
+    """Настроить переменные окружения, связанные с логированием."""
+    os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "3")
+
+
+# Hide Numba performance warnings
 try:
     from numba import jit, prange, NumbaPerformanceWarning  # type: ignore
 


### PR DESCRIPTION
## Summary
- encapsulate TF_CPP_MIN_LOG_LEVEL setup in new `configure_logging`
- call `configure_logging()` from application entry points
- test that importing modules doesn't mutate `TF_CPP_MIN_LOG_LEVEL`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a99cffaae4832da489079670822673