### PR TITLE
Align ws subscription batch default

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -24,7 +24,7 @@ to take‑profit and stop‑loss distances.
 | history_batch_size | 10 | Number of candles fetched per history request. |
 | max_symbols | 50 | Maximum symbols to track. |
 | max_subscriptions_per_connection | 15 | WebSocket subscriptions allowed per connection. |
-| ws_subscription_batch_size | 15 | Symbols subscribed per batch when connecting. |
+| ws_subscription_batch_size | – | Symbols subscribed per batch when connecting; defaults to `max_subscriptions_per_connection`. |
 | ws_rate_limit | 20 | WebSocket message rate limit. |
 | ws_reconnect_interval | 5 | Seconds to wait before reconnecting. |
 | max_reconnect_attempts | 10 | Maximum WebSocket reconnect attempts. |

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ GPU-зависимости вынесены в отдельный файл `requ
   - `use_strategy_optimizer` включает поиск общих параметров на уровне портфеля с помощью `StrategyOptimizer`.
   - `max_symbols` задаёт количество наиболее ликвидных торговых пар, которые бот выберет из доступных.
   - `secondary_timeframe` определяет дополнительный интервал (по умолчанию `2h`). Свечи этого таймфрейма бот запрашивает напрямую у биржи и не агрегирует из основного. См. `DataHandler.load_initial` и `_send_subscriptions`.
-  - `max_subscriptions_per_connection` (или `ws_subscription_batch_size`) определяет, сколько символов подписывается через одно WebSocket‑соединение. По умолчанию 15.
+  - `max_subscriptions_per_connection` (или `ws_subscription_batch_size`) определяет, сколько символов подписывается через одно WebSocket‑соединение. Если `ws_subscription_batch_size` не указан, он приравнивается к `max_subscriptions_per_connection` (по умолчанию 15).
   - `backup_ws_urls` задаёт список альтернативных WebSocket‑адресов. При переподключении `DataHandler` перебирает их по очереди, что позволяет использовать другие дата‑центры.
   - `ws_inactivity_timeout` определяет, сколько секунд ждать сообщений после отправки ping. Если данных нет дольше этого времени, соединение закрывается и открывается заново.
   - `history_batch_size` задаёт число одновременных запросов истории. При нехватке памяти значение автоматически снижается.
@@ -513,7 +513,7 @@ preventing duplicated updates.
 
 ## Лимиты WebSocket-подписок
 
-Количество подписок через одно соединение ограничивается параметром `max_subscriptions_per_connection` (он же `ws_subscription_batch_size`). Если список пар превышает это значение, бот откроет дополнительные WebSocket‑соединения.
+Количество подписок через одно соединение ограничивается параметром `max_subscriptions_per_connection` (он же `ws_subscription_batch_size`). Если `ws_subscription_batch_size` не указан, используется `max_subscriptions_per_connection`. Если список пар превышает это значение, бот откроет дополнительные WebSocket‑соединения.
 
 Подписки отправляются пакетами. Размер пакета определяется этим же параметром. При необходимости бот делает паузу между отправками, чтобы не превышать ограничения биржи на частоту запросов.
 
@@ -522,7 +522,6 @@ preventing duplicated updates.
 ```json
 {
     "max_subscriptions_per_connection": 15,
-    "ws_subscription_batch_size": 15,
     "history_batch_size": 10,
     "history_retention": 200
 }

--- a/tests/test_config_ws_subscription_batch_size.py
+++ b/tests/test_config_ws_subscription_batch_size.py
@@ -1,0 +1,12 @@
+from config import BotConfig
+
+
+def test_ws_batch_size_defaults_to_max_subscriptions():
+    cfg = BotConfig(max_subscriptions_per_connection=7, ws_subscription_batch_size=None)
+    assert cfg.ws_subscription_batch_size == 7
+
+
+def test_ws_batch_size_respects_explicit_value():
+    cfg = BotConfig(max_subscriptions_per_connection=7, ws_subscription_batch_size=3)
+    assert cfg.ws_subscription_batch_size == 3
+


### PR DESCRIPTION
## Summary
- default `ws_subscription_batch_size` to `max_subscriptions_per_connection`
- document the relationship between batch size and connection limit
- add tests covering the default calculation

## Testing
- `pre-commit run flake8 --files config.py CONFIG.md README.md tests/test_config_ws_subscription_batch_size.py`
- `pytest tests/test_config_ws_subscription_batch_size.py tests/test_config_list_parsing.py tests/test_config_logging.py tests/test_config_path_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_68a99d018e24832db218ffdb8ec5fac8