### PR TITLE
Use env token in PyPI workflow

### DIFF
--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -73,7 +73,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
-          password: ${{ secrets.TOKENPYPI }}
+          password: ${{ env.TOKENPYPI }}
           attestations: false
       - name: Skip PyPI publish (missing token)
         if: env.TOKENPYPI == ''


### PR DESCRIPTION
## Summary
- reference PyPI token from environment in publish workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a99d16e804832da35a5f0295549f83