### PR TITLE
chore: use relative bot path in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: ubuntu-24.04
     defaults:
       run:
-        working-directory: /mnt/bot
+        working-directory: bot
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
-          path: /mnt/bot
+          path: bot
           persist-credentials: false
           fetch-depth: 0
       - name: Cleanup git submodules
@@ -60,14 +60,14 @@ jobs:
           python -m venv /mnt/venv
           echo "/mnt/venv/bin" >> $GITHUB_PATH
           source /mnt/venv/bin/activate
-          pip install --no-cache-dir -r /mnt/bot/requirements-ci.txt
+          pip install --no-cache-dir -r requirements-ci.txt
       - name: Run flake8
-        run: flake8 /mnt/bot
+        run: flake8 .
       - name: Remove test caches
         run: |
-          rm -rf /mnt/bot/.pytest_cache /mnt/bot/.cache
-          find /mnt/bot -type d -name '__pycache__' -exec rm -rf {} +
-          find /mnt/bot -name '*.pyc' -delete
+          rm -rf .pytest_cache .cache
+          find . -type d -name '__pycache__' -exec rm -rf {} +
+          find . -name '*.pyc' -delete
       - name: Run unit tests
         run: pytest -m "not integration"
       - name: Cleanup buildx
@@ -79,11 +79,11 @@ jobs:
     needs: unit
     defaults:
       run:
-        working-directory: /mnt/bot
+        working-directory: bot
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
-          path: /mnt/bot
+          path: bot
           persist-credentials: false
           fetch-depth: 0
       - name: Cleanup git submodules
@@ -120,12 +120,12 @@ jobs:
           python -m venv /mnt/venv
           echo "/mnt/venv/bin" >> $GITHUB_PATH
           source /mnt/venv/bin/activate
-          pip install --no-cache-dir -r /mnt/bot/requirements-ci.txt
+          pip install --no-cache-dir -r requirements-ci.txt
       - name: Remove test caches
         run: |
-          rm -rf /mnt/bot/.pytest_cache /mnt/bot/.cache
-          find /mnt/bot -type d -name '__pycache__' -exec rm -rf {} +
-          find /mnt/bot -name '*.pyc' -delete
+          rm -rf .pytest_cache .cache
+          find . -type d -name '__pycache__' -exec rm -rf {} +
+          find . -name '*.pyc' -delete
       - name: Run integration tests
         run: pytest -m integration
       - name: Cleanup buildx

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+          path: bot
       - name: Free disk space
         uses: jlumbroso/free-disk-space@main
         timeout-minutes: 10
@@ -68,9 +69,6 @@ jobs:
           sudo ln -s /mnt/docker /var/lib/docker
           sudo systemctl start docker
 
-      - name: Copy repository to /mnt
-        run: sudo rsync -a $GITHUB_WORKSPACE /mnt/
-
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -95,12 +93,12 @@ jobs:
         run: |
           mount | grep '/mnt'
           df -h /mnt
-        working-directory: /mnt/bot
+        working-directory: bot
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
-          context: /mnt/bot
+          context: bot
           file: ${{ matrix.file }}
           push: true
           load: true
@@ -111,13 +109,13 @@ jobs:
       - name: Apply security upgrades in built image
         run: |
           docker run --rm ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.image }}:latest bash -lc "apt-get update && apt-get upgrade -y && apt-get clean && rm -rf /var/lib/apt/lists/*"
-        working-directory: /mnt/bot
+        working-directory: bot
 
       - name: Move Docker layer cache
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-        working-directory: /mnt/bot
+        working-directory: bot
 
       - name: Set up Trivy
         uses: aquasecurity/setup-trivy@v0.2.3
@@ -131,7 +129,7 @@ jobs:
           sudo rm -rf /mnt/trivy-cache || true
           rm -rf ~/.cache/trivy || true
           mkdir -p /mnt/trivy-cache
-        working-directory: /mnt/bot
+        working-directory: bot
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.32.0
         env:
@@ -140,23 +138,23 @@ jobs:
           version: v0.65.0
           image-ref: ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.image }}:latest
           format: table
-          output: /mnt/bot/${{ matrix.artifact }}.txt
+          output: bot/${{ matrix.artifact }}.txt
           scanners: vuln
 
       - name: Show Trivy scan results
         run: cat ${{ matrix.artifact }}.txt
-        working-directory: /mnt/bot
+        working-directory: bot
 
       - name: Upload Trivy report artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}
-          path: /mnt/bot/${{ matrix.artifact }}.txt
+          path: bot/${{ matrix.artifact }}.txt
 
       - uses: actions/download-artifact@v5
         if: matrix.artifact == 'trivy-report-ci'
         with:
           name: trivy-report-ci
-          path: /mnt/bot
+          path: bot
       - name: Cleanup buildx
         run: docker buildx prune -af || true


### PR DESCRIPTION
## Summary
- use `path: bot` for checkout
- adjust workflow steps to run in `bot` directory

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9ad0f8150832db526dee3f00fd322