### PR TITLE
chore: remove post-trivy docker prune

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -101,8 +101,5 @@ jobs:
 
       - name: Clean Trivy temp
         run: rm -rf /mnt/trivy-temp || true
-
-      - name: Free disk space
-        run: docker system prune -af
       - name: Cleanup buildx
         run: docker buildx prune -af || true


### PR DESCRIPTION
## Summary
- avoid running `docker system prune -af` after Trivy scan

## Testing
- `pre-commit run --files .github/workflows/trivy.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a9ade5e200832daa1709ea0712380f