### PR TITLE
ci: login to ghcr before trivy scan

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   build:
@@ -23,6 +24,7 @@ jobs:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+      packages: read # for docker login to ghcr.io
     name: Build
     runs-on: ubuntu-24.04
     steps:
@@ -50,6 +52,9 @@ jobs:
       - name: Build an image from Dockerfile.ci
         run: |
           docker build -f Dockerfile.ci -t ghcr.io/${{ github.repository }}:${{ github.sha }} .
+
+      - name: Login to GHCR
+        run: docker login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Trivy
         uses: aquasecurity/setup-trivy@v0.2.3


### PR DESCRIPTION
## Summary
- login to ghcr before running trivy
- grant GITHUB_TOKEN packages:read

## Testing
- `pre-commit run flake8 --files .github/workflows/trivy.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9adeb3440832d86bb92b412a3aa4c