### PR TITLE
chore: drop tensorflow check from CPU Dockerfile

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -56,7 +56,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # Verify that all heavy packages were installed and no GPU libraries remain
 RUN echo "Checking package versions..." && \
-    $VIRTUAL_ENV/bin/python -c "import torch, tensorflow as tf; print('Torch:', torch.__version__, 'TF:', tf.__version__)" && \
+    $VIRTUAL_ENV/bin/python -c "import torch; print('Torch:', torch.__version__)" && \
     if /app/venv/bin/pip freeze | grep -qi nvidia; then echo 'Unexpected NVIDIA packages found' >&2; exit 1; else echo 'No NVIDIA packages installed'; fi && \
     $VIRTUAL_ENV/bin/python -c "import stable_baselines3 as sb3, mlflow, pytorch_lightning as pl; print('SB3:', sb3.__version__, 'MLflow:', mlflow.__version__, 'Lightning:', pl.__version__)"
 


### PR DESCRIPTION
## Summary
- remove TensorFlow version check from CPU Dockerfile

## Testing
- `pre-commit run --hook-stage manual --files Dockerfile.cpu`
- `pytest` *(fails: interrupted)*
- `docker build -f Dockerfile.cpu . -t bot-cpu-image` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ae80f7c0832d8ae445a34cdf54c0