### PR TITLE
chore: rename project to trading-bot-x

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ check unless explicitly enabled. Set `ENABLE_TF=1` as a build argument when
 you require TensorFlow features:
 
 ```bash
-docker build --build-arg ENABLE_TF=1 -t trading-bot .
+docker build --build-arg ENABLE_TF=1 -t trading-bot-x .
 ```
 
 Omit the argument to skip the import and avoid the associated warnings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "trading-bot"
+name = "trading-bot-x"
 version = "0.1.0"
 description = "Пример торгового бота на Python."
 readme = "README.md"


### PR DESCRIPTION
## Summary
- обновлено имя проекта на trading-bot-x
- обновлено упоминание имени в README

## Testing
- `pytest`
- `python -m build`
- `twine upload dist/*` *(не выполнено: отсутствует API token)*

------
https://chatgpt.com/codex/tasks/task_e_68a9aed86348832d8e1817538f104af5