### PR TITLE
chore: use repo Python version for PyPI publish

### DIFF
--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version-file: .python-version
       - name: Install build tools
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- use `.python-version` to define Python version in PyPI release workflow

## Testing
- `PATH=$PWD/.venv/bin:$PATH .venv/bin/pre-commit run --files .github/workflows/submit-pypi.yml`

------
https://chatgpt.com/codex/tasks/task_e_68a9af99901c832dbb5624f0abded3d6