### PR TITLE
chore: pin pip-tools version in submit workflow

### DIFF
--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -46,7 +46,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install build twine
       - name: Install pip-tools
-        run: pip install pip-tools
+        run: pip install pip-tools==7.5.0
       - name: Copy project to /mnt
         run: rsync -a . /mnt/project
       - name: Check dependencies


### PR DESCRIPTION
## Summary
- pin pip-tools to 7.5.0 in PyPI submission workflow

## Testing
- `python -m pre_commit run flake8 --files .github/workflows/submit-pypi.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9af9aed30832d83caa1902ebfba1f