### PR TITLE
fix: ensure trivy scans existing image

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -63,7 +63,6 @@ jobs:
 
       - name: Cleanup before Trivy scan
         run: |
-          docker system prune -af || true
           sudo rm -rf /tmp/* || true
           sudo rm -rf /mnt/trivy-cache /mnt/trivy-temp || true
           rm -rf ~/.cache/trivy || true
@@ -108,3 +107,5 @@ jobs:
         run: rm -rf /mnt/trivy-temp || true
       - name: Cleanup buildx
         run: docker buildx prune -af || true
+      - name: Cleanup Docker
+        run: docker system prune -af || true


### PR DESCRIPTION
## Summary
- avoid removing built image before scanning
- prune docker system after trivy run

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9d8cf3c0c832d80d81a3261cc6568