### PR TITLE
Wrap model.generate in no_grad

### DIFF
--- a/server.py
+++ b/server.py
@@ -116,11 +116,12 @@ def generate_text(prompt: str, *, temperature: float = 0.7, max_new_tokens: int 
     if tokenizer is None or model is None:
         raise RuntimeError("Model is not loaded")
     inputs = tokenizer(prompt, return_tensors="pt").to(device)
-    outputs = model.generate(
-        **inputs,
-        temperature=temperature,
-        max_new_tokens=max_new_tokens,
-    )
+    with torch.no_grad():
+        outputs = model.generate(
+            **inputs,
+            temperature=temperature,
+            max_new_tokens=max_new_tokens,
+        )
     text = tokenizer.decode(outputs[0], skip_special_tokens=True)
     if text.startswith(prompt):
         text = text[len(prompt) :]


### PR DESCRIPTION
## Summary
- wrap `model.generate` with `torch.no_grad()` in `generate_text`

## Testing
- `pytest tests/test_utils.py::test_safe_api_call_test_mode -q`
- `python - <<'PY'
import os, psutil
os.environ['GPT_MODEL']='nonexistent/model'
from importlib import reload
import server
reload(server)
server.load_model()
process = psutil.Process()
mem_before = process.memory_info().rss
output1 = server.generate_text('Hello world', max_new_tokens=5)
mem_after1 = process.memory_info().rss
output2 = server.generate_text('Hello world', max_new_tokens=5)
mem_after2 = process.memory_info().rss
print('output1:', repr(output1))
print('output2:', repr(output2))
print('mem before:', mem_before)
print('mem after first:', mem_after1)
print('mem after second:', mem_after2)
print('memory delta:', mem_after2 - mem_after1)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a9d8d10914832d9457398cfe247947