### PR TITLE
fix docker publish context

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -96,11 +96,10 @@ jobs:
         working-directory: bot
 
       - name: Build and push Docker image
-        working-directory: bot
         uses: docker/build-push-action@v6
         with:
-          context: .
-          file: ${{ matrix.file }}
+          context: ./bot
+          file: ./bot/${{ matrix.file }}
           push: true
           load: true
           tags: ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.image }}:latest


### PR DESCRIPTION
## Summary
- remove redundant working-directory from Docker build step
- adjust context and Dockerfile paths to be relative to repo root

## Testing
- `pytest`
- `./bin/act -n -W .github/workflows/docker-publish.yml -j build -P ubuntu-24.04=ghcr.io/catthehacker/ubuntu:act-latest` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d9a6e490832d8d88fa10146508bd