### PR TITLE
Remove unnecessary runtime packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,10 +72,8 @@ WORKDIR /app
 
 # Установка минимальных пакетов выполнения
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
-    tzdata \
     libssl3t64 \
     zlib1g \
-    tar=${TAR_VERSION} \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && ldconfig \
     && python3 --version \


### PR DESCRIPTION
## Summary
- remove `tzdata` and `tar` from runtime image packages

## Testing
- `pytest`
- `docker build -t bot-test .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68a9da59c674832d97697c49f93103d5