### PR TITLE
chore: ignore dev directories in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,9 @@ __pycache__
 *.log.*
 trading_bot.log
 logs/
+tests/
+scripts/
+.github/
 .git
 .gitignore
 dist/


### PR DESCRIPTION
## Summary
- ignore tests/, scripts/ and .github/ in Docker builds

## Testing
- `pytest -q`
- `docker build -f Dockerfile.test . -t bot-test --no-cache` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68a9da5edc68832d94565c8fdc1f6471