### PR TITLE
Add python3 to runtime Docker dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,7 @@ WORKDIR /app
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     libssl3t64 \
     zlib1g \
+    python3-minimal \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && ldconfig \
     && python3 --version \


### PR DESCRIPTION
## Summary
- include python3-minimal in runtime image to provide system Python

## Testing
- `docker build -t bot-test .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ea68fe40832db8446e77f2153cb4