### PR TITLE
chore: drop pyarrow from CI requirements

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -5,7 +5,6 @@ flake8==7.3.0
 httpx>=0.27.0
 joblib>=1.4.2
 pandas>=2.0.0,<3.0.0
-pyarrow>=16.1.0
 pytest==8.4.1
 pytest-asyncio>=1.1
 tenacity>=8.5,<10


### PR DESCRIPTION
## Summary
- drop `pyarrow` from requirements-ci since tests don't use it

## Testing
- `pytest tests/test_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68a9eb67de80832dab6ed2af87d98d22