### PR TITLE
chore: include tests and scripts in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,8 +9,6 @@ __pycache__
 *.log.*
 trading_bot.log
 logs/
-tests/
-scripts/
 .github/
 .git
 .gitignore


### PR DESCRIPTION
## Summary
- include tests and scripts in docker builds by adjusting .dockerignore

## Testing
- `pre-commit run --files .dockerignore` *(fails: command not found)*
- `pytest`
- `docker build -f Dockerfile.ci -t bot-ci-test .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68a9eb70a568832dbbd702eab750e84a