### PR TITLE
Add pyarrow to CI requirements

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -9,3 +9,5 @@ pytest==8.4.1
 pytest-asyncio>=1.1
 tenacity>=8.5,<10
 fastapi==0.116.1
+pyarrow>=16.1.0
+


### PR DESCRIPTION
## Summary
- add pyarrow dependency for CI tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9ef475f64832d94ec2bcbabb98cf7