### PR TITLE
Validate BotConfig field types

### DIFF
--- a/tests/test_config_type_validation.py
+++ b/tests/test_config_type_validation.py
@@ -1,0 +1,16 @@
+import pytest
+
+from config import BotConfig
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [
+        ("max_positions", "5"),
+        ("enable_grid_search", "false"),
+        ("backup_ws_urls", "ws"),
+    ],
+)
+def test_invalid_types_raise_value_error(key, value):
+    with pytest.raises(ValueError, match=key):
+        BotConfig(**{key: value})


### PR DESCRIPTION
## Summary
- add runtime type validation for `BotConfig` fields
- test that mis-typed configuration values raise `ValueError`

## Testing
- `pytest tests/test_config_type_validation.py tests/test_config_ws_subscription_batch_size.py tests/test_config_list_parsing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9f2061064832db26d9cb58ca807a5