### PR TITLE
refactor: extract password length validator

### DIFF
--- a/password_utils.py
+++ b/password_utils.py
@@ -19,12 +19,17 @@ def validate_password_complexity(password: str) -> None:
         raise ValueError("Password must contain a special character")
 
 
-def hash_password(password: str) -> str:
-    """Хэширует пароль, используя bcrypt."""
+def validate_password_length(password: str) -> None:
+    """Проверяет, что длина пароля находится в допустимых пределах."""
     if len(password) < MIN_PASSWORD_LENGTH:
         raise ValueError("Password too short")
     if len(password) > MAX_PASSWORD_LENGTH:
         raise ValueError("Password exceeds maximum length")
+
+
+def hash_password(password: str) -> str:
+    """Хэширует пароль, используя bcrypt."""
+    validate_password_length(password)
     validate_password_complexity(password)
     return bcrypt.hashpw(
         password.encode(), bcrypt.gensalt(rounds=BCRYPT_ROUNDS)
@@ -33,9 +38,6 @@ def hash_password(password: str) -> str:
 
 def verify_password(password: str, stored_hash: str) -> bool:
     """Проверяет пароль по сохранённому bcrypt-хэшу."""
-    if len(password) < MIN_PASSWORD_LENGTH:
-        raise ValueError("Password too short")
-    if len(password) > MAX_PASSWORD_LENGTH:
-        raise ValueError("Password exceeds maximum length")
+    validate_password_length(password)
     return bcrypt.checkpw(password.encode(), stored_hash.encode())
 

--- a/tests/test_password_utils.py
+++ b/tests/test_password_utils.py
@@ -5,6 +5,7 @@ from password_utils import (
     BCRYPT_ROUNDS,
     MAX_PASSWORD_LENGTH,
     MIN_PASSWORD_LENGTH,
+    validate_password_length,
     hash_password,
     verify_password,
 )
@@ -18,6 +19,18 @@ WEAK_PASSWORDS = [
     "AAAAaaa1",  # no special
     "AAAA!aaa",  # no digit
 ]
+
+
+def test_validate_password_length_accepts_valid_length():
+    validate_password_length("a" * MIN_PASSWORD_LENGTH)
+
+
+@pytest.mark.parametrize(
+    "password", ["a" * (MIN_PASSWORD_LENGTH - 1), "a" * (MAX_PASSWORD_LENGTH + 1)]
+)
+def test_validate_password_length_rejects_invalid_length(password):
+    with pytest.raises(ValueError):
+        validate_password_length(password)
 
 
 def test_hash_password_allows_short_password():


### PR DESCRIPTION
## Summary
- deduplicate password length checks with new `validate_password_length`
- test direct length validation and reuse in password hashing and verification

## Testing
- `pre-commit run --files password_utils.py tests/test_password_utils.py`
- `pytest tests/test_password_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9f2086294832da363cedf32e179ae