### PR TITLE
chore: restrict symlink scan during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     && python3 -m pip install --no-compile --no-cache-dir --break-system-packages 'pip>=24.0' \
     && curl --netrc-file /dev/null -L https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
     && echo "${ZLIB_SHA256}  zlib.tar.gz" | sha256sum -c - \
-    && find . -type l -lname "*..*" -print \
+    && (find /usr -type l -lname "*..*" -print 2>/dev/null || true) \
     && tar --no-overwrite-dir --keep-old-files -xf zlib.tar.gz \
     && cd zlib-${ZLIB_VERSION} && ./configure --prefix=/usr && make -j"$(nproc)" && make install && cd .. \
     && rm -rf zlib.tar.gz zlib-${ZLIB_VERSION} \


### PR DESCRIPTION
## Summary
- scan only /usr for suspicious symlinks during build to avoid pseudo-filesystems

## Testing
- `pre-commit run --files Dockerfile` *(fails: ModuleNotFoundError: No module named 'tenacity')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68a9f253846c832da26ff62e88bd12c8