### PR TITLE
refactor: simplify async model loading

### DIFF
--- a/server.py
+++ b/server.py
@@ -71,21 +71,13 @@ def load_model() -> str:
         raise RuntimeError("Failed to load both primary and fallback models")
 
 
-_ORIGINAL_LOAD_MODEL = load_model
-
-
 async def load_model_async() -> None:
     """Asynchronously load the model without blocking the event loop.
 
     Raises:
         RuntimeError: If both primary and fallback models fail to load.
     """
-    global load_model
-    fn = load_model
-    try:
-        await asyncio.to_thread(fn)
-    finally:
-        load_model = _ORIGINAL_LOAD_MODEL
+    await asyncio.to_thread(load_model)
 
 
 @asynccontextmanager

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -9,22 +9,22 @@ import server
 from fastapi.testclient import TestClient
 
 
-def make_client():
+def make_client(monkeypatch):
     def dummy_load_model():
         server.tokenizer = object()
         server.model = object()
-    server.load_model = dummy_load_model
+    monkeypatch.setattr(server, "load_model", dummy_load_model)
     return TestClient(server.app)
 
 
-def test_completions_requires_key():
-    with make_client() as client:
+def test_completions_requires_key(monkeypatch):
+    with make_client(monkeypatch) as client:
         resp = client.post("/v1/completions", json={"prompt": "hi"})
         assert resp.status_code == 401
 
 
-def test_chat_completions_requires_key():
-    with make_client() as client:
+def test_chat_completions_requires_key(monkeypatch):
+    with make_client(monkeypatch) as client:
         resp = client.post(
             "/v1/chat/completions",
             json={"messages": [{"role": "user", "content": "hi"}]},

--- a/tests/test_server_request_validation.py
+++ b/tests/test_server_request_validation.py
@@ -12,16 +12,16 @@ from fastapi.testclient import TestClient
 HEADERS = {"Authorization": "Bearer testkey"}
 
 
-def make_client():
+def make_client(monkeypatch):
     def dummy_load_model():
         server.tokenizer = object()
         server.model = object()
-    server.load_model = dummy_load_model
+    monkeypatch.setattr(server, "load_model", dummy_load_model)
     return TestClient(server.app)
 
 
-def test_chat_completions_validation():
-    with make_client() as client:
+def test_chat_completions_validation(monkeypatch):
+    with make_client(monkeypatch) as client:
         resp = client.post(
             "/v1/chat/completions",
             json={"messages": [{"role": "user", "content": "hi"}], "temperature": 2.1},
@@ -37,8 +37,8 @@ def test_chat_completions_validation():
         assert resp.status_code == 422
 
 
-def test_completions_validation():
-    with make_client() as client:
+def test_completions_validation(monkeypatch):
+    with make_client(monkeypatch) as client:
         resp = client.post(
             "/v1/completions",
             json={"prompt": "hi", "temperature": -0.1},


### PR DESCRIPTION
## Summary
- remove `_ORIGINAL_LOAD_MODEL` and global `load_model` usage
- call `await asyncio.to_thread(load_model)` directly in `load_model_async`
- adjust server tests to monkeypatch `load_model` safely

## Testing
- `pre-commit run --files server.py tests/test_server_request_validation.py tests/test_server_auth.py`
- `pytest tests/test_server_model_loading.py tests/test_server_request_validation.py tests/test_server_auth.py`
- manual async load check via `python`

------
https://chatgpt.com/codex/tasks/task_e_68a9f20269b8832dad8261b3aac4707b