### PR TITLE
feat(ci): add flask to test requirements

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -9,5 +9,7 @@ pytest==8.4.1
 pytest-asyncio>=1.1
 tenacity>=8.5,<10
 fastapi==0.116.1
+flask>=3.1.1,<4
 pyarrow>=16.1.0
+werkzeug>=3.1.3,<4
 


### PR DESCRIPTION
## Summary
- include flask and werkzeug in CI requirements to support service tests

## Testing
- `pytest`
- `pytest -m integration tests/test_integration_services.py`

------
https://chatgpt.com/codex/tasks/task_e_68a9f37615b0832d893f36f799376999