### PR TITLE
Allow integers where floats expected

### DIFF
--- a/config.py
+++ b/config.py
@@ -159,6 +159,8 @@ class BotConfig:
     @staticmethod
     def _isinstance(value: Any, typ: Any) -> bool:
         origin = get_origin(typ)
+        if typ is float:
+            return isinstance(value, (int, float))
         if origin is None:
             return isinstance(value, typ)
         if origin is Union:


### PR DESCRIPTION
## Summary
- permit integer values for float-typed fields in `_isinstance`

## Testing
- `pytest tests/test_trade_manager.py::test_process_symbol_retries_on_client_error -q` *(fails: ValueError: Invalid type for check_interval)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f64beca4832db9fbd2d13967976b