### PR TITLE
Use float for check_interval

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -40,7 +40,7 @@ to take‑profit and stop‑loss distances.
 | risk_vol_max | 2.0 | Upper bound for volatility based risk scaling. |
 | max_positions | 5 | Maximum simultaneous open positions. |
 | top_signals | 5 | Number of top ranked signals to trade. |
-| check_interval | 60 | Seconds between trade evaluation cycles. |
+| check_interval | 60.0 | Seconds between trade evaluation cycles. |
 | data_cleanup_interval | 3600 | Interval for removing old cached data. |
 | base_probability_threshold | 0.6 | Starting probability threshold for trades. |
 | trailing_stop_percentage | 1.0 | Percent drop from peak price to trigger trailing stop. |

--- a/config.json
+++ b/config.json
@@ -28,7 +28,7 @@
     "risk_vol_max": 2.0,
     "max_positions": 5,
     "top_signals": 5,
-    "check_interval": 60,
+    "check_interval": 60.0,
     "data_cleanup_interval": 3600,
     "base_probability_threshold": 0.6,
     "trailing_stop_percentage": 1.0,

--- a/config.py
+++ b/config.py
@@ -68,7 +68,7 @@ class BotConfig:
     risk_vol_max: float = _get_default("risk_vol_max", 2.0)
     max_positions: int = _get_default("max_positions", 5)
     top_signals: int = _get_default("top_signals", DEFAULTS.get("max_positions", 5))
-    check_interval: int = _get_default("check_interval", 60)
+    check_interval: float = _get_default("check_interval", 60.0)
     data_cleanup_interval: int = _get_default("data_cleanup_interval", 3600)
     base_probability_threshold: float = _get_default("base_probability_threshold", 0.6)
     trailing_stop_percentage: float = _get_default("trailing_stop_percentage", 1.0)

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -87,7 +87,7 @@ def test_get_opt_interval(vol, expected):
 
 
 def test_get_opt_interval_zero_threshold():
-    cfg = BotConfig(optimization_interval=7200, volatility_threshold=0)
+    cfg = BotConfig(optimization_interval=7200, volatility_threshold=0.0)
     opt_zero = ParameterOptimizer(cfg, data_handler)
     interval = opt_zero.get_opt_interval("BTCUSDT", 0.01)
     assert interval >= 1800

--- a/tests/test_optimizer_ray.py
+++ b/tests/test_optimizer_ray.py
@@ -219,7 +219,7 @@ async def test_optimize_zero_vol_threshold(_stub_modules):
         timeframe='1m',
         optuna_trials=1,
         optimization_interval=1,
-        volatility_threshold=0,
+            volatility_threshold=0.0,
         ema30_period=30,
         ema100_period=100,
         ema200_period=200,

--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -172,12 +172,12 @@ def make_config():
         leverage=10,
         min_risk_per_trade=0.01,
         max_risk_per_trade=0.05,
-        check_interval=1,
+        check_interval=1.0,
         performance_window=60,
         sl_multiplier=1.0,
         tp_multiplier=2.0,
         order_retry_attempts=3,
-        order_retry_delay=0,
+        order_retry_delay=0.0,
         reversal_margin=0.05,
     )
 

--- a/tests/test_trade_manager_loops.py
+++ b/tests/test_trade_manager_loops.py
@@ -105,9 +105,9 @@ class DummyModelBuilder:
 def make_config():
     return BotConfig(
         cache_dir=tempfile.mkdtemp(),
-        check_interval=1,
+        check_interval=1.0,
         performance_window=1,
-        order_retry_delay=0,
+        order_retry_delay=0.0,
         reversal_margin=0.05,
     )
 

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -232,7 +232,7 @@ class TradeManager:
         self.leverage = config.get("leverage", 10)
         self.min_risk_per_trade = config.get("min_risk_per_trade", 0.01)
         self.max_risk_per_trade = config.get("max_risk_per_trade", 0.05)
-        self.check_interval = config.get("check_interval", 60)
+        self.check_interval = config.get("check_interval", 60.0)
         self.performance_window = config.get("performance_window", 86400)
         self.state_file = os.path.join(config["cache_dir"], "trade_manager_state.parquet")
         self.returns_file = os.path.join(


### PR DESCRIPTION
## Summary
- use `float` for `check_interval` configuration
- update default sources and tests to align with float type

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9f64e415c832d8da667d750883acb