### PR TITLE
Remove keep-old-files flag from zlib extraction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     && curl --netrc-file /dev/null -L https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
     && echo "${ZLIB_SHA256}  zlib.tar.gz" | sha256sum -c - \
     && (find /usr -type l -lname "*..*" -print 2>/dev/null || true) \
-    && tar --no-overwrite-dir --keep-old-files -xf zlib.tar.gz \
+    && tar --no-overwrite-dir -xf zlib.tar.gz \
     && cd zlib-${ZLIB_VERSION} && ./configure --prefix=/usr && make -j"$(nproc)" && make install && cd .. \
     && rm -rf zlib.tar.gz zlib-${ZLIB_VERSION} \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
## Summary
- remove obsolete `--keep-old-files` flag from zlib extraction in Dockerfile

## Testing
- `docker build .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f756d394832d8ca088b3cda5649b