### PR TITLE
Align cachetools version in GPU requirements

### DIFF
--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -9,7 +9,7 @@ astor==0.8.1
 astunparse==1.6.3
 attrs==25.3.0
 blake3==1.0.5
-cachetools==6.1.0
+cachetools==5.5.2
 cbor2==5.7.0
 certifi==2025.8.3
 cffi==1.17.1


### PR DESCRIPTION
## Summary
- fix cachetools version in requirements-gpu.txt to match core dependencies

## Testing
- `pip-compile --strip-extras requirements-core.in`
- `pip install --dry-run -r requirements-core.txt -r requirements-gpu.txt` *(fails: Cannot install hf-xet==1.1.7 and hf-xet==1.1.8)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9fa5c78e0832d8e45b952fe048c26