### PR TITLE
Add python-dotenv to CI requirements

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -11,5 +11,6 @@ tenacity>=8.5,<10
 fastapi==0.116.1
 flask>=3.1.1,<4
 pyarrow>=16.1.0
+python-dotenv==1.1.1
 werkzeug>=3.1.3,<4
 


### PR DESCRIPTION
## Summary
- include python-dotenv in CI requirements to ensure integration tests can import env variables

## Testing
- `pip install -r requirements-ci.txt`
- `pytest -m integration` *(partial run: initial tests passed without ModuleNotFoundError; suite interrupted due to time)*

------
https://chatgpt.com/codex/tasks/task_e_68a9faca5d64832d8c0f3207724f1d84