### PR TITLE
ci: skip existing packages on PyPI publish

### DIFF
--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -79,6 +79,7 @@ jobs:
           user: __token__
           password: ${{ env.TOKENPYPI }}
           attestations: false
+          skip-existing: true
       - name: Skip PyPI publish (missing token)
         if: env.TOKENPYPI == ''
         run: echo "TOKENPYPI not set; skipping publish."


### PR DESCRIPTION
## Summary
- avoid failure if package already exists on PyPI

## Testing
- `pre-commit run --files .github/workflows/submit-pypi.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9fb251450832dafa3e198c6f54563