### PR TITLE
Use password-stdin for GHCR login in Trivy workflow

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -54,7 +54,9 @@ jobs:
           docker build -f Dockerfile.ci -t ghcr.io/${{ github.repository }}:${{ github.sha }} .
 
       - name: Login to GHCR
-        run: docker login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+        env:
+          CR_PAT: ${{ secrets.CR_PAT }}
+        run: echo "$CR_PAT" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Set up Trivy
         uses: aquasecurity/setup-trivy@v0.2.3


### PR DESCRIPTION
## Summary
- use `--password-stdin` with `CR_PAT` secret for GHCR login in Trivy workflow

## Testing
- `pytest` *(fails: KeyboardInterrupt, no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68a9fc14b0a8832d9962fa415ce71747