### PR TITLE
chore: pin CI Dockerfile package versions

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -8,18 +8,18 @@ ARG DEBIAN_FRONTEND=noninteractive
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
 # Обновление linux-libc-dev устраняет CVE-2025-21976, а libgcrypt20 — CVE-2024-2236
-RUN apt-get update && apt-get upgrade -y && apt-get dist-upgrade -y && apt-get install -y --no-install-recommends \
-    linux-libc-dev \
-    libgcrypt20 \
-    libpam0g \
-    libssl3t64 \
-    python3.12-minimal \
-    zlib1g-dev \
-    build-essential \
-    python3 \
-    python3-dev \
-    python3-venv \
-    python3-pip \
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    linux-libc-dev=6.8.0-78.78 \
+    libgcrypt20=1.10.3-2build1 \
+    libpam0g=1.5.3-5ubuntu5.4 \
+    libssl3t64=3.0.13-0ubuntu3.5 \
+    python3.12-minimal=3.12.3-1ubuntu0.8 \
+    zlib1g-dev=1:1.3.dfsg-3.1ubuntu2 \
+    build-essential=12.10ubuntu1 \
+    python3=3.12.3-0ubuntu1 \
+    python3-dev=3.12.3-0ubuntu1 \
+    python3-venv=3.12.3-0ubuntu1 \
+    python3-pip=24.0+dfsg-1ubuntu1 \
     && python3 -m venv /venv \
     && /venv/bin/python -m pip install --no-cache-dir --upgrade --break-system-packages pip==25.2 \
     && find / -xdev -type l -lname "*..*" -print \
@@ -44,10 +44,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
 # Устанавливаем только необходимые пакеты выполнения
-RUN apt-get update && apt-get upgrade -y && apt-get dist-upgrade -y && apt-get install -y --no-install-recommends \
-    libssl3t64 \
-    python3.12-minimal \
-    python3 \
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    libssl3t64=3.0.13-0ubuntu3.5 \
+    python3.12-minimal=3.12.3-1ubuntu0.8 \
+    python3=3.12.3-0ubuntu1 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
## Summary
- pin CI Dockerfile package versions for deterministic builds
- drop unnecessary upgrade steps in CI image

## Testing
- `pre-commit run --files Dockerfile.ci`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9fc1c9d98832d9bf4ec39526aa18f