### PR TITLE
Fix workflow working directory so initial cleanup runs before checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,11 @@ jobs:
   unit:
     name: Unit tests
     runs-on: ubuntu-24.04
-    defaults:
-      run:
-        working-directory: bot
     steps:
       - name: Initial cleanup
         run: docker system prune -af && sudo rm -rf /tmp/*
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
-          path: bot
           persist-credentials: false
           fetch-depth: 0
       - name: Cleanup git submodules
@@ -87,15 +83,11 @@ jobs:
     name: Integration tests
     runs-on: ubuntu-24.04
     needs: unit
-    defaults:
-      run:
-        working-directory: bot
     steps:
       - name: Initial cleanup
         run: docker system prune -af && sudo rm -rf /tmp/*
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
-          path: bot
           persist-credentials: false
           fetch-depth: 0
       - name: Cleanup git submodules


### PR DESCRIPTION
## Summary
- allow initial cleanup to run before checkout by removing job-level `working-directory`
- clone repo directly into `GITHUB_WORKSPACE`

## Testing
- `pre-commit run --files .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_68a9ffa5e694832d9bd69d4e48a193f9