### PR TITLE
chore: update python versions in Dockerfile.ci

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -14,11 +14,11 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     libpam0g=1.5.3-5ubuntu5.4 \
     libssl3t64=3.0.13-0ubuntu3.5 \
     python3.12-minimal=3.12.3-1ubuntu0.8 \
-    zlib1g-dev=1:1.3.dfsg-3.1ubuntu2 \
+    zlib1g-dev=1:1.3.dfsg-3.1ubuntu2.1 \
     build-essential=12.10ubuntu1 \
-    python3=3.12.3-0ubuntu1 \
-    python3-dev=3.12.3-0ubuntu1 \
-    python3-venv=3.12.3-0ubuntu1 \
+    python3=3.12.3-0ubuntu2 \
+    python3-dev=3.12.3-0ubuntu2 \
+    python3-venv=3.12.3-0ubuntu2 \
     python3-pip=24.0+dfsg-1ubuntu1 \
     && python3 -m venv /venv \
     && /venv/bin/python -m pip install --no-cache-dir --upgrade --break-system-packages pip==25.2 \
@@ -47,7 +47,7 @@ ENV PIP_BREAK_SYSTEM_PACKAGES=1
 RUN apt-get update && apt-get install --no-install-recommends -y \
     libssl3t64=3.0.13-0ubuntu3.5 \
     python3.12-minimal=3.12.3-1ubuntu0.8 \
-    python3=3.12.3-0ubuntu1 \
+    python3=3.12.3-0ubuntu2 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
## Summary
- bump python3, dev and venv packages to 3.12.3-0ubuntu2
- update zlib1g-dev patch version
- align runtime python3 with new release

## Testing
- `docker build -f Dockerfile.ci .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa002de834832d9e7b6b40c9e1f78d