### PR TITLE
chore: align hf-xet version

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -143,7 +143,7 @@ h11==0.16.0
     # via
     #   httpcore
     #   uvicorn
-hf-xet==1.1.7
+hf-xet==1.1.8
     # via huggingface-hub
 httpcore==1.0.9
     # via httpx

--- a/requirements.txt
+++ b/requirements.txt
@@ -200,7 +200,7 @@ h5py==3.14.0
     # via
     #   keras
     #   tensorflow
-hf-xet==1.1.7
+hf-xet==1.1.8
     # via huggingface-hub
 httpcore==1.0.9
     # via httpx


### PR DESCRIPTION
## Summary
- align hf-xet version across requirements files

## Testing
- `pip install hf-xet==1.1.8`
- `pip install fastapi-cloud-cli==0.1.5`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa007d5cd4832daa44e4799f676012