### PR TITLE
Pin jsonschema version consistently

### DIFF
--- a/requirements-core.in
+++ b/requirements-core.in
@@ -34,5 +34,6 @@ httpx>=0.27.0
 cryptography>=42.0.0
 bcrypt>=4.2.0
 openai<1.100
+jsonschema==4.25.1
 pytest-asyncio>=1.1
 

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -183,7 +183,7 @@ joblib==1.5.1
     #   -r requirements-core.in
     #   imbalanced-learn
     #   scikit-learn
-jsonschema==4.25.0
+jsonschema==4.25.1
     # via ray
 jsonschema-specifications==2025.4.1
     # via jsonschema

--- a/requirements-gpu.in
+++ b/requirements-gpu.in
@@ -2,3 +2,4 @@ cupy-cuda12x>=13.5.1
 vllm>=0.10.0
 torch==2.7.1
 tensorflow==2.20.0
+jsonschema==4.25.1


### PR DESCRIPTION
## Summary
- pin jsonschema==4.25.1 across core and gpu inputs and lockfile

## Testing
- `pre-commit run --files requirements-core.in requirements-gpu.in requirements-core.txt requirements-gpu.txt requirements.txt`
- `docker build -f Dockerfile.ci -t myapp-ci .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0330086c832d8b807692426eb7f5