### PR TITLE
chore: remove manual Trivy setup

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -86,7 +86,6 @@ jobs:
           # ignore-unlikely-affected: true  # enable once Trivy >= v0.66 is available
           limit-severities-for-sarif: CRITICAL
           scanners: vuln
-          skip-setup-trivy: true
 
       - name: Show Trivy scan results
         run: cat trivy-results.sarif


### PR DESCRIPTION
## Summary
- let Trivy action install the scanner by default

## Testing
- `python -m flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa0c2ee4a8832d9a1751181375031b