### PR TITLE
chore: prepare LVM volume before maximizing build space

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -43,6 +43,10 @@ jobs:
           swap-storage: true
       - name: Clean Docker dir
         run: sudo rm -rf /var/lib/docker/*
+      - name: Prepare build volume
+        run: |
+          sudo wipefs -a /dev/buildvg/buildlv || true
+          sudo rm -rf /mnt/*
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,10 @@ jobs:
           swap-storage: true
       - name: Clean Docker dir
         run: sudo rm -rf /var/lib/docker/*
+      - name: Prepare build volume
+        run: |
+          sudo wipefs -a /dev/buildvg/buildlv || true
+          sudo rm -rf /mnt/*
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:
@@ -107,6 +111,10 @@ jobs:
           swap-storage: true
       - name: Clean Docker dir
         run: sudo rm -rf /var/lib/docker/*
+      - name: Prepare build volume
+        run: |
+          sudo wipefs -a /dev/buildvg/buildlv || true
+          sudo rm -rf /mnt/*
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Prepare build mount dir
         run: |
           sudo mkdir -p /mnt
+          sudo wipefs -a /dev/buildvg/buildlv || true
           sudo rm -rf /mnt/*
       - name: Install LVM
         run: sudo apt-get update && sudo apt-get install -y lvm2

--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -33,6 +33,10 @@ jobs:
       - name: Clean Docker dir
         run: sudo rm -rf /var/lib/docker/*
         timeout-minutes: 5
+      - name: Prepare build volume
+        run: |
+          sudo wipefs -a /dev/buildvg/buildlv || true
+          sudo rm -rf /mnt/*
       - name: Максимизировать пространство для сборки
         uses: easimon/maximize-build-space@v10
         timeout-minutes: 15

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -52,6 +52,10 @@ jobs:
         run: |
           export PIP_CACHE_DIR=/mnt/pip-cache
           pip install --no-cache-dir semgrep
+      - name: Prepare build volume
+        run: |
+          sudo wipefs -a /dev/buildvg/buildlv || true
+          sudo rm -rf /mnt/*
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:

--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -28,6 +28,10 @@ jobs:
           swap-storage: true
       - name: Clean Docker dir
         run: sudo rm -rf /var/lib/docker/*
+      - name: Prepare build volume
+        run: |
+          sudo wipefs -a /dev/buildvg/buildlv || true
+          sudo rm -rf /mnt/*
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -42,6 +42,10 @@ jobs:
           swap-storage: true
       - name: Clean Docker dir
         run: sudo rm -rf /var/lib/docker/*
+      - name: Prepare build volume
+        run: |
+          sudo wipefs -a /dev/buildvg/buildlv || true
+          sudo rm -rf /mnt/*
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:


### PR DESCRIPTION
## Summary
- wipe existing build volume and clean /mnt before calling `easimon/maximize-build-space`
- ensure docker-publish workflow cleans the LVM device and mount directory

## Testing
- `SKIP=pytest pre-commit run --files .github/workflows/ci.yml .github/workflows/bandit.yml .github/workflows/gptoss_review.yml .github/workflows/semgrep.yml .github/workflows/trivy.yml .github/workflows/submit-pypi.yml .github/workflows/docker-publish.yml`
- `act -j bandit -W .github/workflows/bandit.yml` *(fails: Couldn't get a valid docker connection: no DOCKER_HOST and an invalid container socket '')*

------
https://chatgpt.com/codex/tasks/task_e_68aa0c52e7e8832d94f21bd6a6acbee4