### PR TITLE
ci: remove redundant trivy setup

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -86,7 +86,6 @@ jobs:
           # ignore-unlikely-affected: true  # enable once Trivy >= v0.66 is available
           limit-severities-for-sarif: CRITICAL
           scanners: vuln
-          skip-setup-trivy: true
 
       - name: Show Trivy scan results
         run: cat trivy-results.sarif


### PR DESCRIPTION
## Summary
- remove `skip-setup-trivy` to let aquasecurity/trivy-action install Trivy automatically

## Testing
- `pre-commit run --files .github/workflows/trivy.yml`
- `trivy fs --security-checks vuln --exit-code 0 --skip-dirs .venv --skip-dirs node_modules --no-progress .`


------
https://chatgpt.com/codex/tasks/task_e_68aa0c686b50832da7839ea5047bdaee