### PR TITLE
Handle password length and specify file encodings

### DIFF
--- a/config.py
+++ b/config.py
@@ -21,7 +21,7 @@ CONFIG_PATH = os.getenv(
     "CONFIG_PATH", os.path.join(os.path.dirname(__file__), "config.json")
 )
 try:
-    with open(CONFIG_PATH, "r") as f:
+    with open(CONFIG_PATH, "r", encoding="utf-8") as f:
         DEFAULTS = json.load(f)
 except (OSError, json.JSONDecodeError) as exc:
     logger.warning("Failed to load %s: %s", CONFIG_PATH, exc)
@@ -246,7 +246,7 @@ def load_config(path: str = CONFIG_PATH) -> BotConfig:
     if not resolved_path.is_relative_to(allowed_dir):
         raise ValueError(f"Path {resolved_path} is outside of {allowed_dir}")
     if resolved_path.exists():
-        with open(resolved_path, "r") as f:
+        with open(resolved_path, "r", encoding="utf-8") as f:
             try:
                 cfg.update(json.load(f))
             except json.JSONDecodeError as exc:

--- a/password_utils.py
+++ b/password_utils.py
@@ -38,6 +38,9 @@ def hash_password(password: str) -> str:
 
 def verify_password(password: str, stored_hash: str) -> bool:
     """Проверяет пароль по сохранённому bcrypt-хэшу."""
-    validate_password_length(password)
+    try:
+        validate_password_length(password)
+    except ValueError:
+        return False
     return bcrypt.checkpw(password.encode(), stored_hash.encode())
 

--- a/tests/test_password_utils.py
+++ b/tests/test_password_utils.py
@@ -54,8 +54,7 @@ def test_hash_password_rejects_long_password():
 def test_verify_password_rejects_long_password():
     hashed = hash_password(VALID_PASSWORD)
     long_password = "Aa1!" + "a" * (MAX_PASSWORD_LENGTH - 3)
-    with pytest.raises(ValueError):
-        verify_password(long_password, hashed)
+    assert not verify_password(long_password, hashed)
 
 
 @pytest.mark.parametrize("password", ["", "a" * (MIN_PASSWORD_LENGTH - 1)])
@@ -67,8 +66,7 @@ def test_hash_password_rejects_short_password(password):
 @pytest.mark.parametrize("password", ["", "a" * (MIN_PASSWORD_LENGTH - 1)])
 def test_verify_password_rejects_short_password(password):
     hashed = hash_password(VALID_PASSWORD)
-    with pytest.raises(ValueError):
-        verify_password(password, hashed)
+    assert not verify_password(password, hashed)
 
 
 def test_hash_password_generates_unique_hashes():

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -352,7 +352,7 @@ class TradeManager:
                 )
                 return
             self.positions.to_parquet(self.state_file)
-            with open(self.returns_file, "w") as f:
+            with open(self.returns_file, "w", encoding="utf-8") as f:
                 json.dump(self.returns_by_symbol, f)
             self.last_save_time = time.time()
             self.positions_changed = False
@@ -372,7 +372,7 @@ class TradeManager:
                     self.positions = self.positions.tz_localize("UTC", level="timestamp")
                 self._sort_positions()
             if os.path.exists(self.returns_file):
-                with open(self.returns_file, "r") as f:
+                with open(self.returns_file, "r", encoding="utf-8") as f:
                     self.returns_by_symbol = json.load(f)
                 logger.info("TradeManager state loaded")
         except (OSError, ValueError, json.JSONDecodeError) as e:


### PR DESCRIPTION
## Summary
- specify UTF-8 encoding when reading/writing config and return files
- return False for invalid password lengths instead of raising errors
- adjust tests to reflect new password verification behavior

## Testing
- `pre-commit run --files config.py trade_manager.py password_utils.py tests/test_password_utils.py`
- `pytest tests/test_config_* tests/test_trade_manager* tests/test_password_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa0cc64d38832d92fa8ebe9c03dda3