### PR TITLE
chore: upgrade openai version

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -286,7 +286,7 @@ nvidia-nvjitlink-cu12==12.6.85
     #   torch
 nvidia-nvtx-cu12==12.6.77
     # via torch
-openai==1.99.9
+openai==1.100.2
     # via -r requirements-core.in
 opentelemetry-api==1.36.0
     # via


### PR DESCRIPTION
## Summary
- unify OpenAI dependency to version 1.100.2

## Testing
- `python -m pre_commit run --files requirements-core.txt requirements-gpu.txt`
- `docker build -f Dockerfile.ci .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa123d65fc832d91d0531a937e830a