### PR TITLE
ci: guard wipefs on build volume

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,9 @@ jobs:
         run: sudo rm -rf /var/lib/docker/*
       - name: Prepare build volume
         run: |
-          sudo wipefs -a /dev/buildvg/buildlv || true
+          if [ -e /dev/buildvg/buildlv ]; then
+            sudo wipefs -a /dev/buildvg/buildlv
+          fi
           sudo rm -rf /mnt/*
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
@@ -113,7 +115,9 @@ jobs:
         run: sudo rm -rf /var/lib/docker/*
       - name: Prepare build volume
         run: |
-          sudo wipefs -a /dev/buildvg/buildlv || true
+          if [ -e /dev/buildvg/buildlv ]; then
+            sudo wipefs -a /dev/buildvg/buildlv
+          fi
           sudo rm -rf /mnt/*
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10


### PR DESCRIPTION
## Summary
- avoid warnings when build volume device is missing by checking for its existence before wiping

## Testing
- `SKIP=pytest pre-commit run --files .github/workflows/ci.yml`
- `pytest -m "not integration"`


------
https://chatgpt.com/codex/tasks/task_e_68aa13165318832d83d80de2f2342b83