### PR TITLE
Улучшение скрипта Dependabot: проверка переменных и подавление вывода

### DIFF
--- a/scripts/run_dependabot.sh
+++ b/scripts/run_dependabot.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [[ -z "${GITHUB_REPOSITORY:-}" ]]; then
+    echo "GITHUB_REPOSITORY is not set; cannot trigger Dependabot" >&2
+    exit 1
+fi
 repo="${GITHUB_REPOSITORY}"
 
 if [[ -z "${TOKEN:-}" ]]; then
@@ -10,7 +14,7 @@ fi
 token="${TOKEN}"
 
 for ecosystem in pip github-actions; do
-  if ! curl --fail-with-body -S -s -X POST \
+  if ! curl --fail-with-body -S -s -o /dev/null -X POST \
     -H "Authorization: Bearer ${token}" \
     -H "Accept: application/vnd.github+json" \
     -H "Content-Type: application/json" \
@@ -19,7 +23,7 @@ for ecosystem in pip github-actions; do
     -d "{\"package-ecosystem\":\"${ecosystem}\",\"directory\":\"/\"}"; then
     code=${PIPESTATUS[0]}
     if [[ $code -eq 22 ]]; then
-      echo "Dependabot endpoint returned 404 for ${ecosystem}; skipping" >&2
+      echo "Dependabot endpoint returned 404 for ${ecosystem}" >&2
       continue
     fi
     echo "Failed to trigger Dependabot for ${ecosystem}" >&2


### PR DESCRIPTION
## Summary
- проверяем наличие GITHUB_REPOSITORY и TOKEN
- скрываем тело ответа curl и упрощаем сообщение о 404

## Testing
- `pre-commit run --files scripts/run_dependabot.sh`
- `pytest tests/test_config_logging.py`

------
https://chatgpt.com/codex/tasks/task_e_68aa1370709c832da0f20ade3283a28f