### PR TITLE
ci: guard wipefs with device check

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -45,7 +45,11 @@ jobs:
         run: sudo rm -rf /var/lib/docker/*
       - name: Prepare build volume
         run: |
-          sudo wipefs -a /dev/buildvg/buildlv || true
+          if [ -e /dev/buildvg/buildlv ]; then
+            sudo wipefs -a /dev/buildvg/buildlv || true
+          else
+            echo "Device /dev/buildvg/buildlv not found, skipping wipefs"
+          fi
           sudo rm -rf /mnt/*
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
         run: |
           if [ -e /dev/buildvg/buildlv ]; then
             sudo wipefs -a /dev/buildvg/buildlv
+          else
+            echo "Device /dev/buildvg/buildlv not found, skipping wipefs"
           fi
           sudo rm -rf /mnt/*
       - name: Maximize build space
@@ -117,6 +119,8 @@ jobs:
         run: |
           if [ -e /dev/buildvg/buildlv ]; then
             sudo wipefs -a /dev/buildvg/buildlv
+          else
+            echo "Device /dev/buildvg/buildlv not found, skipping wipefs"
           fi
           sudo rm -rf /mnt/*
       - name: Maximize build space

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -49,7 +49,11 @@ jobs:
       - name: Prepare build mount dir
         run: |
           sudo mkdir -p /mnt
-          sudo wipefs -a /dev/buildvg/buildlv || true
+          if [ -e /dev/buildvg/buildlv ]; then
+            sudo wipefs -a /dev/buildvg/buildlv || true
+          else
+            echo "Device /dev/buildvg/buildlv not found, skipping wipefs"
+          fi
           sudo rm -rf /mnt/*
       - name: Install LVM
         run: sudo apt-get update && sudo apt-get install -y lvm2

--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -35,7 +35,11 @@ jobs:
         timeout-minutes: 5
       - name: Prepare build volume
         run: |
-          sudo wipefs -a /dev/buildvg/buildlv || true
+          if [ -e /dev/buildvg/buildlv ]; then
+            sudo wipefs -a /dev/buildvg/buildlv || true
+          else
+            echo "Device /dev/buildvg/buildlv not found, skipping wipefs"
+          fi
           sudo rm -rf /mnt/*
       - name: Максимизировать пространство для сборки
         uses: easimon/maximize-build-space@v10

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -54,7 +54,11 @@ jobs:
           pip install --no-cache-dir semgrep
       - name: Prepare build volume
         run: |
-          sudo wipefs -a /dev/buildvg/buildlv || true
+          if [ -e /dev/buildvg/buildlv ]; then
+            sudo wipefs -a /dev/buildvg/buildlv || true
+          else
+            echo "Device /dev/buildvg/buildlv not found, skipping wipefs"
+          fi
           sudo rm -rf /mnt/*
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10

--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -30,7 +30,11 @@ jobs:
         run: sudo rm -rf /var/lib/docker/*
       - name: Prepare build volume
         run: |
-          sudo wipefs -a /dev/buildvg/buildlv || true
+          if [ -e /dev/buildvg/buildlv ]; then
+            sudo wipefs -a /dev/buildvg/buildlv || true
+          else
+            echo "Device /dev/buildvg/buildlv not found, skipping wipefs"
+          fi
           sudo rm -rf /mnt/*
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -44,7 +44,11 @@ jobs:
         run: sudo rm -rf /var/lib/docker/*
       - name: Prepare build volume
         run: |
-          sudo wipefs -a /dev/buildvg/buildlv || true
+          if [ -e /dev/buildvg/buildlv ]; then
+            sudo wipefs -a /dev/buildvg/buildlv || true
+          else
+            echo "Device /dev/buildvg/buildlv not found, skipping wipefs"
+          fi
           sudo rm -rf /mnt/*
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10


### PR DESCRIPTION
## Summary
- skip wipefs when /dev/buildvg/buildlv is absent in workflows

## Testing
- `pre-commit run --files .github/workflows/semgrep.yml .github/workflows/trivy.yml .github/workflows/gptoss_review.yml .github/workflows/bandit.yml .github/workflows/docker-publish.yml .github/workflows/submit-pypi.yml .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_68aa25c54504832d93f659bfb622a21c