### PR TITLE
Refactor model loading into ModelManager

### DIFF
--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -11,9 +11,9 @@ from fastapi.testclient import TestClient
 
 def make_client(monkeypatch):
     def dummy_load_model():
-        server.tokenizer = object()
-        server.model = object()
-    monkeypatch.setattr(server, "load_model", dummy_load_model)
+        server.model_manager.tokenizer = object()
+        server.model_manager.model = object()
+    monkeypatch.setattr(server.model_manager, "load_model", dummy_load_model)
     return TestClient(server.app)
 
 

--- a/tests/test_server_model_loading.py
+++ b/tests/test_server_model_loading.py
@@ -21,7 +21,7 @@ def test_load_model_async_raises_runtime_error(monkeypatch):
         import server
 
         with pytest.raises(RuntimeError, match="Failed to load both primary and fallback models"):
-            asyncio.run(server.load_model_async())
+            asyncio.run(server.model_manager.load_model_async())
 
     try:
         importlib.reload(server)

--- a/tests/test_server_request_validation.py
+++ b/tests/test_server_request_validation.py
@@ -14,9 +14,9 @@ HEADERS = {"Authorization": "Bearer testkey"}
 
 def make_client(monkeypatch):
     def dummy_load_model():
-        server.tokenizer = object()
-        server.model = object()
-    monkeypatch.setattr(server, "load_model", dummy_load_model)
+        server.model_manager.tokenizer = object()
+        server.model_manager.model = object()
+    monkeypatch.setattr(server.model_manager, "load_model", dummy_load_model)
     return TestClient(server.app)
 
 


### PR DESCRIPTION
## Summary
- encapsulate model and tokenizer loading in ModelManager class
- update FastAPI routes to use ModelManager instance
- adjust tests for ModelManager

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa25ca0de8832d93a08e8d497b89c3