### PR TITLE
Use error logging and exit if config missing

### DIFF
--- a/config.py
+++ b/config.py
@@ -20,12 +20,13 @@ logger = logging.getLogger(__name__)
 CONFIG_PATH = os.getenv(
     "CONFIG_PATH", os.path.join(os.path.dirname(__file__), "config.json")
 )
+DEFAULTS: Dict[str, Any] = {}
 try:
     with open(CONFIG_PATH, "r", encoding="utf-8") as f:
         DEFAULTS = json.load(f)
 except (OSError, json.JSONDecodeError) as exc:
-    logger.warning("Failed to load %s: %s", CONFIG_PATH, exc)
-    DEFAULTS = {}
+    logger.error("Failed to load %s: %s", CONFIG_PATH, exc)
+    raise SystemExit from exc
 
 
 def _get_default(key: str, fallback: Any) -> Any:


### PR DESCRIPTION
## Summary
- Replace warning with error when `config.json` cannot be loaded
- Terminate startup by raising `SystemExit` if `config.json` is missing or invalid

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa25db9168832d84c508b19326b03e