### PR TITLE
chore: bump requests to 2.32.5

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -411,7 +411,7 @@ referencing==0.36.2
     #   jsonschema-specifications
 regex==2025.7.34
     # via transformers
-requests==2.32.4
+requests==2.32.5
     # via
     #   ccxt
     #   databricks-sdk

--- a/requirements.txt
+++ b/requirements.txt
@@ -553,7 +553,7 @@ regex==2025.7.34
     #   tiktoken
     #   transformers
     #   vllm
-requests==2.32.4
+requests==2.32.5
     # via
     #   ccxt
     #   databricks-sdk


### PR DESCRIPTION
## Summary
- bump requests to 2.32.5

## Testing
- `pre-commit run --files requirements-core.txt requirements.txt`
- `pip install -r requirements-core.txt -r requirements-gpu.txt` *(fails: transformers==4.55.2 vs 4.55.3 conflict)*


------
https://chatgpt.com/codex/tasks/task_e_68aadc85a7b0832dba4b9c810258157b