### PR TITLE
chore: уточнить использование GITHUB_REGISTRIES_PROXY

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -35,5 +35,6 @@ jobs:
           GITHUB_DEPENDABOT_CRED_TOKEN: >-
             ${{ secrets.GITHUB_DEPENDABOT_CRED_TOKEN }}
           DEPENDABOT_ENABLE_CONNECTIVITY_CHECK: 1
+          # GITHUB_REGISTRIES_PROXY intentionally not set
       - name: Cleanup buildx
         run: docker buildx prune -af || true


### PR DESCRIPTION
## Summary
- явно отмечено, что GITHUB_REGISTRIES_PROXY не используется

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml`


------
https://chatgpt.com/codex/tasks/task_e_68aadceff25c832db0c494384e49ce7c