### PR TITLE
chore: bump transformers to 4.55.3

### DIFF
--- a/requirements-core.in
+++ b/requirements-core.in
@@ -23,7 +23,7 @@ stable-baselines3>=2.3.2
 gymnasium>=0.29.1
 mlflow>=3.2.0
 pytorch-lightning>=2.5.2
-transformers==4.55.2
+transformers==4.55.3
 catalyst==21.5
 flask>=3.0.2
 pybit>=5.11.0

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -499,7 +499,7 @@ tqdm==4.67.1
     #   pytorch-lightning
     #   shap
     #   transformers
-transformers==4.55.2
+transformers==4.55.3
     # via -r requirements-core.in
 triton==3.3.1
     # via torch

--- a/requirements.txt
+++ b/requirements.txt
@@ -674,7 +674,7 @@ tqdm==4.67.1
     #   shap
     #   transformers
     #   vllm
-transformers==4.55.2
+transformers==4.55.3
     # via
     #   -r requirements-core.in
     #   compressed-tensors


### PR DESCRIPTION
## Summary
- update transformers to 4.55.3 across core requirement files

## Testing
- `pre-commit run --files requirements-core.in requirements-core.txt requirements.txt requirements-gpu.txt`
- `pytest`
- `pip install -r requirements-core.txt -r requirements-gpu.txt` *(fails: Operation cancelled by user)*
- `docker build -t bot-image .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68aae0b9bd04832d87c1b4802a880f92