### PR TITLE
Log non-200 responses in service health checks

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -270,6 +270,13 @@ async def check_services() -> None:
                     resp = await client.get(f"{url}/{endpoint}", timeout=5)
                     if resp.status_code == 200:
                         return None
+                    if resp.status_code != 200:
+                        logger.warning(
+                            "Ping failed for %s (%s): HTTP %s",
+                            name,
+                            attempt + 1,
+                            resp.status_code,
+                        )
                 except httpx.HTTPError as exc:
                     logger.warning(
                         "Ping failed for %s (%s): %s", name, attempt + 1, exc


### PR DESCRIPTION
## Summary
- warn when service check responses return non-200 status codes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aae2bb0ba8832d9478a800835dce2a