### PR TITLE
Validate bcrypt rounds range

### DIFF
--- a/password_utils.py
+++ b/password_utils.py
@@ -1,12 +1,35 @@
 import os
 import bcrypt
+import logging
 import re
 import string
 
 MIN_PASSWORD_LENGTH = 8
 MAX_PASSWORD_LENGTH = 64
+DEFAULT_BCRYPT_ROUNDS = 12
+logger = logging.getLogger(__name__)
+
+
 _bcrypt_rounds_env = os.getenv("BCRYPT_ROUNDS")
-BCRYPT_ROUNDS = int(_bcrypt_rounds_env) if _bcrypt_rounds_env else 12
+if _bcrypt_rounds_env is not None:
+    try:
+        _rounds = int(_bcrypt_rounds_env)
+        if 4 <= _rounds <= 31:
+            BCRYPT_ROUNDS = _rounds
+        else:
+            logger.warning(
+                "BCRYPT_ROUNDS must be between 4 and 31; using default %d",
+                DEFAULT_BCRYPT_ROUNDS,
+            )
+            BCRYPT_ROUNDS = DEFAULT_BCRYPT_ROUNDS
+    except ValueError:
+        logger.warning(
+            "BCRYPT_ROUNDS is not an integer; using default %d",
+            DEFAULT_BCRYPT_ROUNDS,
+        )
+        BCRYPT_ROUNDS = DEFAULT_BCRYPT_ROUNDS
+else:
+    BCRYPT_ROUNDS = DEFAULT_BCRYPT_ROUNDS
 
 
 def validate_password_complexity(password: str) -> None:

--- a/tests/test_password_utils.py
+++ b/tests/test_password_utils.py
@@ -1,3 +1,6 @@
+import importlib
+import logging
+
 import pytest
 import bcrypt
 
@@ -83,4 +86,16 @@ def test_hash_password_rejects_weak_passwords(weak_password):
 def test_verify_password_accepts_existing_weak_hashes(weak_password):
     stored_hash = bcrypt.hashpw(weak_password.encode(), bcrypt.gensalt()).decode()
     assert verify_password(weak_password, stored_hash)
+
+
+def test_invalid_bcrypt_rounds_env_uses_default(monkeypatch, caplog):
+    import password_utils as pu
+
+    monkeypatch.setenv("BCRYPT_ROUNDS", "32")
+    with caplog.at_level(logging.WARNING):
+        importlib.reload(pu)
+        assert pu.BCRYPT_ROUNDS == pu.DEFAULT_BCRYPT_ROUNDS
+        assert "BCRYPT_ROUNDS" in caplog.text
+    monkeypatch.delenv("BCRYPT_ROUNDS", raising=False)
+    importlib.reload(pu)
 


### PR DESCRIPTION
## Summary
- validate BCRYPT_ROUNDS environment variable, enforcing 4-31 range and logging warnings for invalid values
- add tests for invalid BCRYPT_ROUNDS configuration

## Testing
- `pre-commit run --files password_utils.py tests/test_password_utils.py`
- `pytest -q tests/test_password_utils.py::test_invalid_bcrypt_rounds_env_uses_default`

------
https://chatgpt.com/codex/tasks/task_e_68aae2bda608832db28640201502b032