### PR TITLE
Handle curl errors in Dependabot script

### DIFF
--- a/scripts/run_dependabot.sh
+++ b/scripts/run_dependabot.sh
@@ -14,19 +14,22 @@ fi
 token="${TOKEN}"
 
 for ecosystem in pip github-actions; do
-  if ! response=$(curl --fail-with-body -S -s -X POST \
+  set +e
+  response=$(curl --fail-with-body -S -s -X POST \
     -H "Authorization: Bearer ${token}" \
     -H "Accept: application/vnd.github+json" \
     -H "Content-Type: application/json" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
     "https://api.github.com/repos/${repo}/dependabot/updates" \
-    -d "{\"package-ecosystem\":\"${ecosystem}\",\"directory\":\"/\"}"); then
-    code=$?
-    if [[ $code -eq 22 ]]; then
-      echo "Dependabot endpoint returned 404 for ${ecosystem}" >&2
-      echo "${response}" >&2
-      continue
-    fi
+    -d "{\"package-ecosystem\":\"${ecosystem}\",\"directory\":\"/\"}")
+  code=$?
+  set -e
+  if [[ $code -eq 22 ]]; then
+    echo "Dependabot endpoint returned 404 for ${ecosystem}" >&2
+    echo "${response}" >&2
+    continue
+  fi
+  if [[ $code -ne 0 ]]; then
     echo "Failed to trigger Dependabot for ${ecosystem}" >&2
     echo "${response}" >&2
     exit 1


### PR DESCRIPTION
## Summary
- improve Dependabot trigger script error handling for 404 responses

## Testing
- `TOKEN=invalid GITHUB_REPOSITORY=nonexistent/repo scripts/run_dependabot.sh && echo success`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aae3ee6a10832d8c7c952c5647c8ac