### PR TITLE
Handle specific model loading errors

### DIFF
--- a/server.py
+++ b/server.py
@@ -60,8 +60,8 @@ class ModelManager:
                 )
                 .to(device_local)
             )
-        except Exception:
-            logging.exception("Failed to load model '%s'", model_name)
+        except (OSError, ValueError) as exc:
+            logging.exception("Failed to load model '%s': %s", model_name, exc)
         else:
             self.tokenizer = tokenizer_local
             self.model = model_local
@@ -83,9 +83,11 @@ class ModelManager:
                 )
                 .to(device_local)
             )
-        except Exception:
-            logging.exception("Failed to load fallback model '%s'", fallback_model)
-            raise RuntimeError("Failed to load both primary and fallback models")
+        except (OSError, ValueError) as exc:
+            logging.exception(
+                "Failed to load fallback model '%s': %s", fallback_model, exc
+            )
+            raise RuntimeError("Failed to load both primary and fallback models") from exc
         else:
             self.tokenizer = tokenizer_local
             self.model = model_local

--- a/tests/test_server_model_loading.py
+++ b/tests/test_server_model_loading.py
@@ -4,7 +4,7 @@ import sys, types, asyncio, pytest, importlib
 class _FailingLoader:
     @staticmethod
     def from_pretrained(*args, **kwargs):
-        raise RuntimeError("fail")
+        raise OSError("fail")
 
 
 def test_load_model_async_raises_runtime_error(monkeypatch):


### PR DESCRIPTION
## Summary
- log and handle known `AutoTokenizer`/`AutoModelForCausalLM` loading failures
- raise `RuntimeError` only for known fallback failures
- adjust server model-loading test to raise `OSError`

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aae847b5a0832db7ace3cd407c53de