### PR TITLE
feat: centralize host and port validation

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -2917,16 +2917,11 @@ def ping():
 
 
 if __name__ == "__main__":
-    from bot.utils import configure_logging
+    from bot.utils import configure_logging, validate_host_port
 
     configure_logging()
     load_dotenv()
-    port = int(os.environ.get("PORT", "8000"))
-    # По умолчанию слушаем только локальный интерфейс.
-    host = os.environ.get("HOST", "127.0.0.1")
-    # Prevent binding to all interfaces.
-    if host.strip() == "0.0.0.0":  # nosec B104
-        raise ValueError("HOST=0.0.0.0 запрещён из соображений безопасности")
+    host, port = validate_host_port("HOST", "PORT", 8000)
     if host != "127.0.0.1":
         logger.warning(
             "Используется не локальный хост %s; убедитесь, что это намеренно",

--- a/model_builder.py
+++ b/model_builder.py
@@ -1966,17 +1966,12 @@ def ping():
 
 
 if __name__ == "__main__":
-    from bot.utils import configure_logging
+    from bot.utils import configure_logging, validate_host_port
 
     configure_logging()
     load_dotenv()
     _load_model()
-    port = int(os.environ.get("PORT", "8001"))
-    # По умолчанию слушаем только локальный интерфейс.
-    host = os.environ.get("HOST", "127.0.0.1")
-    # Prevent binding to all interfaces.
-    if host.strip() == "0.0.0.0":  # nosec B104
-        raise ValueError("HOST=0.0.0.0 запрещён из соображений безопасности")
+    host, port = validate_host_port("HOST", "PORT", 8001)
     if host != "127.0.0.1":
         logger.warning(
             "Используется не локальный хост %s; убедитесь, что это намеренно",

--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -120,15 +120,10 @@ def too_large(_):
     return jsonify({'error': 'payload too large'}), 413
 
 if __name__ == '__main__':
-    from bot.utils import configure_logging
+    from bot.utils import configure_logging, validate_host_port
 
     configure_logging()
-    port = int(os.environ.get('PORT', '8001'))
-    # По умолчанию слушаем только локальный интерфейс.
-    host = os.environ.get('HOST', '127.0.0.1')
-    # Prevent binding to all interfaces.
-    if host.strip() == '0.0.0.0':  # nosec B104
-        raise ValueError('HOST=0.0.0.0 запрещён из соображений безопасности')
+    host, port = validate_host_port('HOST', 'PORT', 8001)
     if host != '127.0.0.1':
         app.logger.warning(
             'Используется не локальный хост %s; убедитесь, что это намеренно',

--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -290,15 +290,10 @@ def handle_unexpected_error(exc: Exception) -> tuple:
 
 
 if __name__ == '__main__':
-    from bot.utils import configure_logging
+    from bot.utils import configure_logging, validate_host_port
 
     configure_logging()
-    port = int(os.environ.get('PORT', '8002'))
-    # По умолчанию слушаем только локальный интерфейс.
-    host = os.environ.get('HOST', '127.0.0.1')
-    # Prevent binding to all interfaces.
-    if host.strip() == '0.0.0.0':  # nosec B104
-        raise ValueError('HOST=0.0.0.0 запрещён из соображений безопасности')
+    host, port = validate_host_port('HOST', 'PORT', 8002)
     if host != '127.0.0.1':
         app.logger.warning(
             'Используется не локальный хост %s; убедитесь, что это намеренно',

--- a/tests/test_integration_services.py
+++ b/tests/test_integration_services.py
@@ -9,6 +9,7 @@ import asyncio
 import pytest
 
 from tests.helpers import get_free_port, service_process
+from bot.utils import validate_host_port
 
 pytestmark = pytest.mark.integration
 
@@ -78,25 +79,19 @@ def _shutdown(*_):
 
 def _run_dh(port: int):
     signal.signal(signal.SIGTERM, _shutdown)
-    host = os.environ.get("HOST", "127.0.0.1")
-    if host.strip() == "0.0.0.0":  # nosec B104
-        raise ValueError("HOST=0.0.0.0 запрещён из соображений безопасности")
+    host, _ = validate_host_port("HOST", "PORT", port)
     dh_app.run(host=host, port=port)  # nosec B104  # host validated above
 
 
 def _run_mb(port: int):
     signal.signal(signal.SIGTERM, _shutdown)
-    host = os.environ.get("HOST", "127.0.0.1")
-    if host.strip() == "0.0.0.0":  # nosec B104
-        raise ValueError("HOST=0.0.0.0 запрещён из соображений безопасности")
+    host, _ = validate_host_port("HOST", "PORT", port)
     mb_app.run(host=host, port=port)  # nosec B104  # host validated above
 
 
 def _run_tm(port: int):
     signal.signal(signal.SIGTERM, _shutdown)
-    host = os.environ.get("HOST", "127.0.0.1")
-    if host.strip() == "0.0.0.0":  # nosec B104
-        raise ValueError("HOST=0.0.0.0 запрещён из соображений безопасности")
+    host, _ = validate_host_port("HOST", "PORT", port)
     tm_app.run(host=host, port=port)  # nosec B104  # host validated above
 
 

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -1995,17 +1995,12 @@ def ready() -> tuple:
 
 
 if __name__ == "__main__":
-    from bot.utils import configure_logging
+    from bot.utils import configure_logging, validate_host_port
 
     configure_logging()
     setup_multiprocessing()
     load_dotenv()
-    port = int(os.environ.get("PORT", "8002"))
-    # По умолчанию слушаем только локальный интерфейс.
-    host = os.environ.get("HOST", "127.0.0.1")
-    # Prevent binding to all interfaces.
-    if host.strip() == "0.0.0.0":  # nosec B104
-        raise ValueError("HOST=0.0.0.0 запрещён из соображений безопасности")
+    host, port = validate_host_port("HOST", "PORT", 8002)
     if host != "127.0.0.1":
         logger.warning(
             "Используется не локальный хост %s; убедитесь, что это намеренно",

--- a/utils.py
+++ b/utils.py
@@ -22,6 +22,42 @@ def configure_logging() -> None:
     os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "3")
 
 
+def validate_host_port(host_env: str, port_env: str, default_port: int) -> tuple[str, int]:
+    """Получить и проверить значения хоста и порта из окружения.
+
+    Параметры
+    ---------
+    host_env: str
+        Имя переменной окружения с адресом хоста.
+    port_env: str
+        Имя переменной окружения с портом.
+    default_port: int
+        Значение порта по умолчанию, используемое при ошибке парсинга.
+
+    Возвращает
+    ---------
+    tuple[str, int]
+        Кортеж из проверенного хоста и порта.
+    """
+
+    host = os.environ.get(host_env, "127.0.0.1").strip()
+    if host == "0.0.0.0":  # nosec B104
+        raise ValueError(f"{host_env}=0.0.0.0 запрещён из соображений безопасности")
+
+    port_str = os.environ.get(port_env, str(default_port))
+    try:
+        port = int(port_str)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Некорректное значение %s=%r, используется порт по умолчанию %s",
+            port_env,
+            port_str,
+            default_port,
+        )
+        port = default_port
+    return host, port
+
+
 # Hide Numba performance warnings
 try:
     from numba import jit, prange, NumbaPerformanceWarning  # type: ignore


### PR DESCRIPTION
## Summary
- add `validate_host_port` helper to ensure safe host and port parsing
- use `validate_host_port` in services and tests instead of manual checks

## Testing
- `pytest` *(прервано: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68aae844ca9c832d92630b1fc3abab0c