### PR TITLE
Use httpx.Client in wait_for_api loop

### DIFF
--- a/gptoss_check/check_code.py
+++ b/gptoss_check/check_code.py
@@ -21,7 +21,9 @@ def wait_for_api(api_url: str, timeout: int | None = None) -> None:
     deadline = time.time() + timeout
     while time.time() < deadline:
         try:
-            httpx.get(api_url.rstrip("/"), timeout=5, trust_env=False)
+            with httpx.Client(timeout=5, trust_env=False) as client:
+                response = client.get(api_url.rstrip("/"))
+                response.close()
             return
         except httpx.HTTPError:
             time.sleep(1)


### PR DESCRIPTION
## Summary
- prevent HTTP response leaks by using httpx.Client context manager and closing response

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aae8951680832d9a11f82472a22305