### PR TITLE
Sanitize headers before logging

### DIFF
--- a/server.py
+++ b/server.py
@@ -120,12 +120,14 @@ API_KEYS = {k.strip() for k in os.getenv("API_KEYS", "").split(",") if k.strip()
 @app.middleware("http")
 async def check_api_key(request: Request, call_next):
     auth = request.headers.get("Authorization")
+    headers = dict(request.headers)
+    headers.pop("authorization", None)
     if not auth or not auth.startswith("Bearer "):
         logging.warning(
             "Unauthorized request: method=%s url=%s headers=%s",
             request.method,
             request.url,
-            dict(request.headers),
+            headers,
         )
         return Response(status_code=401)
     token = auth[7:]
@@ -137,7 +139,7 @@ async def check_api_key(request: Request, call_next):
             "Invalid API key: method=%s url=%s headers=%s",
             request.method,
             request.url,
-            dict(request.headers),
+            headers,
         )
         return Response(status_code=401)
     return await call_next(request)


### PR DESCRIPTION
## Summary
- copy request headers and remove Authorization
- log warnings without exposing Authorization header

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aae89d0a90832daf0dcf275beac71e