### PR TITLE
feat: make HTTP client timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,9 @@ use these steps to diagnose the problem:
 7. Use an async-capable worker for `gunicorn` (e.g. `--worker-class
    uvicorn.workers.UvicornWorker`) so async views like the trade
    manager's `/open_position` route can schedule tasks properly.
+8. To change the timeout for outgoing HTTP requests, set
+   `HTTP_CLIENT_TIMEOUT` in your environment (defaults to `5`
+   seconds).
 
 ## Telegram notifications
 

--- a/tests/test_trading_bot.py
+++ b/tests/test_trading_bot.py
@@ -8,6 +8,21 @@ import httpx
 
 
 @pytest.mark.asyncio
+async def test_get_http_client_timeout_env(monkeypatch):
+    monkeypatch.delenv("HTTP_CLIENT_TIMEOUT", raising=False)
+    monkeypatch.setattr(trading_bot, "HTTP_CLIENT", None)
+    monkeypatch.setenv("HTTP_CLIENT_TIMEOUT", "7")
+
+    client = trading_bot.get_http_client()
+    try:
+        assert client.timeout.connect == 7.0
+        assert client.timeout.read == 7.0
+    finally:
+        await client.aclose()
+        trading_bot.HTTP_CLIENT = None
+
+
+@pytest.mark.asyncio
 async def test_send_telegram_alert_reuses_client(monkeypatch):
     calls = []
 

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -179,10 +179,15 @@ HTTP_CLIENT: httpx.AsyncClient | None = None
 
 
 def get_http_client() -> httpx.AsyncClient:
-    """Return a shared HTTP client instance."""
+    """Return a shared HTTP client instance.
+
+    Timeout for requests can be configured via the ``HTTP_CLIENT_TIMEOUT``
+    environment variable (default 5 seconds).
+    """
     global HTTP_CLIENT
     if HTTP_CLIENT is None:
-        HTTP_CLIENT = httpx.AsyncClient(trust_env=False)
+        timeout = safe_float("HTTP_CLIENT_TIMEOUT", 5.0)
+        HTTP_CLIENT = httpx.AsyncClient(trust_env=False, timeout=timeout)
     return HTTP_CLIENT
 
 


### PR DESCRIPTION
## Summary
- allow configuring HTTP timeout via `HTTP_CLIENT_TIMEOUT`
- document new environment variable
- test timeout handling in `get_http_client`

## Testing
- `pre-commit run --files trading_bot.py tests/test_trading_bot.py README.md`
- `pytest tests/test_trading_bot.py::test_get_http_client_timeout_env -q`


------
https://chatgpt.com/codex/tasks/task_e_68aae896de4c832d9c78ba991f1e23a9