### PR TITLE
Ensure API_KEYS environment variable is required

### DIFF
--- a/server.py
+++ b/server.py
@@ -116,6 +116,12 @@ app = FastAPI(lifespan=lifespan)
 
 API_KEYS = {k.strip() for k in os.getenv("API_KEYS", "").split(",") if k.strip()}
 
+if not API_KEYS:
+    logging.error(
+        "No API keys provided; set the API_KEYS environment variable with at least one key."
+    )
+    raise RuntimeError("API_KEYS environment variable is required")
+
 
 @app.middleware("http")
 async def check_api_key(request: Request, call_next):

--- a/tests/test_server_missing_api_keys.py
+++ b/tests/test_server_missing_api_keys.py
@@ -1,0 +1,13 @@
+import importlib
+import sys
+import os
+import pytest
+
+
+def test_missing_api_keys_causes_startup_failure(monkeypatch):
+    monkeypatch.delenv("API_KEYS", raising=False)
+    sys.modules.pop("server", None)
+    with pytest.raises(RuntimeError, match="API_KEYS environment variable is required"):
+        importlib.import_module("server")
+    sys.modules.pop("server", None)
+    os.environ["API_KEYS"] = "testkey"

--- a/tests/test_server_model_loading.py
+++ b/tests/test_server_model_loading.py
@@ -1,4 +1,6 @@
-import sys, types, asyncio, pytest, importlib
+import sys, types, asyncio, pytest, importlib, os
+
+os.environ["API_KEYS"] = "testkey"
 
 
 class _FailingLoader:


### PR DESCRIPTION
## Summary
- halt server startup when API_KEYS is missing
- clarify missing API_KEYS requirement in model-loading test
- add test confirming API_KEYS is mandatory

## Testing
- `pytest tests/test_server_missing_api_keys.py tests/test_server_model_loading.py tests/test_server_auth.py tests/test_server_request_validation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aae8a1ea28832dbc2853da921ace76