### PR TITLE
chore: remove manual dependabot step

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -18,11 +18,6 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v4
         with:
           persist-credentials: false
-      - name: Run Dependabot
-        run: scripts/run_dependabot.sh
-        env:
-          TOKEN: ${{ secrets.TOKEN }}
-          # TOKEN must have repo and security_events scopes
       - name: Dependabot Action
         if: github.actor == 'dependabot[bot]'
         uses: github/dependabot-action@8a8ecd4a2ccff00ad1680d32caef59634c31d3c0


### PR DESCRIPTION
## Summary
- remove obsolete manual dependabot execution step

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml` *(fails: module 'bot.utils' has no attribute 'validate_host')*

------
https://chatgpt.com/codex/tasks/task_e_68aaea2649c0832d87c1ed05accf561a