### PR TITLE
chore: remove GitHub registry proxy

### DIFF
--- a/github_registries_proxy.json
+++ b/github_registries_proxy.json
@@ -1,6 +1,3 @@
 {
-  "pip": {
-    "http": "http://proxy.example:8080",
-    "https": "http://proxy.example:8080"
-  }
+  "pip": {}
 }


### PR DESCRIPTION
## Summary
- remove unused GitHub registry proxy config

## Testing
- `pre-commit run --files github_registries_proxy.json` *(fails: TypeError: not enough arguments for format string; AttributeError: module 'bot.utils' has no attribute 'validate_host')*
- `scripts/run_dependabot.sh` *(fails: GITHUB_REPOSITORY is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68aaee3145d8832d82aeaaeba55f0817