### PR TITLE
Initialize host and port before TradeManager startup

### DIFF
--- a/trade_manager.py
+++ b/trade_manager.py
@@ -75,6 +75,7 @@ from bot.utils import (
     is_cuda_available,
     check_dataframe_empty_async as _check_df_async,
     safe_api_call,
+    configure_logging,
 )
 from bot.config import BotConfig, load_config
 import contextlib
@@ -1999,5 +2000,7 @@ if __name__ == "__main__":
     configure_logging()
     setup_multiprocessing()
     load_dotenv()
+    host = os.getenv("HOST", "0.0.0.0")
+    port = int(os.getenv("PORT", "8002"))
     logger.info("Запуск сервиса TradeManager на %s:%s", host, port)
     api_app.run(host=host, port=port)  # nosec B104  # хост проверен выше


### PR DESCRIPTION
## Summary
- import `configure_logging` into `trade_manager`
- define `host` and `port` from environment before logging service start

## Testing
- `pytest tests/test_trade_manager_routes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaef0f34b0832db20489e5c5cc6896