### PR TITLE
Define host for integration service tests

### DIFF
--- a/tests/test_integration_services.py
+++ b/tests/test_integration_services.py
@@ -16,6 +16,9 @@ if sys.platform == "win32":
     multiprocessing.set_start_method("spawn", force=True)
 ctx = multiprocessing.get_context("spawn")
 
+# Default host for test services
+host = "127.0.0.1"
+
 
 
 


### PR DESCRIPTION
## Summary
- define fixed host value for integration service tests
- ensure data handler, model builder, and trade manager stubs use declared host

## Testing
- `pytest tests/test_integration_services.py::test_services_communicate -q -m integration`


------
https://chatgpt.com/codex/tasks/task_e_68aaef0dd948832db3c5d2e16f9443fa