### PR TITLE
Define host and port in DataHandler

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -77,6 +77,10 @@ from bot.utils import (
     safe_api_call,
 )
 
+# Network configuration
+host = os.getenv("HOST", "0.0.0.0")
+port = int(os.getenv("PORT", "8000"))
+
 PROFILE_DATA_HANDLER = os.getenv("DATA_HANDLER_PROFILE") == "1"
 
 


### PR DESCRIPTION
## Summary
- Initialize `host` and `port` from environment at module load
- Use these values in the startup logging and server run call

## Testing
- `pytest tests/test_data_handler.py::test_price_endpoint_returns_default -q`
- `pytest tests/test_utils.py::test_validate_host_default -q` *(fails: AttributeError: module 'bot.utils' has no attribute 'validate_host')*


------
https://chatgpt.com/codex/tasks/task_e_68aaef06c104832d8f516df3b0582201