### PR TITLE
feat: add Dependabot workflow with proxy config

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,22 @@
+name: Dependabot
+
+on:
+  workflow_dispatch:
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Read registries proxy
+        id: read_proxy
+        run: |
+          echo "json=$(jq -c '.' github_registries_proxy.json)" >> $GITHUB_OUTPUT
+
+      - name: Run Dependabot
+        uses: github/dependabot-action@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REGISTRIES_PROXY: "${{ steps.read_proxy.outputs.json }}"


### PR DESCRIPTION
## Summary
- add workflow invoking github/dependabot-action with registry proxy
- read proxy JSON via jq and pass to action

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml --hook-stage manual`
- `jq -e '.' github_registries_proxy.json`
- `act workflow_dispatch -j dependabot -s GITHUB_TOKEN=ghp_dummy` *(fails: Couldn't get a valid docker connection)*
- `pytest` *(fails: AttributeError: module 'bot.utils' has no attribute 'validate_host')*

------
https://chatgpt.com/codex/tasks/task_e_68aaee304c18832dbd8ea05a6db380cd