### PR TITLE
Исправить установку python3 в Dockerfile runtime образа

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,10 +77,10 @@ COPY --from=builder /app/venv /app/venv
 
 # Установка минимальных пакетов выполнения
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
-    python3-minimal \
+    python3 \
+    libpython3.12-stdlib \
     libssl3t64 \
     zlib1g \
-    python3-minimal \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && ldconfig \
     && /app/venv/bin/python --version \


### PR DESCRIPTION
## Summary
- replace `python3-minimal` with `python3` and add `libpython3.12-stdlib`
- remove duplicate `python3-minimal` entry in runtime image setup

## Testing
- `pre-commit run --files Dockerfile` *(fails: ImportError: cannot import name 'configure_logging' from 'utils')*
- `python3 -c "import ccxt, torch, ray, optuna, shap, numba; print(ccxt.__version__, torch.__version__, ray.__version__, optuna.__version__, shap.__version__, numba.__version__)"`
- `docker build -t bot:latest .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf4641d98832d896583d8f606c373