### PR TITLE
Use validated host and safe port in model builder service

### DIFF
--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -14,6 +14,7 @@ from dotenv import load_dotenv
 from sklearn.linear_model import LogisticRegression
 
 load_dotenv()
+from utils import validate_host, safe_int
 
 app = Flask(__name__)
 app.config["MAX_CONTENT_LENGTH"] = 1 * 1024 * 1024  # 1 MB limit
@@ -118,6 +119,9 @@ def ping() -> tuple:
 @app.errorhandler(413)
 def too_large(_):
     return jsonify({'error': 'payload too large'}), 413
+
+host = validate_host()
+port = safe_int(os.getenv("PORT", "8000"))
 
 if __name__ == '__main__':
     app.logger.info('Запуск сервиса ModelBuilder на %s:%s', host, port)


### PR DESCRIPTION
## Summary
- load utils helpers after dotenv for host and port parsing
- initialize host and port using validation helpers before starting service

## Testing
- `pre-commit run --files services/model_builder_service.py` *(fails: ImportError: cannot import name 'configure_logging' from 'utils')*

------
https://chatgpt.com/codex/tasks/task_e_68aaf5dd7ef8832da8dc519be7bae402