### PR TITLE
chore: schedule dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,7 +1,8 @@
 name: Dependabot
 
 on:
-  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   dependabot:


### PR DESCRIPTION
## Summary
- run Dependabot action on a daily schedule

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf90097ec832dbeb588090bd07faa