### PR TITLE
fix: set GitHub token for dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,5 +1,9 @@
 name: Dependabot
 
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   workflow_dispatch:
 
@@ -18,5 +22,5 @@ jobs:
       - name: Run Dependabot
         uses: github/dependabot-action@main
         env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REGISTRIES_PROXY: "${{ secrets.AVERINALEKS }}"


### PR DESCRIPTION
## Summary
- use `secrets.GITHUB_TOKEN` in Dependabot workflow
- add write permissions for contents and pull requests

## Testing
- `pre-commit run --hook-stage manual --files .github/workflows/dependabot.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aaf906fd6c832da16eb61155d974ae