### PR TITLE
Validate TradeManager service host and port

### DIFF
--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -10,7 +10,7 @@ import ccxt
 import os
 from dotenv import load_dotenv
 import logging
-import argparse
+from utils import validate_host, safe_int
 
 logging.basicConfig(level=logging.INFO)
 
@@ -291,13 +291,8 @@ def handle_unexpected_error(exc: Exception) -> tuple:
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Run TradeManager service')
-    parser.add_argument('--host', default=os.getenv('TRADE_MANAGER_HOST', '0.0.0.0'))
-    parser.add_argument('--port', type=int, default=int(os.getenv('TRADE_MANAGER_PORT', '8000')))
-    args = parser.parse_args()
-
-    host = args.host
-    port = args.port
+    host = validate_host(os.getenv("TRADE_MANAGER_HOST"))
+    port = safe_int(os.getenv("TRADE_MANAGER_PORT", "8000"))
 
     init_exchange()
     app.logger.info('Запуск сервиса TradeManager на %s:%s', host, port)


### PR DESCRIPTION
## Summary
- validate TradeManager host using `validate_host`
- parse port safely via `safe_int` and drop `argparse`
- run bandit to ensure no B104 warning

## Testing
- `bandit services/trade_manager_service.py`
- `pytest -q` *(fails: ImportError: cannot import name 'configure_logging' from 'utils')*

------
https://chatgpt.com/codex/tasks/task_e_68aaf90da424832dbd1a02f52e4f6963