### PR TITLE
feat: enforce safe host default

### DIFF
--- a/tests/test_trade_manager_routes.py
+++ b/tests/test_trade_manager_routes.py
@@ -5,6 +5,7 @@ import inspect
 import asyncio
 import concurrent.futures
 import logging
+import pytest
 
 
 class DummyLoop:
@@ -130,3 +131,17 @@ def test_open_position_route_concurrent(monkeypatch):
     assert len(loop.calls) == 5
     for _, call_args in loop.calls:
         call_args[0].close()
+
+
+def test_resolve_host_defaults_to_local(monkeypatch):
+    tm, _, _ = _setup_module(monkeypatch)
+    monkeypatch.delenv("HOST", raising=False)
+    host = tm._resolve_host()
+    assert host == "127.0.0.1"
+
+
+def test_resolve_host_rejects_all_interfaces(monkeypatch):
+    tm, _, _ = _setup_module(monkeypatch)
+    monkeypatch.setenv("HOST", "0.0.0.0")
+    with pytest.raises(SystemExit):
+        tm._resolve_host()


### PR DESCRIPTION
## Summary
- ensure TradeManager binds to localhost by default and validates explicit HOST
- test host resolution for safe and unsafe addresses

## Testing
- `pytest tests/test_trade_manager_routes.py::test_open_position_route_schedules_task tests/test_trade_manager_routes.py::test_start_route_schedules_run tests/test_trade_manager_routes.py::test_stats_route_returns_data tests/test_trade_manager_routes.py::test_open_position_route_concurrent -q`
- `pytest tests/test_trade_manager_routes.py::test_resolve_host_defaults_to_local tests/test_trade_manager_routes.py::test_resolve_host_rejects_all_interfaces -q`
- `pre-commit run --files trade_manager.py tests/test_trade_manager_routes.py` *(fails: ImportError: cannot import name 'configure_logging' from 'utils')*

------
https://chatgpt.com/codex/tasks/task_e_68aafbe26828832dba7e4a5358ab287a