### PR TITLE
Define host and port for trade manager service

### DIFF
--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -290,6 +290,9 @@ def handle_unexpected_error(exc: Exception) -> tuple:
     return jsonify({'error': 'internal server error'}), 500
 
 
+host = validate_host()
+port = safe_int(os.getenv("PORT", "8002"))
+
 if __name__ == '__main__':
 
     init_exchange()


### PR DESCRIPTION
## Summary
- ensure trade_manager_service declares `host` and `port` before use

## Testing
- `pre-commit run --files services/trade_manager_service.py` *(fails: ImportError: cannot import name 'configure_logging' from 'utils')*
- `flake8 services/trade_manager_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab00f4d86c832d81fef45700b8c83c