### PR TITLE
Define host in DataHandler service

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -79,6 +79,7 @@ from bot.utils import (
 
 # Network configuration
 port = int(os.getenv("PORT", "8000"))
+host = os.getenv("HOST", "127.0.0.1")
 
 PROFILE_DATA_HANDLER = os.getenv("DATA_HANDLER_PROFILE") == "1"
 


### PR DESCRIPTION
## Summary
- read `HOST` from environment for DataHandler service

## Testing
- `flake8 data_handler.py`
- `pytest -q` *(fails: cannot import name 'configure_logging' from 'utils')*

------
https://chatgpt.com/codex/tasks/task_e_68ab00f631e4832db021960d0e8948ce