### PR TITLE
Ensure cache directory exists before disk usage check

### DIFF
--- a/trade_manager.py
+++ b/trade_manager.py
@@ -345,6 +345,7 @@ class TradeManager:
         ):
             return
         try:
+            os.makedirs(self.config["cache_dir"], exist_ok=True)
             disk_usage = shutil.disk_usage(self.config["cache_dir"])
             if disk_usage.free / (1024**3) < 0.5:
                 logger.warning(


### PR DESCRIPTION
## Summary
- create cache directory before checking disk usage in TradeManager.save_state

## Testing
- `pytest -q tests/test_trade_manager.py::test_compute_stats`
- `pytest -q` *(fails: ImportError: cannot import name 'configure_logging' from 'utils')*

------
https://chatgpt.com/codex/tasks/task_e_68ab01f61080832d959db9374c005547