### PR TITLE
Handle missing Telegram config

### DIFF
--- a/trade_manager.py
+++ b/trade_manager.py
@@ -199,11 +199,16 @@ class TradeManager:
             logger.warning(
                 "TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID not set; Telegram alerts will not be sent"
             )
-        self.telegram_logger = TelegramLogger(
-            telegram_bot,
-            chat_id,
-            max_queue_size=config.get("telegram_queue_size"),
-        )
+            self.telegram_logger = types.SimpleNamespace(
+                info=lambda *a, **k: None,
+                warning=lambda *a, **k: None,
+            )
+        else:
+            self.telegram_logger = TelegramLogger(
+                telegram_bot,
+                chat_id,
+                max_queue_size=config.get("telegram_queue_size"),
+            )
         self.positions = pd.DataFrame(
             columns=[
                 "symbol",


### PR DESCRIPTION
## Summary
- provide a no-op logger when Telegram config is absent
- otherwise instantiate the regular TelegramLogger

## Testing
- `pre-commit run --files trade_manager.py` *(fails: ImportError: cannot import name 'configure_logging' from 'utils')*

------
https://chatgpt.com/codex/tasks/task_e_68ab020f64ac832dac631e94cb80030c