### PR TITLE
Validate HOST environment variable with ipaddress

### DIFF
--- a/trade_manager.py
+++ b/trade_manager.py
@@ -12,6 +12,7 @@ import sys
 import types
 import json
 import logging
+import ipaddress
 import aiohttp
 
 try:  # pragma: no cover - optional dependency
@@ -2009,8 +2010,13 @@ def _resolve_host() -> str:
             "HOST не установлен, используется 127.0.0.1. Укажите HOST для внешнего доступа",
         )
         return "127.0.0.1"
-    if host_env in {"0.0.0.0", "::"}:
-        logger.error("Небезопасный HOST %s без явной конфигурации", host_env)
+    try:
+        ip = ipaddress.ip_address(host_env)
+        if ip.is_unspecified:
+            logger.error("Небезопасный HOST %s без явной конфигурации", host_env)
+            raise SystemExit(1)
+    except ValueError:
+        logger.error("Некорректное значение HOST %s", host_env)
         raise SystemExit(1)
     return host_env
 


### PR DESCRIPTION
## Summary
- validate HOST using ipaddress for safer configurations

## Testing
- `pytest tests/test_trade_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab02bf7074832daa6a6ba3e17ee0e0