### PR TITLE
chore: prune docker artifacts after trivy scan

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -110,5 +110,6 @@ jobs:
           path: trivy-results.sarif
       - name: Cleanup after Trivy scan
         run: |
+          docker system prune -af || true
           rm -rf /mnt/trivy-cache /mnt/trivy-temp ~/.cache/trivy || true
           sudo rm -rf /tmp/* || true

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -47,7 +47,6 @@ ENV PIP_BREAK_SYSTEM_PACKAGES=1
 RUN apt-get update && apt-get install --no-install-recommends -y \
     libssl3t64=3.0.13-0ubuntu3.5 \
     python3.12-minimal=3.12.3-1ubuntu0.8 \
-    python3=3.12.3-0ubuntu2 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
## Summary
- clean up docker artifacts after Trivy scan
- slim runtime stage by dropping python3 package

## Testing
- `pre-commit run flake8 --files .github/workflows/trivy.yml Dockerfile.ci`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab27a010f8832d987ed17536c756e3