### PR TITLE
chore: drop gpu from CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        device: [cpu, gpu]
+        device: [cpu]
     steps:
       - name: Initial cleanup
         run: docker system prune -af && sudo rm -rf /tmp/*
@@ -69,18 +69,14 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /mnt/venv
-          key: ${{ runner.os }}-venv-${{ matrix.device }}-${{ hashFiles('requirements-ci.txt', 'requirements-cpu.txt', 'requirements-gpu.txt') }}
+          key: ${{ runner.os }}-venv-${{ matrix.device }}-${{ hashFiles('requirements-ci.txt', 'requirements-cpu.txt') }}
       - name: Set up virtual environment
         run: |
           if [ ! -d /mnt/venv ]; then
             python -m venv /mnt/venv
             source /mnt/venv/bin/activate
             pip install --no-cache-dir -r requirements-ci.txt
-            if [ "${{ matrix.device }}" = "gpu" ]; then
-              pip install --no-cache-dir -r requirements-gpu.txt
-            else
-              pip install --no-cache-dir -r requirements-cpu.txt
-            fi
+            pip install --no-cache-dir -r requirements-cpu.txt
           fi
           echo "/mnt/venv/bin" >> $GITHUB_PATH
       - name: Run flake8
@@ -101,7 +97,7 @@ jobs:
     needs: unit
     strategy:
       matrix:
-        device: [cpu, gpu]
+        device: [cpu]
     steps:
       - name: Initial cleanup
         run: docker system prune -af && sudo rm -rf /tmp/*
@@ -151,18 +147,14 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /mnt/venv
-          key: ${{ runner.os }}-venv-${{ matrix.device }}-${{ hashFiles('requirements-ci.txt', 'requirements-cpu.txt', 'requirements-gpu.txt') }}
+          key: ${{ runner.os }}-venv-${{ matrix.device }}-${{ hashFiles('requirements-ci.txt', 'requirements-cpu.txt') }}
       - name: Set up virtual environment
         run: |
           if [ ! -d /mnt/venv ]; then
             python -m venv /mnt/venv
             source /mnt/venv/bin/activate
             pip install --no-cache-dir -r requirements-ci.txt
-            if [ "${{ matrix.device }}" = "gpu" ]; then
-              pip install --no-cache-dir -r requirements-gpu.txt
-            else
-              pip install --no-cache-dir -r requirements-cpu.txt
-            fi
+            pip install --no-cache-dir -r requirements-cpu.txt
           fi
           echo "/mnt/venv/bin" >> $GITHUB_PATH
       - name: Remove test caches


### PR DESCRIPTION
## Summary
- run CI only on CPU and install cpu-only requirements

## Testing
- `pytest -m "not integration"` *(fails: ImportError: cannot import name 'HistoricalDataCache' and others)*
- `act -n -j unit -W .github/workflows/ci.yml` *(fails: no valid docker connection)*

------
https://chatgpt.com/codex/tasks/task_e_68ab28056d08832da025b955afc13267