### PR TITLE
ci: ensure cache directory exists before caching

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -74,9 +74,19 @@ jobs:
           sudo rm -rf /mnt/trivy-cache /mnt/trivy-temp || true
           rm -rf ~/.cache/trivy || true
 
+      - name: Prepare Trivy cache directory
+        run: mkdir -p /mnt/trivy-cache
+
+      - name: Cache Trivy vulnerability database
+        uses: actions/cache@v4
+        with:
+          path: /mnt/trivy-cache
+          key: ${{ runner.os }}-trivy-cache-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-trivy-cache-
+
       - name: Create Trivy directories
         run: |
-          mkdir -p /mnt/trivy-cache
           mkdir -p /mnt/trivy-temp
 
       - name: Run Trivy vulnerability scanner


### PR DESCRIPTION
## Summary
- ensure Trivy cache folder exists before caching

## Testing
- `pre-commit run --files .github/workflows/trivy.yml` *(failed: cannot import name 'configure_logging' from 'utils')*
- `pytest -q` *(failed: cannot import name 'configure_logging' from 'utils')*

------
https://chatgpt.com/codex/tasks/task_e_68ab279d726c832d98497d2914d33162