### PR TITLE
Reset HTTP client after closing

### DIFF
--- a/tests/test_trading_bot.py
+++ b/tests/test_trading_bot.py
@@ -23,6 +23,23 @@ async def test_get_http_client_timeout_env(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_close_http_client_resets_global(monkeypatch):
+    class DummyClient:
+        def __init__(self):
+            self.closed = False
+
+        async def aclose(self):
+            self.closed = True
+
+    dummy = DummyClient()
+    monkeypatch.setattr(trading_bot, "HTTP_CLIENT", dummy)
+    monkeypatch.setattr(trading_bot, "_TASKS", set())
+    await trading_bot.close_http_client()
+    assert dummy.closed
+    assert trading_bot.HTTP_CLIENT is None
+
+
+@pytest.mark.asyncio
 async def test_send_telegram_alert_reuses_client(monkeypatch):
     calls = []
 

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -193,9 +193,11 @@ def get_http_client() -> httpx.AsyncClient:
 
 async def close_http_client() -> None:
     """Close the module-level HTTP client if it exists."""
+    global HTTP_CLIENT
     await shutdown_async_tasks()
     if HTTP_CLIENT is not None:
         await HTTP_CLIENT.aclose()
+        HTTP_CLIENT = None
 
 
 


### PR DESCRIPTION
## Summary
- Reset the shared HTTP client after closing to allow recreation.
- Add regression test ensuring HTTP client is cleared and closed.

## Testing
- `pytest tests/test_run_async.py::test_close_http_client_shuts_down_tasks tests/test_trading_bot.py::test_close_http_client_resets_global -q`
- `pytest -q` *(fails: cannot import name 'configure_logging' from 'utils')*


------
https://chatgpt.com/codex/tasks/task_e_68ab294492f4832da80c1883d7a956ab