### PR TITLE
Move load_dotenv() calls to runtime entry points

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -77,10 +77,7 @@ from bot.utils import (
     safe_api_call,
 )
 
-# Network configuration
-port = int(os.getenv("PORT", "8000"))
-host = os.getenv("HOST", "127.0.0.1")
-
+# Profiling configuration
 PROFILE_DATA_HANDLER = os.getenv("DATA_HANDLER_PROFILE") == "1"
 
 
@@ -2921,5 +2918,8 @@ def ping():
 
 
 if __name__ == "__main__":
+    load_dotenv()
+    host = os.getenv("HOST", "127.0.0.1")
+    port = int(os.getenv("PORT", "8000"))
     logger.info("Запуск сервиса DataHandler на %s:%s", host, port)
     api_app.run(host=host, port=port)  # nosec B104  # хост проверен выше

--- a/services/data_handler_service.py
+++ b/services/data_handler_service.py
@@ -4,8 +4,6 @@ import logging
 import ccxt
 import os
 from dotenv import load_dotenv
-
-load_dotenv()
 app = Flask(__name__)
 app.config["MAX_CONTENT_LENGTH"] = 1 * 1024 * 1024  # 1 MB limit
 
@@ -74,3 +72,11 @@ def handle_unexpected_error(exc: Exception) -> tuple:
     """Log unexpected errors and return a 500 response."""
     logging.exception("Unhandled error: %s", exc)
     return jsonify({'error': 'internal server error'}), 500
+
+
+if __name__ == "__main__":
+    load_dotenv()
+    host = os.getenv("HOST", "127.0.0.1")
+    port = int(os.getenv("PORT", "8000"))
+    app.logger.info('Запуск сервиса DataHandlerService на %s:%s', host, port)
+    app.run(host=host, port=port)

--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -12,8 +12,6 @@ import os
 from pathlib import Path
 from dotenv import load_dotenv
 from sklearn.linear_model import LogisticRegression
-
-load_dotenv()
 from utils import validate_host, safe_int
 
 app = Flask(__name__)
@@ -120,10 +118,10 @@ def ping() -> tuple:
 def too_large(_):
     return jsonify({'error': 'payload too large'}), 413
 
-host = validate_host()
-port = safe_int(os.getenv("PORT", "8000"))
-
 if __name__ == '__main__':
+    load_dotenv()
+    host = validate_host()
+    port = safe_int(os.getenv("PORT", "8000"))
     app.logger.info('Запуск сервиса ModelBuilder на %s:%s', host, port)
     _load_model()
     app.run(host=host, port=port)  # nosec B104  # host validated above

--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -14,8 +14,6 @@ from utils import validate_host, safe_int
 
 logging.basicConfig(level=logging.INFO)
 
-load_dotenv()
-
 app = Flask(__name__)
 app.config["MAX_CONTENT_LENGTH"] = 1 * 1024 * 1024  # 1 MB limit
 
@@ -290,11 +288,11 @@ def handle_unexpected_error(exc: Exception) -> tuple:
     return jsonify({'error': 'internal server error'}), 500
 
 
-host = validate_host()
-port = safe_int(os.getenv("PORT", "8002"))
-
 if __name__ == '__main__':
 
+    load_dotenv()
+    host = validate_host()
+    port = safe_int(os.getenv("PORT", "8002"))
     init_exchange()
     app.logger.info('Запуск сервиса TradeManager на %s:%s', host, port)
     app.run(host=host, port=port)  # nosec B104  # host validated above

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -1921,8 +1921,7 @@ def _initialize_trade_manager() -> None:
         raise
 
 
-# Load environment variables when the module is imported
-load_dotenv()
+# Set ready event immediately in test mode
 if os.getenv("TEST_MODE") == "1":
     _ready_event.set()
 


### PR DESCRIPTION
## Summary
- remove global load_dotenv usage from trade manager and services
- invoke load_dotenv within main blocks for data handler and services

## Testing
- `pytest -q` *(fails: cannot import name 'configure_logging' from 'utils')*


------
https://chatgpt.com/codex/tasks/task_e_68ab28e0cd50832d97fb27b92c58df21