### PR TITLE
Указать требуемую версию Python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ description = "Пример торгового бота на Python."
 readme = "README.md"
 license = "MIT"
 authors = [{ name = "Project Authors" }]
+requires-python = ">=3.10"
+classifiers = ["Programming Language :: Python :: 3"]
 dependencies = ["flask>=3.0.2"]
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary
- add requires-python and Python classifier to project metadata

## Testing
- `pytest` *(fails: ImportError: cannot import name 'configure_logging' from 'utils')*

------
https://chatgpt.com/codex/tasks/task_e_68ab2e6f3fd8832d8e3f5e171862f16a