### PR TITLE
chore: update GPU requirements

### DIFF
--- a/requirements-gpu.in
+++ b/requirements-gpu.in
@@ -1,5 +1,5 @@
 cupy-cuda12x>=13.5.1
 vllm>=0.10.0
-torch==2.7.1
+torch==2.8.0
 tensorflow==2.20.0
 jsonschema==4.25.1

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -71,20 +71,20 @@ networkx==3.5
 ninja==1.13.0
 numba==0.61.2
 numpy==2.2.6
-nvidia-cublas-cu12==12.6.4.1
-nvidia-cuda-cupti-cu12==12.6.80
-nvidia-cuda-nvrtc-cu12==12.6.77
-nvidia-cuda-runtime-cu12==12.6.77
-nvidia-cudnn-cu12==9.5.1.17
-nvidia-cufft-cu12==11.3.0.4
-nvidia-cufile-cu12==1.11.1.6
-nvidia-curand-cu12==10.3.7.77
-nvidia-cusolver-cu12==11.7.1.2
-nvidia-cusparse-cu12==12.5.4.2
-nvidia-cusparselt-cu12==0.6.3
-nvidia-nccl-cu12==2.26.2
-nvidia-nvjitlink-cu12==12.6.85
-nvidia-nvtx-cu12==12.6.77
+nvidia-cublas-cu12
+nvidia-cuda-cupti-cu12
+nvidia-cuda-nvrtc-cu12
+nvidia-cuda-runtime-cu12
+nvidia-cudnn-cu12
+nvidia-cufft-cu12
+nvidia-cufile-cu12
+nvidia-curand-cu12
+nvidia-cusolver-cu12
+nvidia-cusparse-cu12
+nvidia-cusparselt-cu12
+nvidia-nccl-cu12
+nvidia-nvjitlink-cu12
+nvidia-nvtx-cu12
 openai==1.100.2
 openai-harmony==0.0.4
 opencv-python-headless==4.12.0.88
@@ -138,9 +138,9 @@ tensorflow==2.20.0
 termcolor==3.1.0
 tiktoken==0.11.0
 tokenizers==0.21.4
-torch==2.7.1 --index-url https://download.pytorch.org/whl/cu121
-torchaudio==2.7.1 --index-url https://download.pytorch.org/whl/cu121
-torchvision==0.22.1 --index-url https://download.pytorch.org/whl/cu121
+torch==2.8.0 --index-url https://download.pytorch.org/whl/cu121
+torchaudio==2.8.0 --index-url https://download.pytorch.org/whl/cu121
+torchvision==0.23.0 --index-url https://download.pytorch.org/whl/cu121
 tqdm==4.67.1
 transformers==4.55.3
 triton==3.3.1


### PR DESCRIPTION
## Summary
- upgrade torch to 2.8.0 in GPU requirements
- drop hard pins for nvidia CUDA packages

## Testing
- `pip-compile --upgrade requirements-gpu.in` (fails: cannot satisfy vllm's torch==2.7.1 requirement)
- `pytest -q` (fails: ImportError: cannot import name 'configure_logging' from 'utils')

------
https://chatgpt.com/codex/tasks/task_e_68ab2dd33a98832dab2143abdd80269a