### PR TITLE
Simplify feed method in SafeHTMLParser

### DIFF
--- a/safe_html_parser.py
+++ b/safe_html_parser.py
@@ -53,12 +53,11 @@ class SafeHTMLParser(HTMLParser):
         data: str
             Chunk of HTML data to process.
         """
-        encoded = data.encode("utf-8")
-        byte_length = len(encoded)
+        byte_length = len(data.encode("utf-8"))
         self._fed += byte_length
         if self._fed > self._max_feed_size:
             raise ValueError("HTML input exceeds maximum allowed size")
-        super().feed(encoded.decode("utf-8"))
+        super().feed(data)
 
     def close(self) -> None:  # type: ignore[override]
         """Finalize parsing and reset internal byte counter.


### PR DESCRIPTION
## Summary
- Avoid unnecessary UTF-8 encode/decode in `SafeHTMLParser.feed`

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'tenacity', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2edf011c832d8e11881f280cc7b2