### PR TITLE
Ensure Telegram worker finalizes queue task on send errors

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -493,8 +493,12 @@ class TelegramLogger(logging.Handler):
             if chat_id is None:
                 queue.task_done()
                 return
-            await self._send(text, chat_id, urgent)
-            queue.task_done()
+            try:
+                await self._send(text, chat_id, urgent)
+            except Exception:
+                logger.exception("Ошибка отправки сообщения в Telegram")
+            finally:
+                queue.task_done()
             await asyncio.sleep(1)
 
     async def _send(self, message: str, chat_id: int | str, urgent: bool):


### PR DESCRIPTION
## Summary
- log exceptions in Telegram worker and always call `queue.task_done`

## Testing
- `pytest` *(fails: bot.gpt_client.GPTClientError: Invalid GPT_OSS_API host)*
- `pre-commit run --files utils.py` *(fails: bot.gpt_client.GPTClientError: Invalid GPT_OSS_API host)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2ee90014832da3d6ec4a162fd721