### PR TITLE
chore: activate venv in pypi workflow

### DIFF
--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -52,8 +52,11 @@ jobs:
       - name: Create virtual environment
         run: |
           python -m venv /mnt/venv && source /mnt/venv/bin/activate
+      - name: Add venv to PATH
+        run: echo "/mnt/venv/bin" >> $GITHUB_PATH
       - name: Install build tools
         run: |
+          source /mnt/venv/bin/activate
           python -m pip install --upgrade pip
           pip install build twine
       - name: Install pip-tools
@@ -79,7 +82,9 @@ jobs:
             rsync -a /mnt/project/requirements.out requirements.out
           fi
       - name: Build package
-        run: python -m build
+        run: |
+          source /mnt/venv/bin/activate
+          python -m build
       - name: Publish to PyPI
         if: env.TOKENPYPI != ''
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- ensure virtualenv path is exported in publish workflow
- activate virtualenv when installing dependencies and building the package

## Testing
- `pre-commit run flake8 --files .github/workflows/submit-pypi.yml`
- `pre-commit run --files .github/workflows/submit-pypi.yml` *(fails: Interrupted (^C): KeyboardInterrupt:)*
- `python -m venv /mnt/venv`
- `source /mnt/venv/bin/activate`
- `pip list`
- `which pip`


------
https://chatgpt.com/codex/tasks/task_e_68ab301f95e8832d89eec0c1e5490853