### PR TITLE
Add dependency lock generation in PyPI workflow

### DIFF
--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -58,6 +58,10 @@ jobs:
           pip install build twine
       - name: Install pip-tools
         run: pip install pip-tools==7.5.0
+      - name: Generate dependency lock
+        run: |
+          source /mnt/venv/bin/activate
+          pip-compile --strip-extras -o requirements.out requirements.txt
       - name: Copy project to /mnt
         run: rsync -a . /mnt/project
       - name: Check dependencies


### PR DESCRIPTION
## Summary
- generate a locked requirements file during PyPI publishing

## Testing
- `pre-commit run --files .github/workflows/submit-pypi.yml` *(interrupted)*
- `pre-commit run flake8 --files .github/workflows/submit-pypi.yml`


------
https://chatgpt.com/codex/tasks/task_e_68ab30217f88832d8529307770ee330a