### PR TITLE
Add test for invalid GPT_OSS_TIMEOUT handling

### DIFF
--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -196,6 +196,15 @@ def test_get_api_url_timeout_non_positive(monkeypatch, caplog):
     assert "Non-positive GPT_OSS_TIMEOUT value" in caplog.text
 
 
+def test_get_api_url_timeout_invalid(monkeypatch, caplog):
+    monkeypatch.setenv("GPT_OSS_API", "https://example.com")
+    monkeypatch.setenv("GPT_OSS_TIMEOUT", "abc")
+    with caplog.at_level(logging.WARNING):
+        _, timeout = _get_api_url_timeout()
+    assert timeout == 5.0
+    assert "Invalid GPT_OSS_TIMEOUT value 'abc'; defaulting to 5.0" in caplog.text
+
+
 def test_query_gpt_retry_success(monkeypatch):
     monkeypatch.setenv("GPT_OSS_API", "https://example.com")
     calls = {"count": 0}


### PR DESCRIPTION
## Summary
- warn and default to 5.0s when GPT_OSS_TIMEOUT is non-numeric

## Testing
- `pytest tests/test_gpt_client.py::test_get_api_url_timeout_invalid -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab30635078832dabc7093099143284