### PR TITLE
chore: unify torch version

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -482,7 +482,7 @@ threadpoolctl==3.6.0
     #   scikit-learn
 tokenizers==0.21.4
     # via transformers
-torch==2.7.1
+torch==2.8.0
     # via
     #   catalyst
     #   pytorch-lightning


### PR DESCRIPTION
## Summary
- unify torch version in requirements-core.txt to 2.8.0

## Testing
- `pytest` *(fails: No module named 'fastapi_csrf_protect')*
- `docker build -f Dockerfile.gptoss -t gptoss-bot:latest .` *(fails: docker command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab33dd1b84832dbf2be5a7ef803aea