### PR TITLE
chore: align openai requirement

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -293,7 +293,7 @@ nvidia-nvjitlink-cu12==12.8.93
     #   torch
 nvidia-nvtx-cu12==12.8.90
     # via torch
-openai==1.99.9
+openai==1.100.2
     # via -r requirements-core.in
 opentelemetry-api==1.36.0
     # via


### PR DESCRIPTION
## Summary
- align `openai` version in core requirements with GPU requirements

## Testing
- `pre-commit run --files requirements-core.txt requirements-gpu.txt` *(fails: interrupted during pytest)*
- `docker build -t bot-test .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3b04dd44832db7c984bd5874c971