### PR TITLE
Refactor logging configuration and improve imports

### DIFF
--- a/trade_manager.py
+++ b/trade_manager.py
@@ -16,6 +16,12 @@ import ipaddress
 import re
 import aiohttp
 
+try:  # pragma: no cover - fallback for tests
+    from dotenv import load_dotenv
+except Exception:  # pragma: no cover - stub
+    def load_dotenv(*args, **kwargs):
+        return None
+
 try:  # pragma: no cover - optional dependency
     import pandas as pd  # type: ignore
 except ImportError as exc:  # noqa: W0703 - allow missing pandas
@@ -71,14 +77,22 @@ else:
 import httpx
 from tenacity import retry, wait_exponential, stop_after_attempt
 import inspect
+# Базовые утилиты импортируются всегда
 from bot.utils import (
     logger,
     TelegramLogger,
     is_cuda_available,
     check_dataframe_empty_async as _check_df_async,
     safe_api_call,
-    configure_logging,
 )
+
+# ``configure_logging`` может отсутствовать в тестовых заглушках
+try:  # pragma: no cover - fallback для тестов
+    from bot.utils import configure_logging
+except ImportError:  # pragma: no cover - заглушка
+    def configure_logging() -> None:  # type: ignore
+        """Stubbed logging configurator."""
+        pass
 from bot.config import BotConfig, load_config
 import contextlib
 
@@ -95,7 +109,6 @@ except ImportError as exc:  # noqa: W0703 - optional dependency may not be insta
 import time
 from typing import Dict, Optional, Tuple
 import shutil
-from dotenv import load_dotenv
 from flask import Flask, request, jsonify
 if os.getenv("TEST_MODE") == "1" and not hasattr(Flask, "asgi_app"):
     Flask.asgi_app = property(lambda self: self.wsgi_app)

--- a/utils.py
+++ b/utils.py
@@ -18,10 +18,46 @@ from io import StringIO, BytesIO
 
 
 def configure_logging() -> None:
-    """Настроить переменные окружения, связанные с логированием."""
+    """Настроить переменные окружения и handlers для логирования."""
     os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "3")
 
+    level_name = os.getenv("LOG_LEVEL", "INFO").upper()
+    logger.setLevel(getattr(logging, level_name, logging.INFO))
 
+    log_dir = os.getenv("LOG_DIR", "/app/logs")
+    fallback_dir = os.path.join(os.path.dirname(__file__), "logs")
+    try:
+        os.makedirs(log_dir, exist_ok=True)
+        if not os.access(log_dir, os.W_OK):
+            raise PermissionError
+    except (OSError, PermissionError):
+        log_dir = fallback_dir
+        os.makedirs(log_dir, exist_ok=True)
+
+    if logger.handlers:
+        return
+
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+
+    file_handler = logging.FileHandler(os.path.join(log_dir, "trading_bot.log"))
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(formatter)
+    logger.addHandler(console_handler)
+
+    logger.info(
+        "Logging initialized at %s; writing logs to %s",
+        logging.getLevelName(logger.level),
+        log_dir,
+    )
+
+
+# Инициализировать логирование при импорте модуля
+configure_logging()
 
 
 # Hide Numba performance warnings
@@ -408,39 +444,6 @@ class BybitSDKAsync:
             return res.get("result", {})
 
         return await asyncio.to_thread(_sync)
-
-
-level_name = os.getenv("LOG_LEVEL", "INFO").upper()
-logger.setLevel(getattr(logging, level_name, logging.INFO))
-
-log_dir = os.getenv("LOG_DIR", "/app/logs")
-fallback_dir = os.path.join(os.path.dirname(__file__), "logs")
-try:
-    os.makedirs(log_dir, exist_ok=True)
-    if not os.access(log_dir, os.W_OK):
-        raise PermissionError
-except (OSError, PermissionError):
-    log_dir = fallback_dir
-    os.makedirs(log_dir, exist_ok=True)
-
-if not logger.handlers:
-    formatter = logging.Formatter(
-        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-    )
-
-    file_handler = logging.FileHandler(os.path.join(log_dir, "trading_bot.log"))
-    file_handler.setFormatter(formatter)
-    logger.addHandler(file_handler)
-
-    console_handler = logging.StreamHandler()
-    console_handler.setFormatter(formatter)
-    logger.addHandler(console_handler)
-
-    logger.info(
-        "Logging initialized at %s; writing logs to %s",
-        logging.getLevelName(logger.level),
-        log_dir,
-    )
 
 
 class TelegramLogger(logging.Handler):


### PR DESCRIPTION
## Summary
- centralize logging setup in `configure_logging` and initialize handlers once
- guard `trade_manager` imports for `load_dotenv` and `configure_logging` to support test stubs

## Testing
- `pytest`
- `pytest tests/test_utils.py::test_logging_not_duplicated_on_reimport -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab3a6aada8832da88a941ca25a9e5f