### PR TITLE
fix: avoid Path Validation Error in Trivy workflow

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -121,5 +121,4 @@ jobs:
       - name: Cleanup after Trivy scan
         run: |
           docker system prune -af || true
-          rm -rf /mnt/trivy-cache /mnt/trivy-temp ~/.cache/trivy || true
           sudo rm -rf /tmp/* || true


### PR DESCRIPTION
## Summary
- remove cleanup that deletes Trivy cache directory to avoid Path Validation Error from `actions/cache`

## Testing
- `pytest -q` *(fails: cannot import 'configure_logging' from 'utils')*
- `ACT_SKIP='Initial cleanup,Checkout code,Free disk space,Clean Docker dir,Prepare build volume,Maximize build space,Build an image from Dockerfile.ci,Login to GHCR,Cleanup before Trivy scan,Create Trivy directories,Run Trivy vulnerability scanner,Show Trivy scan results,Upload Trivy scan results to GitHub Security tab,Upload Trivy report artifact' ./bin/act -j build -W .github/workflows/trivy.yml` *(fails: Couldn't get a valid docker connection)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3b8a4934832da34b73fa8a97f20b