### PR TITLE
Use read_proxy output for Dependabot registry proxy

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -24,4 +24,4 @@ jobs:
         uses: github/dependabot-action@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REGISTRIES_PROXY: "${{ secrets.AVERINALEKS }}"
+          GITHUB_REGISTRIES_PROXY: "${{ steps.read_proxy.outputs.json }}"


### PR DESCRIPTION
## Summary
- use read_proxy output for GITHUB_REGISTRIES_PROXY in Dependabot workflow

## Testing
- `python -m flake8`
- `pytest` *(fails: ImportError: cannot import name 'load_dotenv' and RetryError in multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3f60e9c4832d85cc3545bdd4ea91