### PR TITLE
Enable manual Dependabot workflow dispatch

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -7,6 +7,7 @@ permissions:
 on:
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
 
 jobs:
   dependabot:


### PR DESCRIPTION
## Summary
- allow manual execution of Dependabot workflow

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml` *(fails: 19 failed, 299 passed, 1 skipped, 17 deselected)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3f61825c832d9141c49e368ac075