### PR TITLE
Add async no-op Telegram logger stub

### DIFF
--- a/trade_manager.py
+++ b/trade_manager.py
@@ -220,9 +220,13 @@ class TradeManager:
             logger.warning(
                 "TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID not set; Telegram alerts will not be sent"
             )
+            async def _noop(*_, **__):
+                pass
+
             self.telegram_logger = types.SimpleNamespace(
                 info=lambda *a, **k: None,
                 warning=lambda *a, **k: None,
+                send_telegram_message=_noop,
             )
         else:
             self.telegram_logger = TelegramLogger(


### PR DESCRIPTION
## Summary
- avoid AttributeError when Telegram credentials are missing by adding async send_telegram_message stub

## Testing
- `pytest -m "not integration"` *(fails: ImportError: cannot import name 'load_dotenv', AssertionError: assert 'TF_CPP_MIN_LOG_LEVEL' not in environ)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4bcf28fc832d98d009b3270df509