### PR TITLE
feat: allow optional TensorFlow log suppression

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -19,9 +19,10 @@ from tenacity import retry, stop_after_attempt, wait_exponential
 
 from bot.config import BotConfig
 from bot.gpt_client import GPTClientError, query_gpt_json_async
-from bot.utils import logger
+from bot.utils import logger, suppress_tf_logs
 
 load_dotenv()
+suppress_tf_logs()
 
 CFG = BotConfig()
 

--- a/utils.py
+++ b/utils.py
@@ -15,9 +15,13 @@ from typing import Dict, List, Optional
 import shutil
 
 
+def suppress_tf_logs() -> None:
+    """Установить ``TF_CPP_MIN_LOG_LEVEL=3`` для подавления логов TensorFlow."""
+    os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "3")
+
+
 def configure_logging() -> None:
     """Настроить переменные окружения и handlers для логирования."""
-    os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "3")
 
     level_name = os.getenv("LOG_LEVEL", "INFO").upper()
     logger.setLevel(getattr(logging, level_name, logging.INFO))


### PR DESCRIPTION
## Summary
- decouple TensorFlow log suppression from module import
- expose `suppress_tf_logs()` for explicit use
- call `suppress_tf_logs()` in `trading_bot` startup

## Testing
- `pytest -m "not integration"` *(fails: tests/test_model_builder_import.py::..., tests/test_simulation.py::..., tests/test_trade_manager.py::...)*
- `pytest tests/test_tf_logging.py::test_import_does_not_set_tf_log_level -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab4bd226ec832d91ef1a6b96fd38fc