### PR TITLE
Require fastapi_csrf_protect and drop fallback stub

### DIFF
--- a/server.py
+++ b/server.py
@@ -16,22 +16,16 @@ except Exception:  # pragma: no cover - fallback if python-dotenv is missing
 if not getattr(dotenv, "dotenv_values", None):  # pragma: no cover - stub for tests
     dotenv = types.ModuleType("dotenv")
     dotenv.dotenv_values = lambda *args, **kwargs: {}
+    dotenv.load_dotenv = lambda *args, **kwargs: None
     sys.modules["dotenv"] = dotenv
 
 from fastapi import FastAPI, HTTPException, Request, Response
 try:
     from fastapi_csrf_protect import CsrfProtect
-except Exception:  # pragma: no cover - allow missing dependency
-    class CsrfProtect:  # type: ignore[empty-body]
-        def __init__(self, *args, **kwargs) -> None:
-            pass
-
-        @classmethod
-        def load_config(cls, func):
-            return func
-
-        async def validate_csrf(self, request) -> None:  # pragma: no cover - no-op
-            return None
+except ImportError as exc:  # pragma: no cover - dependency required
+    raise RuntimeError(
+        "fastapi_csrf_protect is required. Install it with 'pip install fastapi-csrf-protect'."
+    ) from exc
 
 from pydantic import BaseModel, Field
 

--- a/tests/test_server_csrf_optional.py
+++ b/tests/test_server_csrf_optional.py
@@ -1,21 +1,17 @@
 import importlib
 import sys
+import types
 
-from fastapi.testclient import TestClient
+import pytest
 
 
-def test_server_starts_without_csrf(monkeypatch):
+def test_server_requires_csrf(monkeypatch):
     monkeypatch.setenv("API_KEYS", "testkey")
     monkeypatch.setitem(sys.modules, "fastapi_csrf_protect", None)
+    dotenv_stub = types.ModuleType("dotenv")
+    dotenv_stub.load_dotenv = lambda *a, **k: None
+    dotenv_stub.dotenv_values = lambda *a, **k: {}
+    monkeypatch.setitem(sys.modules, "dotenv", dotenv_stub)
     monkeypatch.delitem(sys.modules, "server", raising=False)
-    server = importlib.import_module("server")
-
-    def dummy_load_model():
-        server.model_manager.tokenizer = object()
-        server.model_manager.model = object()
-
-    monkeypatch.setattr(server.model_manager, "load_model", dummy_load_model)
-    client = TestClient(server.app)
-    with client:
-        resp = client.get("/nonexistent", headers={"Authorization": "Bearer testkey"})
-    assert resp.status_code == 404
+    with pytest.raises(RuntimeError):
+        importlib.import_module("server")


### PR DESCRIPTION
## Summary
- remove fallback CsrfProtect implementation and fail fast if fastapi_csrf_protect is missing
- extend dotenv stub to include load_dotenv so other modules import cleanly
- test that server fails to start without fastapi_csrf_protect

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab7b6ff260832db0cc284a8a227d00