### PR TITLE
Require CSRF_SECRET environment variable

### DIFF
--- a/server.py
+++ b/server.py
@@ -143,12 +143,15 @@ app = FastAPI(lifespan=lifespan)
 
 
 class CsrfSettings(BaseModel):
-    secret_key: str = os.getenv("CSRF_SECRET", "change_me")
+    secret_key: str
 
 
 @CsrfProtect.load_config
 def get_csrf_config() -> CsrfSettings:
-    return CsrfSettings()
+    secret_key = os.getenv("CSRF_SECRET")
+    if not secret_key:
+        raise RuntimeError("CSRF_SECRET environment variable is not set")
+    return CsrfSettings(secret_key=secret_key)
 
 
 csrf_protect = CsrfProtect()


### PR DESCRIPTION
## Summary
- remove default CSRF secret placeholder
- raise a clear error when CSRF_SECRET is missing

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'load_dotenv' from 'dotenv' )*
- `CSRF_SECRET=dummy pytest -q` *(fails: ImportError: cannot import name 'load_dotenv' from 'dotenv'; thread shutdown assert)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7b77a968832da44c98d32dd930b1