### PR TITLE
Handle specific Telegram exceptions

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -523,7 +523,7 @@ class TelegramLogger(logging.Handler):
                 return
             try:
                 await self._send(text, chat_id, urgent)
-            except Exception:
+            except (RetryAfter, Forbidden, BadRequest, httpx.HTTPError):
                 logger.exception("Ошибка отправки сообщения в Telegram")
             finally:
                 queue.task_done()


### PR DESCRIPTION
## Summary
- limit Telegram worker to catch only known exceptions
- add test ensuring unexpected errors propagate

## Testing
- `pre-commit run flake8 --files utils.py tests/test_telegram_logger.py`
- `pre-commit run --files utils.py tests/test_telegram_logger.py` *(fails: ImportError: cannot import name 'load_dotenv')*
- `pytest tests/test_telegram_logger.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab7b818628832d84d880bae6d159c1