### PR TITLE
chore: configure trivy temp directory

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -128,13 +128,17 @@ jobs:
       - name: Cleanup before Trivy scan
         run: |
           sudo rm -rf /tmp/* || true
-          sudo rm -rf /mnt/trivy-cache || true
+          sudo rm -rf /mnt/trivy-cache /mnt/trivy-tmp || true
           rm -rf ~/.cache/trivy || true
           mkdir -p /mnt/trivy-cache
+        working-directory: bot
+      - name: Prepare Trivy temp
+        run: mkdir -p /mnt/trivy-tmp
         working-directory: bot
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.32.0
         env:
+          TMPDIR: /mnt/trivy-tmp
           TRIVY_CACHE_DIR: /mnt/trivy-cache
         with:
           version: v0.65.0

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Cleanup before Trivy scan
         run: |
           sudo rm -rf /tmp/* || true
-          sudo rm -rf /mnt/trivy-cache /mnt/trivy-temp || true
+          sudo rm -rf /mnt/trivy-cache /mnt/trivy-tmp || true
           rm -rf ~/.cache/trivy || true
 
       - name: Prepare Trivy cache directory
@@ -85,14 +85,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-trivy-cache-
 
-      - name: Create Trivy directories
-        run: |
-          mkdir -p /mnt/trivy-temp
+      - name: Prepare Trivy temp
+        run: mkdir -p /mnt/trivy-tmp
 
       - name: Run Trivy vulnerability scanner
         env:
+          TMPDIR: /mnt/trivy-tmp
           TRIVY_CACHE_DIR: /mnt/trivy-cache
-          TRIVY_TEMP_DIR: /mnt/trivy-temp
         uses: aquasecurity/trivy-action@0.32.0
         with:
           cache-dir: /mnt/trivy-cache


### PR DESCRIPTION
## Summary
- store Trivy temporary files on /mnt to avoid /tmp overflow
- set TMPDIR and create /mnt/trivy-tmp before running aquasecurity/trivy-action

## Testing
- `python -m pre_commit run --files .github/workflows/trivy.yml .github/workflows/docker-publish.yml` *(fails: CSRF_SECRET environment variable is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7ea8ba14832dace381b47b26d868