### PR TITLE
ci: include fastapi-csrf-protect in test requirements

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -9,6 +9,7 @@ pytest==8.4.1
 pytest-asyncio>=1.1
 tenacity>=8.5,<10
 fastapi==0.116.1
+fastapi-csrf-protect==1.0.6
 flask>=3.1.1,<4
 pyarrow>=16.1.0
 python-dotenv==1.1.1


### PR DESCRIPTION
## Summary
- add fastapi-csrf-protect to CI test requirements

## Testing
- `pip install -r requirements-ci.txt`
- `CSRF_SECRET=test pytest -m "not integration"`


------
https://chatgpt.com/codex/tasks/task_e_68ab81ef6ed4832db9e41901041eefb7