### PR TITLE
Set CSRF secret during server API key test

### DIFF
--- a/tests/test_server_missing_api_keys.py
+++ b/tests/test_server_missing_api_keys.py
@@ -7,7 +7,9 @@ import pytest
 def test_missing_api_keys_causes_startup_failure(monkeypatch):
     monkeypatch.delenv("API_KEYS", raising=False)
     sys.modules.pop("server", None)
+    os.environ["CSRF_SECRET"] = "testsecret"
     with pytest.raises(RuntimeError, match="API_KEYS environment variable is required"):
         importlib.import_module("server")
     sys.modules.pop("server", None)
+    os.environ.pop("CSRF_SECRET", None)
     os.environ["API_KEYS"] = "testkey"


### PR DESCRIPTION
## Summary
- ensure CSRF secret is set before importing `server` in API key missing test
- clean up CSRF secret after the test

## Testing
- `pytest tests/test_server_missing_api_keys.py`


------
https://chatgpt.com/codex/tasks/task_e_68aca66cdaa0832d85d489f1a5e7db50