### PR TITLE
Set CSRF secret for server model loading test

### DIFF
--- a/tests/test_server_model_loading.py
+++ b/tests/test_server_model_loading.py
@@ -20,6 +20,7 @@ def test_load_model_async_raises_runtime_error(monkeypatch):
         torch.cuda = types.SimpleNamespace(is_available=lambda: False)
         m.setitem(sys.modules, "torch", torch)
 
+        os.environ["CSRF_SECRET"] = "testsecret"
         import server
 
         with pytest.raises(RuntimeError, match="Failed to load both primary and fallback models"):
@@ -29,3 +30,5 @@ def test_load_model_async_raises_runtime_error(monkeypatch):
         importlib.reload(server)
     except ModuleNotFoundError:
         pass
+    finally:
+        os.environ.pop("CSRF_SECRET", None)


### PR DESCRIPTION
## Summary
- ensure server model loading test sets CSRF secret before importing server
- clean up CSRF secret environment variable after test run

## Testing
- `pre-commit run --files tests/test_server_model_loading.py` (fails: ModuleNotFoundError: No module named 'tenacity')
- `pytest tests/test_server_model_loading.py`


------
https://chatgpt.com/codex/tasks/task_e_68aca67186fc832d974fd37bd268be55