### PR TITLE
Закрепление checkout в submit-pypi workflow за конкретным коммитом

### DIFF
--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -17,6 +17,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
       - name: Free disk space
         uses: jlumbroso/free-disk-space@main
         with:


### PR DESCRIPTION
## Summary
- привязал actions/checkout в submit-pypi к текущему SHA

## Testing
- `pre-commit run --files .github/workflows/submit-pypi.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acaf3ad344832d9ed7810c45f57f18