### PR TITLE
Use client context manager for Telegram sending

### DIFF
--- a/gptoss_check/check_code.py
+++ b/gptoss_check/check_code.py
@@ -59,12 +59,12 @@ def send_telegram(msg: str) -> None:
     chat_id = os.getenv("TELEGRAM_CHAT_ID")
     if token and chat_id:
         try:
-            httpx.post(
-                f"https://api.telegram.org/bot{token}/sendMessage",
-                data={"chat_id": chat_id, "text": msg[:4000]},
-                timeout=15,
-                trust_env=False,
-            )
+            with httpx.Client(timeout=15, trust_env=False) as client:
+                response = client.post(
+                    f"https://api.telegram.org/bot{token}/sendMessage",
+                    data={"chat_id": chat_id, "text": msg[:4000]},
+                )
+                response.close()
         except httpx.HTTPError as err:
             logger.warning("⚠️ Failed to send Telegram message: %s", err)
 


### PR DESCRIPTION
## Summary
- close Telegram HTTP requests with an httpx.Client context manager

## Testing
- `pytest tests/test_gpt_client.py::test_retry_logic -q` *(fails: AttributeError: module 'httpx' has no attribute 'Response')*


------
https://chatgpt.com/codex/tasks/task_e_68acb101b6f0832d91e050768ca77ccc