### PR TITLE
Remove redundant API wait in query

### DIFF
--- a/gptoss_check/check_code.py
+++ b/gptoss_check/check_code.py
@@ -37,8 +37,6 @@ def query(prompt: str) -> str:
     if not api_url:
         raise RuntimeError("Переменная окружения GPT_OSS_API не установлена")
 
-    wait_for_api(api_url)
-
     max_retries = 3
     backoff = 1
     for attempt in range(1, max_retries + 1):


### PR DESCRIPTION
## Summary
- stop querying API readiness inside `query`
- keep `run` as sole API check for GPT-OSS

## Testing
- `pytest -q` *(fails: Missing dependencies like tenacity, fastapi, pyarrow, async plugins)*
- `pytest tests/test_gptoss_check.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68acb0fd8bb8832d9cdd284bc50484d4