### PR TITLE
chore: drop backports-asyncio-runner

### DIFF
--- a/requirements-core.in
+++ b/requirements-core.in
@@ -37,5 +37,4 @@ bcrypt>=4.2.0
 openai==1.101.0
 jsonschema==4.25.1
 pytest-asyncio>=1.1
-backports-asyncio-runner; python_version<'3.11'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,8 +33,6 @@ attrs==25.3.0
     #   aiohttp
     #   jsonschema
     #   referencing
-backports-asyncio-runner==1.2.0
-    # via pytest-asyncio
 bcrypt==4.3.0
     # via -r requirements-core.in
 blinker==1.9.0


### PR DESCRIPTION
## Summary
- remove backports-asyncio-runner dependency for Python>=3.11

## Testing
- `pre-commit run --files requirements-core.in requirements.txt requirements.out` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip-compile --upgrade --output-file=requirements.out requirements.txt` *(aborted: long-running dependency resolution)*

------
https://chatgpt.com/codex/tasks/task_e_68acb1ed27b8832d809088d3dc7d4698