### PR TITLE
Verify GPT API host IP before each request

### DIFF
--- a/gpt_client.py
+++ b/gpt_client.py
@@ -36,7 +36,7 @@ class GPTClientResponseError(GPTClientError):
     """Raised when the GPT OSS API returns an unexpected structure."""
 
 
-def _validate_api_url(api_url: str) -> None:
+def _validate_api_url(api_url: str) -> tuple[str, set[str]]:
     parsed = urlparse(api_url)
     if not parsed.scheme or not parsed.hostname:
         raise GPTClientError("Invalid GPT_OSS_API URL")
@@ -55,8 +55,10 @@ def _validate_api_url(api_url: str) -> None:
         )
         raise GPTClientError("Invalid GPT_OSS_API host") from exc
 
+    resolved_ips = {info[4][0] for info in addr_info}
+
     if scheme == "http":
-        for resolved_ip in {info[4][0] for info in addr_info}:
+        for resolved_ip in resolved_ips:
             ip = ip_address(resolved_ip)
             if not (ip.is_loopback or ip.is_private):
                 logger.critical("Insecure GPT_OSS_API URL: %s", api_url)
@@ -64,27 +66,57 @@ def _validate_api_url(api_url: str) -> None:
                     "GPT_OSS_API must use HTTPS or be a private address"
                 )
 
+    return parsed.hostname, resolved_ips
+
 
 @retry(
     stop=stop_after_attempt(3),
     wait=wait_exponential(min=1, max=10),
     reraise=True,
 )
-def _post_with_retry(url: str, prompt: str, timeout: float) -> httpx.Response:
+def _post_with_retry(
+    url: str,
+    prompt: str,
+    timeout: float,
+    hostname: str,
+    allowed_ips: set[str],
+) -> httpx.Response:
     """POST helper that retries on network failures."""
+    try:
+        current_ips = {
+            info[4][0]
+            for info in socket.getaddrinfo(hostname, None, family=socket.AF_UNSPEC)
+        }
+    except socket.gaierror as exc:
+        logger.error(
+            "Failed to resolve GPT_OSS_API host %s before request: %s",
+            hostname,
+            exc,
+        )
+        raise GPTClientNetworkError("Failed to resolve GPT_OSS_API host") from exc
+
+    if not current_ips & allowed_ips:
+        logger.error(
+            "GPT_OSS_API host IP mismatch: %s resolved to %s, expected %s",
+            hostname,
+            current_ips,
+            allowed_ips,
+        )
+        raise GPTClientNetworkError("GPT_OSS_API host resolution mismatch")
+
     with httpx.Client(trust_env=False, timeout=timeout) as client:
         response = client.post(url, json={"prompt": prompt})
         response.raise_for_status()
         return response
 
 
-def _get_api_url_timeout() -> tuple[str, float]:
+def _get_api_url_timeout() -> tuple[str, float, str, set[str]]:
     api_url = os.getenv("GPT_OSS_API")
     if not api_url:
         logger.error("Environment variable GPT_OSS_API is not set")
         raise GPTClientNetworkError("GPT_OSS_API environment variable not set")
 
-    _validate_api_url(api_url)
+    hostname, allowed_ips = _validate_api_url(api_url)
 
     timeout_env = os.getenv("GPT_OSS_TIMEOUT", "5")
     try:
@@ -102,7 +134,7 @@ def _get_api_url_timeout() -> tuple[str, float]:
         timeout = 5.0
 
     url = api_url.rstrip("/") + "/v1/completions"
-    return url, timeout
+    return url, timeout, hostname, allowed_ips
 
 
 def query_gpt(prompt: str) -> str:
@@ -117,9 +149,9 @@ def query_gpt(prompt: str) -> str:
     if len(prompt.encode("utf-8")) > MAX_PROMPT_BYTES:
         raise GPTClientError("Prompt exceeds maximum length")
 
-    url, timeout = _get_api_url_timeout()
+    url, timeout, hostname, allowed_ips = _get_api_url_timeout()
     try:
-        response = _post_with_retry(url, prompt, timeout)
+        response = _post_with_retry(url, prompt, timeout, hostname, allowed_ips)
         if len(response.content) > MAX_RESPONSE_BYTES:
             raise GPTClientError("Response exceeds maximum length")
     except httpx.HTTPError as exc:  # pragma: no cover - network errors
@@ -156,7 +188,7 @@ async def query_gpt_async(prompt: str) -> str:
     if len(prompt.encode("utf-8")) > MAX_PROMPT_BYTES:
         raise GPTClientError("Prompt exceeds maximum length")
 
-    url, timeout = _get_api_url_timeout()
+    url, timeout, hostname, allowed_ips = _get_api_url_timeout()
 
     @retry(
         stop=stop_after_attempt(3),
@@ -164,6 +196,28 @@ async def query_gpt_async(prompt: str) -> str:
         reraise=True,
     )
     async def _post() -> httpx.Response:
+        try:
+            current_ips = {
+                info[4][0]
+                for info in socket.getaddrinfo(hostname, None, family=socket.AF_UNSPEC)
+            }
+        except socket.gaierror as exc:
+            logger.error(
+                "Failed to resolve GPT_OSS_API host %s before request: %s",
+                hostname,
+                exc,
+            )
+            raise GPTClientNetworkError("Failed to resolve GPT_OSS_API host") from exc
+
+        if not current_ips & allowed_ips:
+            logger.error(
+                "GPT_OSS_API host IP mismatch: %s resolved to %s, expected %s",
+                hostname,
+                current_ips,
+                allowed_ips,
+            )
+            raise GPTClientNetworkError("GPT_OSS_API host resolution mismatch")
+
         async with httpx.AsyncClient(trust_env=False, timeout=timeout) as client:
             response = await client.post(url, json={"prompt": prompt})
             response.raise_for_status()

--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -227,7 +227,7 @@ def test_get_api_url_timeout_non_positive(monkeypatch, caplog):
     monkeypatch.setenv("GPT_OSS_API", "https://example.com")
     monkeypatch.setenv("GPT_OSS_TIMEOUT", "0")
     with caplog.at_level(logging.WARNING):
-        _, timeout = _get_api_url_timeout()
+        _, timeout, _, _ = _get_api_url_timeout()
     assert timeout == 5.0
     assert "Non-positive GPT_OSS_TIMEOUT value" in caplog.text
 
@@ -236,7 +236,7 @@ def test_get_api_url_timeout_invalid(monkeypatch, caplog):
     monkeypatch.setenv("GPT_OSS_API", "https://example.com")
     monkeypatch.setenv("GPT_OSS_TIMEOUT", "abc")
     with caplog.at_level(logging.WARNING):
-        _, timeout = _get_api_url_timeout()
+        _, timeout, _, _ = _get_api_url_timeout()
     assert timeout == 5.0
     assert "Invalid GPT_OSS_TIMEOUT value 'abc'; defaulting to 5.0" in caplog.text
 


### PR DESCRIPTION
## Summary
- Resolve GPT_OSS_API host and record allowed IPs during URL validation
- Re-resolve host before each request and abort if IP changes
- Update tests for new API URL helper signature

## Testing
- `pytest tests/test_gpt_client.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68acb41b4df8832db5f330946f5f0916