### PR TITLE
Ensure API_KEYS is configured and document setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,24 @@ tries to register them more than once. They are warnings, not fatal errors, and
 can be safely ignored. Building the image with `Dockerfile.cpu` avoids them
 entirely.
 
+## Настройка API ключей
+
+Сервер FastAPI использует переменную окружения `API_KEYS` для проверки запросов.
+Задайте её как список токенов через запятую до запуска приложения:
+
+```bash
+export API_KEYS=key1,key2
+```
+
+Переменную можно также добавить в файл `.env`:
+
+```dotenv
+API_KEYS=key1,key2
+```
+
+Каждый запрос должен передавать заголовок `Authorization: Bearer <token>` с
+одним из перечисленных ключей, иначе сервер вернёт `401`.
+
 ## Lightweight service scripts
 
 The `services` directory provides minimal versions of the microservices. They

--- a/server.py
+++ b/server.py
@@ -151,6 +151,10 @@ def get_csrf_config() -> CsrfSettings:
 csrf_protect = CsrfProtect()
 
 API_KEYS = {k.strip() for k in os.getenv("API_KEYS", "").split(",") if k.strip()}
+if not API_KEYS:
+    raise RuntimeError(
+        "API_KEYS environment variable is required. Set API_KEYS to a comma-separated list of tokens."
+    )
 
 ALLOWED_HOSTS = {"127.0.0.1", "::1"}
 host = os.getenv(
@@ -164,14 +168,6 @@ except ValueError:
     sys.exit(1)
 
 MAX_REQUEST_BYTES = 1 * 1024 * 1024  # 1 MB
-
-if not API_KEYS:
-    logging.error(
-        "No API keys provided; set the API_KEYS environment variable with at least one key. host=%s port=%d",
-        host,
-        port,
-    )
-    raise RuntimeError("API_KEYS environment variable is required")
 
 
 def _loggable_headers(headers: Mapping[str, str]) -> dict[str, str]:


### PR DESCRIPTION
## Summary
- validate that API_KEYS env var contains at least one token
- raise clear RuntimeError when API keys are missing
- document API key configuration in README

## Testing
- `pytest tests/test_server_missing_api_keys.py::test_missing_api_keys_causes_startup_failure -q`
- `pytest tests/test_server_auth.py tests/test_server_model_loading.py tests/test_server_csrf_optional.py tests/test_server_request_validation.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tenacity')*


------
https://chatgpt.com/codex/tasks/task_e_68acb4246788832da1fa8c6f736f5f51