### PR TITLE
feat: add model cache and timeout

### DIFF
--- a/tests/test_server_model_loading.py
+++ b/tests/test_server_model_loading.py
@@ -32,3 +32,61 @@ def test_load_model_async_raises_runtime_error(monkeypatch):
         pass
     finally:
         os.environ.pop("CSRF_SECRET", None)
+
+
+class _ConditionalTokenizer:
+    calls: list[bool] = []
+
+    @staticmethod
+    def from_pretrained(*args, **kwargs):
+        flag = kwargs.get("local_files_only", False)
+        _ConditionalTokenizer.calls.append(flag)
+        if flag:
+            return object()
+        raise OSError("network down")
+
+
+class _DummyModel:
+    def to(self, *_args, **_kwargs):
+        return self
+
+
+class _ConditionalModel:
+    calls: list[bool] = []
+
+    @staticmethod
+    def from_pretrained(*args, **kwargs):
+        flag = kwargs.get("local_files_only", False)
+        _ConditionalModel.calls.append(flag)
+        if flag:
+            return _DummyModel()
+        raise OSError("network down")
+
+
+def test_load_model_uses_local_cache(monkeypatch):
+    with monkeypatch.context() as m:
+        transformers = types.ModuleType("transformers")
+        transformers.AutoTokenizer = _ConditionalTokenizer
+        transformers.AutoModelForCausalLM = _ConditionalModel
+        m.setitem(sys.modules, "transformers", transformers)
+
+        torch = types.ModuleType("torch")
+        torch.cuda = types.SimpleNamespace(is_available=lambda: False)
+        m.setitem(sys.modules, "torch", torch)
+
+        os.environ["CSRF_SECRET"] = "testsecret"
+        import server
+
+        result = server.model_manager.load_model()
+        assert result == "primary"
+        assert _ConditionalTokenizer.calls == [False, True]
+        assert _ConditionalModel.calls == [True]
+
+    try:
+        importlib.reload(server)
+    except ModuleNotFoundError:
+        pass
+    finally:
+        os.environ.pop("CSRF_SECRET", None)
+        _ConditionalTokenizer.calls.clear()
+        _ConditionalModel.calls.clear()


### PR DESCRIPTION
## Summary
- configure request and httpx clients with global timeout
- load models with revision from env and fallback to local cache
- test model cache behavior when network is unavailable

## Testing
- `pytest tests/test_server_model_loading.py::test_load_model_uses_local_cache -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tenacity')*


------
https://chatgpt.com/codex/tasks/task_e_68acb429a9e4832d99cb2a90ba935db6