### PR TITLE
Handle CsrfProtect errors explicitly

### DIFF
--- a/server.py
+++ b/server.py
@@ -21,7 +21,7 @@ if not getattr(dotenv, "dotenv_values", None):  # pragma: no cover - stub for te
 
 from fastapi import FastAPI, HTTPException, Request, Response
 try:
-    from fastapi_csrf_protect import CsrfProtect
+    from fastapi_csrf_protect import CsrfProtect, CsrfProtectError
 except ImportError as exc:  # pragma: no cover - dependency required
     raise RuntimeError(
         "fastapi_csrf_protect is required. Install it with 'pip install fastapi-csrf-protect'."
@@ -193,7 +193,7 @@ async def enforce_csrf(request: Request, call_next):
     if request.method == "POST":
         try:
             await csrf_protect.validate_csrf(request)
-        except Exception:
+        except CsrfProtectError:
             logging.warning(
                 "CSRF validation failed: method=%s url=%s headers=%s",
                 request.method,
@@ -201,6 +201,14 @@ async def enforce_csrf(request: Request, call_next):
                 _loggable_headers(request.headers),
             )
             raise HTTPException(status_code=403, detail="CSRF token missing or invalid")
+        except Exception:
+            logging.exception(
+                "Unexpected error during CSRF validation: method=%s url=%s headers=%s",
+                request.method,
+                request.url,
+                _loggable_headers(request.headers),
+            )
+            raise
     return await call_next(request)
 
 


### PR DESCRIPTION
## Summary
- import `CsrfProtectError` from `fastapi_csrf_protect`
- handle CSRF validation errors separately
- log and re-raise unexpected exceptions in CSRF middleware

## Testing
- `pre-commit run --files server.py` *(fails: ModuleNotFoundError: No module named 'tenacity')*
- `pytest tests/test_server_csrf_optional.py`


------
https://chatgpt.com/codex/tasks/task_e_68acb45c3a94832d85db10983b326568