### PR TITLE
Handle non-ASCII special characters in password validation

### DIFF
--- a/password_utils.py
+++ b/password_utils.py
@@ -2,7 +2,6 @@ import os
 import bcrypt
 import logging
 import re
-import string
 
 MIN_PASSWORD_LENGTH = 8
 MAX_PASSWORD_LENGTH = 64
@@ -40,7 +39,7 @@ def validate_password_complexity(password: str) -> None:
         raise ValueError("Password must contain a lowercase letter")
     if not re.search(r"\d", password):
         raise ValueError("Password must contain a digit")
-    if not any(ch in string.punctuation for ch in password):
+    if not re.search(r"[^\w\s]", password):
         raise ValueError("Password must contain a special character")
 
 

--- a/tests/test_password_utils.py
+++ b/tests/test_password_utils.py
@@ -15,6 +15,7 @@ from password_utils import (
 
 
 VALID_PASSWORD = "Aa1!" + "a" * (MIN_PASSWORD_LENGTH - 4)
+VALID_PASSWORD_NON_ASCII = "Aa1€" + "a" * (MIN_PASSWORD_LENGTH - 4)
 WEAK_PASSWORDS = [
     "aaaaaaaa",  # no uppercase, digit, special
     "AAAAAAAA",  # no lowercase, digit, special
@@ -46,6 +47,11 @@ def test_hash_password_allows_short_password():
 def test_verify_password_success():
     hashed = hash_password(VALID_PASSWORD)
     assert verify_password(VALID_PASSWORD, hashed)
+
+
+def test_hash_password_accepts_non_ascii_special_char():
+    hashed = hash_password(VALID_PASSWORD_NON_ASCII)
+    assert verify_password(VALID_PASSWORD_NON_ASCII, hashed)
 
 
 def test_hash_password_rejects_long_password():


### PR DESCRIPTION
## Summary
- use Unicode-aware regex to validate special characters in passwords
- test password handling with non-ASCII special symbols

## Testing
- `pytest tests/test_password_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68acb45fb8a8832db29c17bbfbef6b75