### PR TITLE
ci: pin free-disk-space action in trivy workflow

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
         continue-on-error: true
         with:
           docker-images: true


### PR DESCRIPTION
## Summary
- pin jlumbroso/free-disk-space action to specific commit

## Testing
- `pre-commit run --files .github/workflows/trivy.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acbf4ec280832da3610fc6432a0ee3