### PR TITLE
Define API_KEYS to satisfy flake8

### DIFF
--- a/server.py
+++ b/server.py
@@ -23,6 +23,7 @@ except ImportError as exc:  # pragma: no cover - dependency required
 
 from pydantic import BaseModel, Field, ValidationError
 
+API_KEYS: set[str] = set()
 TIMEOUT = float(os.getenv("MODEL_DOWNLOAD_TIMEOUT", "30"))
 
 


### PR DESCRIPTION
## Summary
- declare `API_KEYS` set at module level in `server.py`
- silence flake8 F821 undefined name errors

## Testing
- `flake8 server.py`


------
https://chatgpt.com/codex/tasks/task_e_68acc357edfc832dbbe77ca478b925c9