### PR TITLE
fix: save Trivy cache before cleanup

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -82,7 +82,8 @@ jobs:
         run: mkdir -p /mnt/trivy-cache
 
       - name: Cache Trivy vulnerability database
-        uses: actions/cache@v4
+        id: trivy-cache
+        uses: actions/cache/restore@v4
         with:
           path: /mnt/trivy-cache
           key: ${{ runner.os }}-trivy-cache-${{ github.sha }}
@@ -121,6 +122,14 @@ jobs:
         with:
           name: trivy-results
           path: trivy-results.sarif
+
+      - name: Save Trivy cache
+        if: steps.trivy-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: /mnt/trivy-cache
+          key: ${{ runner.os }}-trivy-cache-${{ github.sha }}
+
       - name: Cleanup after Trivy scan
         run: |
           docker system prune -af || true


### PR DESCRIPTION
## Summary
- ensure cache is saved before removing trivy directories

## Testing
- `pre-commit run --files .github/workflows/trivy.yml` *(fails: IndentationError in gpt_client.py)*

------
https://chatgpt.com/codex/tasks/task_e_68acc48d8060832db8c958fbfb3219b7