### PR TITLE
Add secret scanning workflow

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,36 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Secret Scan
+
+permissions:
+  contents: read
+  security-events: write
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '0 0 * * 1'
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        with:
+          args: "--report-format sarif --report-path gitleaks.sarif"
+      - name: Upload SARIF report
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: gitleaks.sarif
+      - name: Cleanup buildx
+        run: docker buildx prune -af || true


### PR DESCRIPTION
## Summary
- add gitleaks-based secret scanning workflow and upload findings to code scanning

## Testing
- `pre-commit run --files .github/workflows/secret-scan.yml`
- `pre-commit run --files .github/workflows/secret-scan.yml --hook-stage manual`


------
https://chatgpt.com/codex/tasks/task_e_68ad65c6eec8832db5cf255a98be8d5d