### PR TITLE
Add Hypothesis-based tests for HTML parser

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -7,6 +7,7 @@ joblib>=1.4.2
 pandas>=2.0.0,<3.0.0
 pytest==8.4.1
 pytest-asyncio>=1.1
+hypothesis>=6.103.0
 tenacity>=8.5,<10
 fastapi==0.116.1
 fastapi-csrf-protect==1.0.6

--- a/tests/test_safe_html_parser_hypothesis.py
+++ b/tests/test_safe_html_parser_hypothesis.py
@@ -1,0 +1,27 @@
+import sys
+import types
+import pytest
+from hypothesis import given, strategies as st
+
+from safe_html_parser import SafeHTMLParser
+
+# Replace any SimpleNamespace entries in sys.modules with ModuleType to satisfy Hypothesis
+for name, module in list(sys.modules.items()):
+    if isinstance(module, types.SimpleNamespace):
+        replacement = types.ModuleType(name)
+        replacement.__dict__.update(module.__dict__)
+        sys.modules[name] = replacement
+
+
+@given(st.text(max_size=100))
+def test_small_inputs_parse_without_error(html):
+    parser = SafeHTMLParser()
+    parser.feed(html)
+    assert parser.fed_bytes == len(html.encode("utf-8"))
+
+
+@given(st.text(min_size=1).filter(lambda s: len(s.encode("utf-8")) > 10))
+def test_inputs_exceeding_limit_raise(html):
+    parser = SafeHTMLParser(max_feed_size=10)
+    with pytest.raises(ValueError):
+        parser.feed(html)


### PR DESCRIPTION
## Summary
- add Hypothesis library to CI requirements
- cover SafeHTMLParser with property-based tests

## Testing
- `pytest tests/test_safe_html_parser_hypothesis.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad65d2bce8832dac3dc42b07b765f5