### PR TITLE
chore: restrict CI to main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,10 @@ name: CI CPU
 
 on:
   push:
-    paths-ignore:
-      - 'docs/**'
+    branches: [ main ]
   pull_request:
+    branches: [ main ]
+  workflow_dispatch:
 
 env:
   CUDA_VISIBLE_DEVICES: ""


### PR DESCRIPTION
## Summary
- trigger CI workflow on pushes and pull requests to `main`
- allow manual `workflow_dispatch`

## Testing
- `pytest -q` *(fails: No module named 'tenacity')*


------
https://chatgpt.com/codex/tasks/task_e_68ad65f03f90832d811e45a95a5e543f