### PR TITLE
chore: add release drafter workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,20 @@
+name-template: 'v$NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
+categories:
+  - title: '### 🚀 Features'
+    labels:
+      - feature
+      - enhancement
+  - title: '### 🐛 Bug Fixes'
+    labels:
+      - bug
+      - fix
+  - title: '### 🧰 Maintenance'
+    labels:
+      - chore
+      - refactor
+      - docs
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+template: |
+  ## Changes
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,18 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- add release drafter configuration and workflow to auto-update release drafts

## Testing
- `pre-commit run --files .github/release-drafter.yml .github/workflows/release-drafter.yml`
- `pytest` *(fails: IndentationError in server.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ad65fb7700832dbd96b917294d71f0