### PR TITLE
ci: install dependencies in CPU workflow

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -25,6 +25,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-ci.txt
+          pip install -r requirements-cpu.txt
       - name: Start mock server
         run: |
           python - <<'PY' &


### PR DESCRIPTION
## Summary
- ensure CI CPU workflow installs dependencies before running mock server

## Testing
- `pre-commit run flake8 --files .github/workflows/ci_cpu.yml`
- `yamllint .github/workflows/ci_cpu.yml` *(fails: line too long)*
- `pre-commit run --files .github/workflows/ci_cpu.yml` *(interrupted: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6b7199b8832d9d6641143cbd615b