### PR TITLE
feat: add hypothesis dependency for CI tests

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -16,3 +16,4 @@ python-dotenv>=1.0.1
 werkzeug>=3.1.3,<4
 mypy==1.10.0
 
+hypothesis>=6.0.0


### PR DESCRIPTION
## Summary
- add hypothesis to CI requirements for property-based testing

## Testing
- `pip install -r requirements-ci.txt`
- `pytest -m "not integration"`


------
https://chatgpt.com/codex/tasks/task_e_68ad73d75dfc832da08dcf1414c81963