### PR TITLE
chore(ci): configure gitleaks via env variable

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -26,8 +26,8 @@ jobs:
           persist-credentials: false
       - name: Run Gitleaks
         uses: gitleaks/gitleaks-action@v2
-        with:
-          args: "--report-format sarif --report-path gitleaks.sarif"
+        env:
+          GITLEAKS_ARGS: "--report-format sarif --report-path gitleaks.sarif"
       - name: Upload SARIF report
         uses: github/codeql-action/upload-sarif@v3
         with:


### PR DESCRIPTION
## Summary
- configure gitleaks using env var for args

## Testing
- `pre-commit run --files .github/workflows/secret-scan.yml` *(interrupted: KeyboardInterrupt)*
- `pytest tests/test_cache.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad76dc64c0832d91e247f9c824d616