### PR TITLE
Добавить fetch-depth в secret scan workflow

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -23,6 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
+          fetch-depth: 0
           persist-credentials: false
       - name: Run Gitleaks
         uses: gitleaks/gitleaks-action@v2


### PR DESCRIPTION
## Summary
- ensure full git history for secret scan by setting fetch-depth to 0 in checkout step

## Testing
- `pre-commit run --files .github/workflows/secret-scan.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad76dc44d0832daa6b7b9ae17e533c