### PR TITLE
fix: configure gitleaks sarif output path

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -27,8 +27,8 @@ jobs:
           persist-credentials: false
       - name: Run Gitleaks
         uses: gitleaks/gitleaks-action@v2
-        env:
-          GITLEAKS_ARGS: "--report-format sarif --report-path gitleaks.sarif"
+        with:
+          args: --report-format sarif --report-path gitleaks.sarif
       - name: Upload SARIF report
         uses: github/codeql-action/upload-sarif@v3
         with:


### PR DESCRIPTION
## Summary
- configure gitleaks action to pass CLI args so SARIF report is generated

## Testing
- `pre-commit run --files .github/workflows/secret-scan.yml`
- `gitleaks detect --source . --report-format sarif --report-path gitleaks.sarif`


------
https://chatgpt.com/codex/tasks/task_e_68ad7ddd3464832da3d9bd3996dac4e0