### PR TITLE
Use data handler script for healthcheck workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -171,31 +171,24 @@ jobs:
   healthcheck:
     needs: build
     runs-on: ubuntu-24.04
-    env:
-      DOCKERHUB_USERNAME: ${{ secrets.AVERINALEKS }}
-      DOCKERHUB_TOKEN: ${{ secrets.BOT }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
           persist-credentials: false
           path: bot
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          registry: docker.io
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
-      - name: Run container
-        run: |
-          docker run -d -p 8000:8000 --name bot-test ${{ env.DOCKERHUB_USERNAME }}/myapp:latest
       - name: Install dependencies
-        run: pip install requests
+        run: pip install gunicorn flask ccxt python-dotenv requests
+      - name: Start data handler service
+        run: |
+          scripts/run_data_handler_service.sh --bind 0.0.0.0:8000 &
+          echo $! > service.pid
+          sleep 5
+        working-directory: bot
       - name: Health check
         run: python scripts/health_check.py
         working-directory: bot
       - name: Cleanup
         if: always()
         run: |
-          docker stop bot-test || true
-          docker rm bot-test || true
+          kill $(cat service.pid) || true


### PR DESCRIPTION
## Summary
- replace Docker-based healthcheck with local data handler service
- ensure service listens on port 8000 and run Python health check

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml`


------
https://chatgpt.com/codex/tasks/task_e_68ad8b703a24832d852a0d897bd20857