### PR TITLE
Add health endpoint to DataHandler

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -2913,6 +2913,13 @@ def clusters(symbol: str):
     return jsonify({"clusters": value})
 
 
+@api_app.route("/health")
+def health():
+    """Basic health check endpoint."""
+
+    return jsonify({"status": "ok"})
+
+
 @api_app.route("/ping")
 def ping():
     return jsonify({"status": "ok"})

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda/nvvm/lib64
       - PYTHONPATH=/app
     healthcheck:
-      test: ["CMD", "curl", "--netrc-file", "/dev/null", "-f", "http://localhost:8000/ping"]
+      test: ["CMD", "curl", "--netrc-file", "/dev/null", "-f", "http://localhost:8000/health"]
       interval: 5s
       timeout: 2s
       retries: 12


### PR DESCRIPTION
## Summary
- add `/health` endpoint returning `{ "status": "ok" }`
- update `docker-compose.yml` to use `/health` in DataHandler healthcheck

## Testing
- `SKIP=pytest pre-commit run --files data_handler.py docker-compose.yml`
- `pytest tests/test_service_scripts.py::test_data_handler_service_price -m integration -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad8b7575b4832d99845fb373743db4