### PR TITLE
Handle missing LLM response in review workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -41,13 +41,14 @@ jobs:
           response=$(curl -s -X POST http://127.0.0.1:8000/v1/completions \
             -H "Content-Type: application/json" \
             -d "$(jq -n --arg prompt "$(cat diff.patch)" --arg model "${{ vars.LLM_MODEL || 'Qwen/Qwen2.5-Coder-7B-Instruct' }}" '{model:$model,prompt:$prompt}')" || true)
-          review=$(echo "$response" | jq -r '.choices[0].text // ""' 2>/dev/null || true)
-          printf "%s" "$review" > review.md
-          if [ ! -s review.md ]; then
-            echo "LLM response was empty" > review.md
+          if echo "$response" | jq -e '.choices[0].text' >/dev/null 2>&1; then
+            review=$(echo "$response" | jq -r '.choices[0].text')
+          else
+            echo "$response" > review.md
             echo "has_content=false" >> "$GITHUB_OUTPUT"
             exit 1
           fi
+          printf "%s" "$review" > review.md
           echo "has_content=true" >> "$GITHUB_OUTPUT"
       - name: Comment PR
         if: always() && steps.llm-review.outputs.has_content == 'true'


### PR DESCRIPTION
## Summary
- handle missing `.choices[0].text` in GPT-OSS review workflow
- write raw response to `review.md` and flag lack of content when the LLM errors

## Testing
- `pre-commit run --files .github/workflows/gptoss_review.yml`
- `GITHUB_OUTPUT=/tmp/out bash /tmp/test_script.sh; cat review.md`


------
https://chatgpt.com/codex/tasks/task_e_68ad8d062078832db480636804eed208