### PR TITLE
chore: guard empty review in workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -60,6 +60,7 @@ jobs:
       - name: LLM review
         id: llm-review
         run: |
+          if [ -z "$review" ]; then
             echo "has_content=false" >> "$GITHUB_OUTPUT"
             exit 1
           fi


### PR DESCRIPTION
## Summary
- ensure LLM review step handles empty output

## Testing
- `act -n pull_request -W .github/workflows/gptoss_review.yml -j review` *(fails: Couldn't get a valid docker connection: no DOCKER_HOST and an invalid container socket '')*

------
https://chatgpt.com/codex/tasks/task_e_68ad95969c48832d9e94df5801dbe19a