### PR TITLE
ci: use custom token for gitleaks

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -27,6 +27,8 @@ jobs:
           persist-credentials: false
       - name: Run Gitleaks
         uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}
       - name: Upload SARIF report
         uses: github/codeql-action/upload-sarif@v3
         with:


### PR DESCRIPTION
## Summary
- use secret TOKEN as GITHUB_TOKEN for gitleaks workflow

## Testing
- `SKIP=pytest pre-commit run --files .github/workflows/secret-scan.yml -v`
- `pytest tests/test_password_utils.py`
- `./bin/act -W .github/workflows/secret-scan.yml` *(fails: couldn't get a valid docker connection)*

------
https://chatgpt.com/codex/tasks/task_e_68ad960cacb4832db81576c519160ccd