### PR TITLE
feat: add health endpoint to data handler service

### DIFF
--- a/services/data_handler_service.py
+++ b/services/data_handler_service.py
@@ -29,7 +29,7 @@ def init_exchange() -> None:
 @app.before_request
 def _ensure_exchange() -> None:
     global initialized
-    if not initialized and request.endpoint != 'ping':
+    if not initialized and request.endpoint not in {'ping', 'health'}:
         init_exchange()
         initialized = True
 
@@ -60,6 +60,11 @@ def price(symbol: str):
 
 @app.route('/ping')
 def ping():
+    return jsonify({'status': 'ok'})
+
+
+@app.route('/health')
+def health():
     return jsonify({'status': 'ok'})
 
 


### PR DESCRIPTION
## Summary
- add /health route returning status ok
- skip exchange initialization for ping and health endpoints

## Testing
- `pytest tests/test_service_scripts.py::test_data_handler_service_price tests/test_service_scripts.py::test_data_handler_service_price_error -m integration -q`
- `pytest tests/test_data_handler_service_logging.py -q`
- `python scripts/health_check.py`


------
https://chatgpt.com/codex/tasks/task_e_68ada2642de8832db95c9f3053f9fd29