### PR TITLE
Skip exchange init for health checks

### DIFF
--- a/services/data_handler_service.py
+++ b/services/data_handler_service.py
@@ -29,7 +29,7 @@ def init_exchange() -> None:
 @app.before_request
 def _ensure_exchange() -> None:
     global initialized
-    if not initialized and request.endpoint != 'ping':
+    if not initialized and request.endpoint not in {'ping', 'health'}:
         init_exchange()
         initialized = True
 
@@ -60,6 +60,11 @@ def price(symbol: str):
 
 @app.route('/ping')
 def ping():
+    return jsonify({'status': 'ok'})
+
+
+@app.route('/health')
+def health():
     return jsonify({'status': 'ok'})
 
 


### PR DESCRIPTION
## Summary
- add a /health endpoint returning status ok
- avoid exchange init for ping and health routes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ada26dfe48832d90d528a9bdb842a8