### PR TITLE
Handle HTTPException in data handler service

### DIFF
--- a/services/data_handler_service.py
+++ b/services/data_handler_service.py
@@ -4,6 +4,7 @@ import logging
 import ccxt
 import os
 from dotenv import load_dotenv
+from werkzeug.exceptions import HTTPException
 app = Flask(__name__)
 app.config["MAX_CONTENT_LENGTH"] = 1 * 1024 * 1024  # 1 MB limit
 
@@ -68,8 +69,10 @@ def too_large(_):
     return jsonify({'error': 'payload too large'}), 413
 
 @app.errorhandler(Exception)
-def handle_unexpected_error(exc: Exception) -> tuple:
+def handle_unexpected_error(exc: Exception):
     """Log unexpected errors and return a 500 response."""
+    if isinstance(exc, HTTPException):
+        return exc
     logging.exception("Unhandled error: %s", exc)
     return jsonify({'error': 'internal server error'}), 500
 

--- a/tests/test_data_handler_service_not_found.py
+++ b/tests/test_data_handler_service_not_found.py
@@ -1,0 +1,25 @@
+import importlib
+import sys
+import types
+
+
+def test_unknown_route_returns_404(monkeypatch):
+    class DummyExchange:
+        def fetch_ticker(self, symbol):
+            return {'last': 1.0}
+
+    ccxt = types.ModuleType("ccxt")
+    ccxt.bybit = lambda *args, **kwargs: DummyExchange()
+    monkeypatch.setitem(sys.modules, "ccxt", ccxt)
+
+    monkeypatch.delitem(sys.modules, "bot.services.data_handler_service", raising=False)
+    monkeypatch.delitem(sys.modules, "services.data_handler_service", raising=False)
+    monkeypatch.delitem(sys.modules, "flask", raising=False)
+    importlib.import_module("flask")
+    import bot.services as services_pkg
+    monkeypatch.delattr(services_pkg, "data_handler_service", raising=False)
+    data_handler_service = importlib.import_module("bot.services.data_handler_service")
+
+    client = data_handler_service.app.test_client()
+    resp = client.get("/missing")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- return HTTPException instances directly in data_handler_service to preserve status codes
- add regression test ensuring unknown routes return 404

## Testing
- `pre-commit run --files services/data_handler_service.py tests/test_data_handler_service_not_found.py`
- `pytest tests/test_data_handler_service_not_found.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ada2672d98832db72b348496a37e62