### PR TITLE
Skip GPT-OSS review when diff or review is empty

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -60,9 +60,9 @@ jobs:
       - name: LLM review
         id: llm-review
         run: |
-          if [ -z "$review" ]; then
+          if [ ! -s diff.patch ] || [ -z "$review" ]; then
             echo "has_content=false" >> "$GITHUB_OUTPUT"
-            exit 1
+            exit 0
           fi
           printf "%s" "$review" > review.md
           echo "has_content=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- avoid failing workflow if `diff.patch` is empty or LLM review output missing

## Testing
- `touch diff.patch` then run review snippet to ensure `has_content=false`
- `act pull_request -W .github/workflows/gptoss_review.yml` *(fails: Couldn't get a valid docker connection)*

------
https://chatgpt.com/codex/tasks/task_e_68adac0de3e8832d997f98533f1c28b2