### PR TITLE
Явное конфигурирование тайм-аутов HTTP-клиентов

### DIFF
--- a/gpt_client.py
+++ b/gpt_client.py
@@ -5,7 +5,10 @@ import socket
 from urllib.parse import urlparse
 from ipaddress import ip_address
 
+# NOTE: httpx is imported for exception types only.
 import httpx
+
+from http_client import get_httpx_client
 import sys
 
 if "tenacity" in sys.modules and not getattr(sys.modules["tenacity"], "__file__", None):
@@ -104,7 +107,7 @@ def _post_with_retry(
         )
         raise GPTClientNetworkError("GPT_OSS_API host resolution mismatch")
 
-    with httpx.Client(trust_env=False, timeout=timeout) as client:
+    with get_httpx_client(timeout=timeout, trust_env=False) as client:
         with client.stream("POST", url, json={"prompt": prompt}) as response:
             response.raise_for_status()
             content = bytearray()

--- a/gptoss_check/check_code.py
+++ b/gptoss_check/check_code.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 import httpx
 
+from http_client import get_httpx_client
+
 from gpt_client import GPTClientError, query_gpt
 
 
@@ -21,7 +23,7 @@ def wait_for_api(api_url: str, timeout: int | None = None) -> None:
     deadline = time.time() + timeout
     while time.time() < deadline:
         try:
-            with httpx.Client(timeout=5, trust_env=False) as client:
+            with get_httpx_client(timeout=5, trust_env=False) as client:
                 response = client.get(api_url.rstrip("/"))
                 response.close()
             return
@@ -57,7 +59,7 @@ def send_telegram(msg: str) -> None:
     chat_id = os.getenv("TELEGRAM_CHAT_ID")
     if token and chat_id:
         try:
-            with httpx.Client(timeout=15, trust_env=False) as client:
+            with get_httpx_client(timeout=15, trust_env=False) as client:
                 response = client.post(
                     f"https://api.telegram.org/bot{token}/sendMessage",
                     data={"chat_id": chat_id, "text": msg[:4000]},

--- a/http_client.py
+++ b/http_client.py
@@ -1,0 +1,29 @@
+"""Utilities for creating HTTP clients with default timeouts."""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+import requests
+
+DEFAULT_TIMEOUT = float(os.getenv("MODEL_DOWNLOAD_TIMEOUT", "30"))
+
+
+def get_requests_session(timeout: float = DEFAULT_TIMEOUT) -> requests.Session:
+    """Return a :class:`requests.Session` with a default timeout."""
+    session = requests.Session()
+    original = session.request
+
+    def request(method: str, url: str, **kwargs):
+        kwargs.setdefault("timeout", timeout)
+        return original(method, url, **kwargs)
+
+    session.request = request  # type: ignore[assignment]
+    return session
+
+
+def get_httpx_client(timeout: float = DEFAULT_TIMEOUT, **kwargs) -> httpx.Client:
+    """Return an :class:`httpx.Client` with a default timeout."""
+    kwargs.setdefault("timeout", timeout)
+    return httpx.Client(**kwargs)

--- a/server.py
+++ b/server.py
@@ -27,40 +27,6 @@ except ImportError as exc:  # pragma: no cover - dependency required
 from pydantic import BaseModel, Field, ValidationError
 
 API_KEYS: set[str] = set()
-TIMEOUT = float(os.getenv("MODEL_DOWNLOAD_TIMEOUT", "30"))
-
-
-def _configure_timeout(timeout: float) -> None:
-    """Ensure all HTTP clients use a default timeout."""
-    try:  # requests
-        import requests
-        from requests.sessions import Session
-
-        original = Session.request
-
-        def request(self, method, url, **kwargs):
-            kwargs.setdefault("timeout", timeout)
-            return original(self, method, url, **kwargs)
-
-        Session.request = request
-    except Exception as exc:  # pragma: no cover - best effort
-        logging.debug("requests timeout setup failed: %s", exc)
-
-    try:  # httpx
-        import httpx
-
-        orig_init = httpx.Client.__init__
-
-        def init(self, *args, **kwargs):  # type: ignore[override]
-            kwargs.setdefault("timeout", timeout)
-            orig_init(self, *args, **kwargs)
-
-        httpx.Client.__init__ = init  # type: ignore[assignment]
-    except Exception as exc:  # pragma: no cover - optional dependency
-        logging.debug("httpx timeout setup failed: %s", exc)
-
-
-_configure_timeout(TIMEOUT)
 
 class ModelManager:
     """Manage loading and inference model state."""


### PR DESCRIPTION
## Summary
- Удалён глобальный патч тайм-аутов HTTP-запросов
- Добавлены фабрики `get_requests_session` и `get_httpx_client`
- Код обновлён для использования новых фабрик

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68add7fe5c88832da127bb5f0ffba27b