### PR TITLE
Implement lazy config loading and custom ConfigLoadError

### DIFF
--- a/tests/test_load_defaults_error.py
+++ b/tests/test_load_defaults_error.py
@@ -1,0 +1,11 @@
+import pytest
+from bot import config
+
+
+def test_load_defaults_raises_config_load_error(monkeypatch, tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text("{invalid")
+    monkeypatch.setattr(config, "CONFIG_PATH", str(bad))
+    monkeypatch.setattr(config, "DEFAULTS", None)
+    with pytest.raises(config.ConfigLoadError):
+        config.load_defaults()


### PR DESCRIPTION
## Summary
- Lazily load configuration defaults from `config.json`
- Replace `SystemExit` with `ConfigLoadError` for better error handling
- Add regression test for failing config loading

## Testing
- `pytest tests/test_load_defaults_error.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68add8030f14832dbba8e7554c99325c