### PR TITLE
feat: add generic password complexity error

### DIFF
--- a/password_utils.py
+++ b/password_utils.py
@@ -33,14 +33,17 @@ else:
 
 def validate_password_complexity(password: str) -> None:
     """Проверяет наличие цифр, верхнего/нижнего регистра и спецсимволов."""
+    violations = []
     if not re.search(r"[A-Z]", password):
-        raise ValueError("Password must contain an uppercase letter")
+        violations.append("uppercase")
     if not re.search(r"[a-z]", password):
-        raise ValueError("Password must contain a lowercase letter")
+        violations.append("lowercase")
     if not re.search(r"\d", password):
-        raise ValueError("Password must contain a digit")
+        violations.append("digit")
     if not re.search(r"[^\w\s]", password):
-        raise ValueError("Password must contain a special character")
+        violations.append("special")
+    if violations:
+        raise ValueError("Пароль не соответствует требованиям сложности")
 
 
 def validate_password_length(password: str) -> None:

--- a/tests/test_password_utils.py
+++ b/tests/test_password_utils.py
@@ -84,7 +84,7 @@ def test_hash_password_generates_unique_hashes():
 
 @pytest.mark.parametrize("weak_password", WEAK_PASSWORDS)
 def test_hash_password_rejects_weak_passwords(weak_password):
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Пароль не соответствует требованиям сложности"):
         hash_password(weak_password)
 
 


### PR DESCRIPTION
## Summary
- collect all password complexity violations and raise a single generic error
- adjust tests to expect the new generic complexity message

## Testing
- `pytest tests/test_password_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68add8060734832db16323ef3bc0993d