### PR TITLE
Silence TensorFlow logs during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ENV OMP_NUM_THREADS=1
 ENV MKL_NUM_THREADS=1
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
+ENV TF_CPP_MIN_LOG_LEVEL=3
 
 # Установка необходимых пакетов для сборки и обновление критических библиотек
 # Обновление linux-libc-dev устраняет CVE-2024-50217 и CVE-2025-21976, а libgcrypt20 — CVE-2024-2236
@@ -69,6 +70,7 @@ ENV OMP_NUM_THREADS=1
 ENV MKL_NUM_THREADS=1
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
+ENV TF_CPP_MIN_LOG_LEVEL=3
 
 WORKDIR /app
 
@@ -106,8 +108,8 @@ RUN echo "Checking library versions and CUDA availability..." && \
     /app/venv/bin/python3 -c "import optuna; print('Optuna Version:', optuna.__version__)" || echo "Optuna check failed" && \
     /app/venv/bin/python3 -c "import shap; print('SHAP Version:', shap.__version__)" || echo "SHAP check failed" && \
     /app/venv/bin/python3 -c "import numba; print('Numba Version:', numba.__version__)" || echo "Numba check failed" && \
+    /app/venv/bin/python3 -c "import stable_baselines3; print('SB3 Version:', stable_baselines3.__version__)" || echo "SB3 check failed" && \
     if [ "$ENABLE_TF" = "1" ]; then /app/venv/bin/python3 -c "import tensorflow as tf; print('TF Version:', tf.__version__)" || echo "TensorFlow check failed"; else echo "TensorFlow check skipped"; fi && \
-    /app/venv/bin/python3 -c "import stable_baselines3 as sb3; print('SB3 Version:', sb3.__version__)" || echo "SB3 check failed" && \
     /app/venv/bin/python3 -c "import pytorch_lightning as pl; print('Lightning Version:', pl.__version__)" || echo "Lightning check failed" && \
     /app/venv/bin/python3 -c "import mlflow; print('MLflow Version:', mlflow.__version__)" || echo "MLflow check failed"
 


### PR DESCRIPTION
## Summary
- Import `stable_baselines3` before optional TensorFlow check so any TF logs appear in order
- Set `TF_CPP_MIN_LOG_LEVEL=3` to suppress TensorFlow info messages during build

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_68add81caec8832db821d2dbb315433b