### PR TITLE
ci: pin release drafter action

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,6 +13,8 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5
+        with:
+          config-name: release-drafter.yml
         env:
           GITHUB_TOKEN: ${{ secrets.TOKEN }}


### PR DESCRIPTION
## Summary
- pin release drafter action to b1476f6e6eb133afa41ed8589daba6dc69b4d3f5
- set config-name to release-drafter.yml

## Testing
- `python -m pre_commit run --files .github/workflows/release-drafter.yml`

------
https://chatgpt.com/codex/tasks/task_e_68ade7c0fee0832d8ade822c2ce31a9b