### PR TITLE
Explicitly configure logging in entry points

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -2926,7 +2926,10 @@ def ping():
 
 
 if __name__ == "__main__":
+    from bot.utils import configure_logging
+
     load_dotenv()
+    configure_logging()
     host = os.getenv("HOST", "127.0.0.1")
     port = int(os.getenv("PORT", "8000"))
     logger.info("Запуск сервиса DataHandler на %s:%s", host, port)

--- a/services/data_handler_service.py
+++ b/services/data_handler_service.py
@@ -83,7 +83,10 @@ def handle_unexpected_error(exc: Exception):
 
 
 if __name__ == "__main__":
+    from bot.utils import configure_logging
+
     load_dotenv()
+    configure_logging()
     host = os.getenv("HOST", "127.0.0.1")
     port = int(os.getenv("PORT", "8000"))
     app.logger.info('Запуск сервиса DataHandlerService на %s:%s', host, port)

--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -119,7 +119,10 @@ def too_large(_):
     return jsonify({'error': 'payload too large'}), 413
 
 if __name__ == '__main__':
+    from bot.utils import configure_logging
+
     load_dotenv()
+    configure_logging()
     host = validate_host()
     port = safe_int(os.getenv("PORT", "8000"))
     app.logger.info('Запуск сервиса ModelBuilder на %s:%s', host, port)

--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -12,8 +12,6 @@ from dotenv import load_dotenv
 import logging
 from utils import validate_host, safe_int
 
-logging.basicConfig(level=logging.INFO)
-
 app = Flask(__name__)
 app.config["MAX_CONTENT_LENGTH"] = 1 * 1024 * 1024  # 1 MB limit
 
@@ -289,8 +287,10 @@ def handle_unexpected_error(exc: Exception) -> tuple:
 
 
 if __name__ == '__main__':
+    from utils import configure_logging
 
     load_dotenv()
+    configure_logging()
     host = validate_host()
     port = safe_int(os.getenv("PORT", "8002"))
     init_exchange()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -79,6 +79,10 @@ def test_logging_not_duplicated_on_reimport(monkeypatch, tmp_path, capsys):
 
     utils_mod = importlib.import_module("bot.utils")
     captured = capsys.readouterr()
+    assert "Logging initialized" not in captured.err
+
+    utils_mod.configure_logging()
+    captured = capsys.readouterr()
     assert captured.err.count("Logging initialized") == 1
 
     utils_mod.logger.info("first")

--- a/utils.py
+++ b/utils.py
@@ -58,10 +58,6 @@ def configure_logging() -> None:
     )
 
 
-# Инициализировать логирование при импорте модуля
-configure_logging()
-
-
 # Hide Numba performance warnings
 try:
     from numba import jit, prange, NumbaPerformanceWarning  # type: ignore


### PR DESCRIPTION
## Summary
- remove automatic logging setup from `utils`
- initialize logging explicitly in application entrypoints
- add tests ensuring re-importing `utils` does not duplicate handlers

## Testing
- `pre-commit run flake8 --files utils.py tests/test_utils.py data_handler.py services/data_handler_service.py services/trade_manager_service.py services/model_builder_service.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adef0cb3e8832dac180a15b176e505