### PR TITLE
Use logging in health check script

### DIFF
--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python
 """Simple health check for API endpoints."""
 import sys
-import time
 from typing import Iterable
 
+import logging
 import requests
+
+
+logger = logging.getLogger(__name__)
 
 
 def check_endpoints(base_url: str, endpoints: Iterable[str]) -> int:
@@ -13,14 +16,15 @@ def check_endpoints(base_url: str, endpoints: Iterable[str]) -> int:
         try:
             response = requests.get(url, timeout=10)
             response.raise_for_status()
-            print(f"{url} -> {response.status_code}")
-        except Exception as exc:  # noqa: BLE001
-            print(f"Health check failed for {url}: {exc}")
+            logger.info("%s -> %s", url, response.status_code)
+        except requests.RequestException as exc:
+            logger.error("Health check failed for %s: %s", url, exc)
             return 1
     return 0
 
 
 def main() -> int:
+    logging.basicConfig(level=logging.INFO)
     base_url = "http://localhost:8000"
     endpoints = ["/health", "/ping"]
     return check_endpoints(base_url, endpoints)


### PR DESCRIPTION
## Summary
- switch health check script to logging instead of prints
- catch only requests.RequestException for endpoint errors
- configure basic logger for health checks

## Testing
- `pytest tests/test_service_scripts.py -k health_check -q`
- `pytest tests/test_config_logging.py -q`
- `python scripts/health_check.py >/tmp/health.log && echo success || echo fail`


------
https://chatgpt.com/codex/tasks/task_e_68adef66b700832daae4dc3f5fa2760a