### PR TITLE
Validate Content-Type in GPT client responses

### DIFF
--- a/gpt_client.py
+++ b/gpt_client.py
@@ -110,6 +110,9 @@ def _post_with_retry(
     with get_httpx_client(timeout=timeout, trust_env=False) as client:
         with client.stream("POST", url, json={"prompt": prompt}) as response:
             response.raise_for_status()
+            content_type = response.headers.get("Content-Type", "")
+            if not content_type.startswith("application/json"):
+                raise GPTClientResponseError("Unexpected Content-Type from GPT OSS API")
             content = bytearray()
             for chunk in response.iter_bytes():
                 content.extend(chunk)
@@ -207,6 +210,9 @@ async def query_gpt_async(prompt: str) -> str:
         async with httpx.AsyncClient(trust_env=False, timeout=timeout) as client:
             async with client.stream("POST", url, json={"prompt": prompt}) as response:
                 response.raise_for_status()
+                content_type = response.headers.get("Content-Type", "")
+                if not content_type.startswith("application/json"):
+                    raise GPTClientResponseError("Unexpected Content-Type from GPT OSS API")
                 content = bytearray()
                 async for chunk in response.aiter_bytes():
                     content.extend(chunk)


### PR DESCRIPTION
## Summary
- ensure GPT client validates `Content-Type` headers and raises GPTClientResponseError for non-JSON
- add tests covering incorrect `Content-Type` handling in synchronous and async clients

## Testing
- `pytest tests/test_gpt_client.py::test_query_gpt_bad_content_type -q`
- `pytest tests/test_gpt_client.py::test_query_gpt_async_bad_content_type -q`
- `pytest tests/test_gpt_client.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68adef6cc478832d9a0894bb6483eaf3