### PR TITLE
Use relative import for sanitize_symbol

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -14,7 +14,7 @@ def _sanitize_symbol(symbol: str) -> str:
 
     Import is done lazily to avoid circular dependencies with ``bot.utils``.
     """
-    from bot.utils import sanitize_symbol  # noqa: WPS433 (import inside function)
+    from .utils import sanitize_symbol  # noqa: WPS433 (import inside function)
 
     return sanitize_symbol(symbol)
 


### PR DESCRIPTION
## Summary
- use relative import for sanitize_symbol in cache module

## Testing
- `pre-commit run --files cache.py` (flake8 passed, pytest hook skipped)
- `pytest tests/test_cache.py -q`
- `python -c "import bot.cache; print(bot.cache._sanitize_symbol('BTC/USDT'))"`
- `python -m bot.cache`


------
https://chatgpt.com/codex/tasks/task_e_68adef710674832db1323bb9f5c0e27d