### PR TITLE
Specify runtime packages in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,7 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y --no-install
     && openssl version
 
 # Копируем исходный код в /app/bot
-RUN apt-get update && apt-get install -y <нужные пакеты> \
+RUN apt-get update && apt-get install -y git curl \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY . /app/bot
 


### PR DESCRIPTION
## Summary
- install git and curl in runtime image instead of placeholder

## Testing
- `docker build .` *(fails: command not found)*
- `pytest` *(interrupted: 26 passed, then keyboard interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68adf28cd390832d85ae826cc126af01