### PR TITLE
fix: add build packages in Dockerfile.ci

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -9,6 +9,7 @@ ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
 # Обновление linux-libc-dev устраняет CVE-2025-21976, а libgcrypt20 — CVE-2024-2236
 RUN apt-get update && apt-get install --no-install-recommends -y \
+    python3 python3-venv build-essential linux-libc-dev libgcrypt20 \
     && python3 -m venv /venv \
     && /venv/bin/python -m pip install --no-cache-dir --upgrade --break-system-packages pip==25.2 \
     && find / -xdev -type l -lname "*..*" -print \


### PR DESCRIPTION
## Summary
- install python and build dependencies in builder stage

## Testing
- `pytest` *(fails: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_68adf896f4d4832dbe84550e6b6f2295