### PR TITLE
chore: update release drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize, edited]
 
 permissions:
@@ -15,7 +15,7 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5
+      - uses: release-drafter/release-drafter@v6
         with:
           config-name: release-drafter.yml
         env:


### PR DESCRIPTION
## Summary
- fix trigger to use `pull_request_target`
- use tagged v6 release of release-drafter action

## Testing
- `pre-commit run --files .github/workflows/release-drafter.yml` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `act pull_request_target -j update_release_draft -s TOKEN=ghs_test --dryrun` *(fails: daemon Docker Engine socket not found and containerDaemonSocket option was not set)*

------
https://chatgpt.com/codex/tasks/task_e_68adf9081f04832d915455d5bd79978b