### PR TITLE
Use context manager for requests session

### DIFF
--- a/http_client.py
+++ b/http_client.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import os
+from contextlib import contextmanager
+from functools import wraps
+from typing import Generator
 
 import httpx
 import requests
@@ -10,17 +13,24 @@ import requests
 DEFAULT_TIMEOUT = float(os.getenv("MODEL_DOWNLOAD_TIMEOUT", "30"))
 
 
-def get_requests_session(timeout: float = DEFAULT_TIMEOUT) -> requests.Session:
+@contextmanager
+def get_requests_session(
+    timeout: float = DEFAULT_TIMEOUT,
+) -> Generator[requests.Session, None, None]:
     """Return a :class:`requests.Session` with a default timeout."""
     session = requests.Session()
     original = session.request
 
+    @wraps(original)
     def request(method: str, url: str, **kwargs):
         kwargs.setdefault("timeout", timeout)
         return original(method, url, **kwargs)
 
     session.request = request  # type: ignore[assignment]
-    return session
+    try:
+        yield session
+    finally:
+        session.close()
 
 
 def get_httpx_client(timeout: float = DEFAULT_TIMEOUT, **kwargs) -> httpx.Client:


### PR DESCRIPTION
## Summary
- use contextmanager to ensure requests session closes
- preserve request metadata via functools.wraps

## Testing
- `pre-commit run --files http_client.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adf91934c0832dab8c7f07b2dfbe2a