### PR TITLE
Restrict HOST to localhost

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -127,10 +127,15 @@ def test_validate_host_rejects_all_interfaces(monkeypatch):
     with pytest.raises(ValueError):
         utils.validate_host()
 
-
-def test_validate_host_custom(monkeypatch, caplog):
+def test_validate_host_rejects_localhost(monkeypatch, caplog):
     monkeypatch.setenv('HOST', 'localhost')
     with caplog.at_level('WARNING'):
-        host = utils.validate_host()
-    assert host == 'localhost'
+        with pytest.raises(ValueError):
+            utils.validate_host()
     assert 'не локальный хост' in caplog.text
+
+
+def test_validate_host_rejects_example_com(monkeypatch):
+    monkeypatch.setenv('HOST', 'example.com')
+    with pytest.raises(ValueError):
+        utils.validate_host()

--- a/utils.py
+++ b/utils.py
@@ -146,10 +146,11 @@ def validate_host() -> str:
         if re.fullmatch(r"\d{1,3}(?:\.\d{1,3}){3}", host):
             raise ValueError(f"Некорректный IP: {host}")
         logger.warning("HOST '%s' не локальный хост", host)
-        return host
+        raise ValueError(f"HOST '{host}' не локальный хост")
 
     if host != "127.0.0.1":
         logger.warning("HOST '%s' не локальный хост", host)
+        raise ValueError(f"HOST '{host}' не локальный хост")
     return host
 
 


### PR DESCRIPTION
## Summary
- raise ValueError on non-local HOST values in `validate_host`
- add tests rejecting `localhost` and `example.com`

## Testing
- `pre-commit run --files utils.py tests/test_utils.py`
- `pytest tests/test_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68adfe716dbc832db19d9ef41b73ca91