### PR TITLE
Validate log level name before applying configuration

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -98,6 +98,25 @@ def test_logging_not_duplicated_on_reimport(monkeypatch, tmp_path, capsys):
     assert captured.err.count("second") == 1
 
 
+def test_configure_logging_invalid_level(monkeypatch, tmp_path, caplog):
+    import logging
+
+    monkeypatch.setenv("LOG_DIR", str(tmp_path))
+    monkeypatch.setenv("LOG_LEVEL", "NOPE")
+
+    logger = logging.getLogger("TradingBot")
+    for h in logger.handlers[:]:
+        logger.removeHandler(h)
+
+    with caplog.at_level(logging.WARNING):
+        utils.configure_logging()
+
+    assert "LOG_LEVEL 'NOPE' недопустим, используется INFO" in caplog.text
+    assert logger.level == logging.INFO
+
+    for h in logger.handlers[:]:
+        logger.removeHandler(h)
+
 def test_jit_stub_preserves_metadata(monkeypatch):
     if not hasattr(utils, "_numba_missing"):
         pytest.skip("numba is installed")

--- a/utils.py
+++ b/utils.py
@@ -24,7 +24,10 @@ def configure_logging() -> None:
     """Настроить переменные окружения и handlers для логирования."""
 
     level_name = os.getenv("LOG_LEVEL", "INFO").upper()
-    logger.setLevel(getattr(logging, level_name, logging.INFO))
+    if level_name not in logging._nameToLevel:
+        logger.warning("LOG_LEVEL '%s' недопустим, используется INFO", level_name)
+        level_name = "INFO"
+    logger.setLevel(logging._nameToLevel[level_name])
 
     log_dir = os.getenv("LOG_DIR", "/app/logs")
     fallback_dir = os.path.join(os.path.dirname(__file__), "logs")


### PR DESCRIPTION
## Summary
- warn and fall back to INFO if LOG_LEVEL is unknown
- test configure_logging handling of invalid log level

## Testing
- `pytest tests/test_utils.py -q`
- `pre-commit run --files utils.py tests/test_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68adfe7174ac832da24548adbbab2103