### PR TITLE
chore: isolate temp files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,12 @@ jobs:
           build-mount-path: /mnt
           pv-loop-path: /root-pv.img
           tmp-pv-loop-path: /mnt/tmp-pv.img
+      - name: Configure temp directories
+        run: |
+          mkdir -p /mnt/tmp /mnt/pip-cache
+          echo "TMPDIR=/mnt/tmp" >> $GITHUB_ENV
+          echo "PIP_CACHE_DIR=/mnt/pip-cache" >> $GITHUB_ENV
+        working-directory: /mnt
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
@@ -84,6 +90,7 @@ jobs:
           fi
           echo "/mnt/venv/bin" >> $GITHUB_PATH
       - name: Audit dependencies
+        working-directory: /mnt
         run: |
           pip install pip-audit
           pip-audit -f json -o pip-audit.json
@@ -92,16 +99,16 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: pip-audit-report
-          path: pip-audit.json
+          path: /mnt/pip-audit.json
       - name: Run flake8
         run: flake8 .
       - name: Remove test caches
         run: |
-          rm -rf .pytest_cache .cache
+          rm -rf /mnt/pytest_cache .pytest_cache .cache
           find . -type d -name '__pycache__' -exec rm -rf {} +
           find . -name '*.pyc' -delete
       - name: Run unit tests
-        run: pytest -m "not integration"
+        run: pytest -m "not integration" --cache-dir=/mnt/pytest_cache
       - name: Cleanup buildx
         run: docker buildx prune -af || true
 
@@ -153,6 +160,12 @@ jobs:
           build-mount-path: /mnt
           pv-loop-path: /root-pv.img
           tmp-pv-loop-path: /mnt/tmp-pv.img
+      - name: Configure temp directories
+        run: |
+          mkdir -p /mnt/tmp /mnt/pip-cache
+          echo "TMPDIR=/mnt/tmp" >> $GITHUB_ENV
+          echo "PIP_CACHE_DIR=/mnt/pip-cache" >> $GITHUB_ENV
+        working-directory: /mnt
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
@@ -177,10 +190,10 @@ jobs:
           echo "/mnt/venv/bin" >> $GITHUB_PATH
       - name: Remove test caches
         run: |
-          rm -rf .pytest_cache .cache
+          rm -rf /mnt/pytest_cache .pytest_cache .cache
           find . -type d -name '__pycache__' -exec rm -rf {} +
           find . -name '*.pyc' -delete
       - name: Run integration tests
-        run: pytest -m integration
+        run: pytest -m integration --cache-dir=/mnt/pytest_cache
       - name: Cleanup buildx
         run: docker buildx prune -af || true


### PR DESCRIPTION
## Summary
- route temporary and cache directories to /mnt in CI workflow
- store pip-audit report and pytest cache under /mnt

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_68ae0443dcc0832d923ed84396168f01