### PR TITLE
Ensure Trivy cache directory persists through job cleanup

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -133,4 +133,4 @@ jobs:
       - name: Cleanup after Trivy scan
         run: |
           docker system prune -af || true
-          sudo rm -rf /tmp/* /mnt/trivy-* || true
+          sudo rm -rf /tmp/* /mnt/trivy-tmp || true


### PR DESCRIPTION
## Summary
- avoid removing `/mnt/trivy-cache` during Trivy cleanup to let `actions/cache` post-step run cleanly

## Testing
- `pre-commit run --files .github/workflows/trivy.yml`

------
https://chatgpt.com/codex/tasks/task_e_68ae03fcbe50832dbdfa460e5931cee1