### PR TITLE
Handle missing numba explicitly

### DIFF
--- a/portfolio_backtest.py
+++ b/portfolio_backtest.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 try:  # pragma: no cover - optional dependency
     from numba import njit
-except Exception:  # pragma: no cover - fallback if numba unavailable
+except ImportError:  # pragma: no cover - fallback if numba unavailable
     def njit(*args, **kwargs):
         def decorator(func):
             return func


### PR DESCRIPTION
## Summary
- Avoid masking unrelated errors by catching only `ImportError` when `numba` is unavailable

## Testing
- `pip uninstall -y numba`
- `pip install hypothesis`
- `pip install flask`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae049c2ce8832dbca6cede8ab6864e