### PR TITLE
Handle localhost as loopback in host validation

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -140,21 +140,21 @@ def test_validate_host_default(monkeypatch, caplog):
     assert host == '127.0.0.1'
     assert 'HOST не установлен' in caplog.text
 
+def test_validate_host_accepts_loopback(monkeypatch):
+    monkeypatch.setenv('HOST', '127.0.0.1')
+    assert utils.validate_host() == '127.0.0.1'
 
-def test_validate_host_rejects_all_interfaces(monkeypatch):
-    monkeypatch.setenv('HOST', '0.0.0.0')
-    with pytest.raises(ValueError):
-        utils.validate_host()
 
-def test_validate_host_rejects_localhost(monkeypatch, caplog):
+def test_validate_host_accepts_localhost(monkeypatch, caplog):
     monkeypatch.setenv('HOST', 'localhost')
-    with caplog.at_level('WARNING'):
-        with pytest.raises(ValueError):
-            utils.validate_host()
-    assert 'не локальный хост' in caplog.text
+    with caplog.at_level('INFO'):
+        host = utils.validate_host()
+    assert host == '127.0.0.1'
+    assert 'localhost' in caplog.text
 
 
-def test_validate_host_rejects_example_com(monkeypatch):
-    monkeypatch.setenv('HOST', 'example.com')
+@pytest.mark.parametrize('host', ['0.0.0.0', '256.0.0.1', 'example.com'])
+def test_validate_host_rejects_invalid(host, monkeypatch):
+    monkeypatch.setenv('HOST', host)
     with pytest.raises(ValueError):
         utils.validate_host()

--- a/utils.py
+++ b/utils.py
@@ -141,6 +141,10 @@ def validate_host() -> str:
         logger.info("HOST не установлен, используется 127.0.0.1")
         return "127.0.0.1"
 
+    if host == "localhost":
+        logger.info("HOST 'localhost' интерпретирован как 127.0.0.1")
+        return "127.0.0.1"
+
     try:
         ip = ipaddress.ip_address(host)
         if ip.is_unspecified:


### PR DESCRIPTION
## Summary
- treat HOST=localhost as 127.0.0.1
- expand host validation tests for localhost, loopback, None and invalid values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae04a970bc832da31848865b5c172a