### PR TITLE
chore: update gitleaks args

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -27,6 +27,8 @@ jobs:
           persist-credentials: false
       - name: Run Gitleaks
         uses: gitleaks/gitleaks-action@v2
+        with:
+          gitleaks_args: --no-git --redact --report-format=sarif --report-path=results.sarif
         env:
           GITHUB_TOKEN: ${{ secrets.TOKEN }}
       - name: Upload SARIF report


### PR DESCRIPTION
## Summary
- add explicit gitleaks args for report generation

## Testing
- `gitleaks detect --no-git --redact --report-format=sarif --report-path=results.sarif`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_68ae06306ca0832dbd5c6b909446b52a