### PR TITLE
ci: swap cleanup before build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
           else
             echo "Device /dev/buildvg/buildlv not found, skipping wipefs"
           fi
+          sudo swapoff /mnt/swapfile || true
+          sudo rm -f /mnt/swapfile
           sudo rm -rf /mnt/*
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
@@ -143,6 +145,8 @@ jobs:
           else
             echo "Device /dev/buildvg/buildlv not found, skipping wipefs"
           fi
+          sudo swapoff /mnt/swapfile || true
+          sudo rm -f /mnt/swapfile
           sudo rm -rf /mnt/*
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10


### PR DESCRIPTION
## Summary
- disable previous runner swap before cleaning /mnt
- remove swapfile explicitly prior to clearing build volume

## Testing
- `pre-commit run --files .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_68ae04ef86b0832d8d2cfc0701947e88