### PR TITLE
fix: use pull_request for release drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,10 +1,11 @@
+---
 name: Release Drafter
 
-on:
+'on':
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize, edited]
 
 permissions:


### PR DESCRIPTION
## Summary
- trigger release-drafter on `pull_request` instead of `pull_request_target`
- quote the `on` key and add document start to satisfy yamllint

## Testing
- `SKIP=pytest pre-commit run --files .github/workflows/release-drafter.yml`
- `yamllint .github/workflows/release-drafter.yml`


------
https://chatgpt.com/codex/tasks/task_e_68ae137653c0832daafa2d106c427d43