### PR TITLE
Использовать публичный API для уровня логов

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -24,10 +24,11 @@ def configure_logging() -> None:
     """Настроить переменные окружения и handlers для логирования."""
 
     level_name = os.getenv("LOG_LEVEL", "INFO").upper()
-    if level_name not in logging._nameToLevel:
+    level_value = getattr(logging, level_name, None)
+    if not isinstance(level_value, int):
         logger.warning("LOG_LEVEL '%s' недопустим, используется INFO", level_name)
-        level_name = "INFO"
-    logger.setLevel(logging._nameToLevel[level_name])
+        level_value = logging.INFO
+    logger.setLevel(level_value)
 
     log_dir = os.getenv("LOG_DIR", "/app/logs")
     fallback_dir = os.path.join(os.path.dirname(__file__), "logs")


### PR DESCRIPTION
## Summary
- заменить использование закрытого API `logging._nameToLevel` на `getattr`

## Testing
- `flake8 utils.py && echo 'flake8 passed'`
- `pytest tests/test_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae157a1204832d9ad4143acd565c3a