### PR TITLE
Specify UTF-8 encoding for log file

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -46,7 +46,9 @@ def configure_logging() -> None:
         "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     )
 
-    file_handler = logging.FileHandler(os.path.join(log_dir, "trading_bot.log"))
+    file_handler = logging.FileHandler(
+        os.path.join(log_dir, "trading_bot.log"), encoding="utf-8"
+    )
     file_handler.setFormatter(formatter)
     logger.addHandler(file_handler)
 


### PR DESCRIPTION
## Summary
- ensure log files are written using UTF-8 encoding

## Testing
- `pytest tests/test_utils.py tests/test_data_handler_service_logging.py`
- `PYTHONPATH=.. python - <<'PY'
import logging, os
from bot import utils
utils.configure_logging()
logging.getLogger('TradingBot').info('Тестовая запись')
log_dir=os.getenv('LOG_DIR','/app/logs')
if not os.path.exists(os.path.join(log_dir,'trading_bot.log')):
    log_dir=os.path.join(os.path.dirname(__file__),'logs')
with open(os.path.join(log_dir,'trading_bot.log'), encoding='utf-8') as f:
    f.readlines()[-1]
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ae157c5828832d936d22b2e44db6fc