### PR TITLE
ci: handle swapfile before clearing build volume

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -50,7 +50,9 @@ jobs:
           else
             echo "Device /dev/buildvg/buildlv not found, skipping wipefs"
           fi
-          sudo rm -rf /mnt/*
+            sudo swapoff /mnt/swapfile || true
+            sudo rm -f /mnt/swapfile || true
+            sudo rm -rf /mnt/* || true
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -54,7 +54,9 @@ jobs:
           else
             echo "Device /dev/buildvg/buildlv not found, skipping wipefs"
           fi
-          sudo rm -rf /mnt/*
+            sudo swapoff /mnt/swapfile || true
+            sudo rm -f /mnt/swapfile || true
+            sudo rm -rf /mnt/* || true
       - name: Install LVM
         run: sudo apt-get update && sudo apt-get install -y lvm2
       - name: Maximize build space

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -59,7 +59,9 @@ jobs:
           else
             echo "Device /dev/buildvg/buildlv not found, skipping wipefs"
           fi
-          sudo rm -rf /mnt/*
+            sudo swapoff /mnt/swapfile || true
+            sudo rm -f /mnt/swapfile || true
+            sudo rm -rf /mnt/* || true
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:

--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -37,7 +37,9 @@ jobs:
           else
             echo "Device /dev/buildvg/buildlv not found, skipping wipefs"
           fi
-          sudo rm -rf /mnt/*
+            sudo swapoff /mnt/swapfile || true
+            sudo rm -f /mnt/swapfile || true
+            sudo rm -rf /mnt/* || true
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -49,7 +49,9 @@ jobs:
           else
             echo "Device /dev/buildvg/buildlv not found, skipping wipefs"
           fi
-          sudo rm -rf /mnt/*
+            sudo swapoff /mnt/swapfile || true
+            sudo rm -f /mnt/swapfile || true
+            sudo rm -rf /mnt/* || true
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:


### PR DESCRIPTION
## Summary
- add swapfile cleanup steps to workflows

## Testing
- `python -m pre_commit run --files .github/workflows/docker-publish.yml .github/workflows/bandit.yml .github/workflows/trivy.yml .github/workflows/submit-pypi.yml .github/workflows/semgrep.yml` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68aee969002c832db5af970eb36579c6