### PR TITLE
Use pull_request_target for release drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,7 +5,7 @@ name: Release Drafter
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize, edited]
 
 permissions:


### PR DESCRIPTION
## Summary
- ensure release drafter runs on pull_request_target events

## Testing
- `./actionlint .github/workflows/release-drafter.yml`


------
https://chatgpt.com/codex/tasks/task_e_68aeea2d9b4c832da65986c6ea39f1b9