### PR TITLE
Refactor GPT client parsing and fix CI workflow

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -48,4 +48,16 @@ jobs:
                       self.end_headers()
           HTTPServer(('127.0.0.1', 8009), Handler).serve_forever()
           PY
+          echo $! > server.pid
           sleep 1
+      - name: Run flake8
+        run: flake8 .
+      - name: Run mypy
+        run: mypy .
+      - name: Run pytest
+        run: pytest
+      - name: Stop mock server
+        if: always()
+        run: |
+          kill $(cat server.pid)
+          rm server.pid

--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -19,6 +19,7 @@ from bot.gpt_client import (
     MAX_RESPONSE_BYTES,
     _get_api_url_timeout,
     _validate_api_url,
+    _parse_gpt_response,
     query_gpt,
     query_gpt_async,
     query_gpt_json_async,
@@ -63,6 +64,21 @@ async def run_query(func, prompt):
         return await func(prompt)
     return await asyncio.to_thread(func, prompt)
 
+
+def test_parse_gpt_response_success():
+    content = json.dumps({"choices": [{"text": "ok"}]}).encode()
+    assert _parse_gpt_response(content) == "ok"
+
+
+def test_parse_gpt_response_invalid_json():
+    with pytest.raises(GPTClientJSONError):
+        _parse_gpt_response(b"not json")
+
+
+def test_parse_gpt_response_missing_field():
+    content = json.dumps({"foo": "bar"}).encode()
+    with pytest.raises(GPTClientResponseError):
+        _parse_gpt_response(content)
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("func, client_cls", QUERIES)


### PR DESCRIPTION
## Summary
- refactor GPT client JSON parsing into `_parse_gpt_response`
- add unit tests for `_parse_gpt_response`
- run linters and tests in CI with proper mock server shutdown

## Testing
- `python -m flake8 gpt_client.py tests/test_gpt_client.py`
- `python -m mypy gpt_client.py tests/test_gpt_client.py`
- `pytest tests/test_gpt_client.py`


------
https://chatgpt.com/codex/tasks/task_e_68aeea998a64832d80afba04d8a0d2a6