### PR TITLE
chore: simplify nvidia deps and cache wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,14 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
+      - name: Get pip cache dir
+        id: pip-cache
+        run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+      - name: Cache pip wheels
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ matrix.device }}-${{ hashFiles('requirements-ci.txt', 'requirements-cpu.txt') }}
       - name: Prepare virtualenv directory
         run: mkdir -p /mnt/venv
       - name: Cache virtualenv
@@ -84,7 +92,7 @@ jobs:
             mkdir -p /mnt/tmp /mnt/pip-cache
             export TMPDIR=/mnt/tmp
             export PIP_CACHE_DIR=/mnt/pip-cache
-            pip install --no-cache-dir -r requirements-ci.txt
+            pip install -r requirements-ci.txt
           fi
           echo "/mnt/venv/bin" >> $GITHUB_PATH
       - name: Audit dependencies
@@ -165,6 +173,14 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
+      - name: Get pip cache dir
+        id: pip-cache
+        run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+      - name: Cache pip wheels
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ matrix.device }}-${{ hashFiles('requirements-ci.txt', 'requirements-cpu.txt') }}
       - name: Prepare virtualenv directory
         run: mkdir -p /mnt/venv
       - name: Cache virtualenv
@@ -181,7 +197,7 @@ jobs:
             mkdir -p /mnt/tmp /mnt/pip-cache
             export TMPDIR=/mnt/tmp
             export PIP_CACHE_DIR=/mnt/pip-cache
-            pip install --no-cache-dir -r requirements-ci.txt
+            pip install -r requirements-ci.txt
           fi
           echo "/mnt/venv/bin" >> $GITHUB_PATH
       - name: Remove test caches

--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -24,6 +24,14 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Get pip cache dir
+        id: pip-cache
+        run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+      - name: Cache pip wheels
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.device }}-${{ hashFiles('requirements-ci.txt', 'requirements-cpu.txt') }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -256,43 +256,6 @@ numpy==2.2.6
     #   tensorboardx
     #   torchmetrics
     #   transformers
-nvidia-cublas-cu12==12.8.4.1
-    # via
-    #   nvidia-cudnn-cu12
-    #   nvidia-cusolver-cu12
-    #   torch
-nvidia-cuda-cupti-cu12==12.8.90
-    # via torch
-nvidia-cuda-nvrtc-cu12==12.8.93
-    # via torch
-nvidia-cuda-runtime-cu12==12.8.90
-    # via torch
-nvidia-cudnn-cu12==9.10.2.21
-    # via torch
-nvidia-cufft-cu12==11.3.3.83
-    # via torch
-nvidia-cufile-cu12==1.13.1.3
-    # via torch
-nvidia-curand-cu12==10.3.9.90
-    # via torch
-nvidia-cusolver-cu12==11.7.3.90
-    # via torch
-nvidia-cusparse-cu12==12.5.8.93
-    # via
-    #   nvidia-cusolver-cu12
-    #   torch
-nvidia-cusparselt-cu12==0.7.1
-    # via torch
-nvidia-nccl-cu12==2.27.3
-    # via torch
-nvidia-nvjitlink-cu12==12.8.93
-    # via
-    #   nvidia-cufft-cu12
-    #   nvidia-cusolver-cu12
-    #   nvidia-cusparse-cu12
-    #   torch
-nvidia-nvtx-cu12==12.8.90
-    # via torch
 openai==1.100.2
     # via -r requirements-core.in
 opentelemetry-api==1.36.0

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -76,68 +76,6 @@ numpy==2.2.6
     #   ml-dtypes
     #   tensorboard
     #   tensorflow
-nvidia-cublas-cu12==12.8.4.1
-    # via
-    #   -r requirements-gpu.in
-    #   nvidia-cudnn-cu12
-    #   nvidia-cusolver-cu12
-    #   torch
-nvidia-cuda-cupti-cu12==12.8.90
-    # via
-    #   -r requirements-gpu.in
-    #   torch
-nvidia-cuda-nvrtc-cu12==12.8.93
-    # via
-    #   -r requirements-gpu.in
-    #   torch
-nvidia-cuda-runtime-cu12==12.8.90
-    # via
-    #   -r requirements-gpu.in
-    #   torch
-nvidia-cudnn-cu12==9.10.2.21
-    # via
-    #   -r requirements-gpu.in
-    #   torch
-nvidia-cufft-cu12==11.3.3.83
-    # via
-    #   -r requirements-gpu.in
-    #   torch
-nvidia-cufile-cu12==1.13.1.3
-    # via
-    #   -r requirements-gpu.in
-    #   torch
-nvidia-curand-cu12==10.3.9.90
-    # via
-    #   -r requirements-gpu.in
-    #   torch
-nvidia-cusolver-cu12==11.7.3.90
-    # via
-    #   -r requirements-gpu.in
-    #   torch
-nvidia-cusparse-cu12==12.5.8.93
-    # via
-    #   -r requirements-gpu.in
-    #   nvidia-cusolver-cu12
-    #   torch
-nvidia-cusparselt-cu12==0.7.1
-    # via
-    #   -r requirements-gpu.in
-    #   torch
-nvidia-nccl-cu12==2.27.3
-    # via
-    #   -r requirements-gpu.in
-    #   torch
-nvidia-nvjitlink-cu12==12.8.93
-    # via
-    #   -r requirements-gpu.in
-    #   nvidia-cufft-cu12
-    #   nvidia-cusolver-cu12
-    #   nvidia-cusparse-cu12
-    #   torch
-nvidia-nvtx-cu12==12.8.90
-    # via
-    #   -r requirements-gpu.in
-    #   torch
 opt-einsum==3.4.0
     # via tensorflow
 optree==0.17.0

--- a/requirements.out
+++ b/requirements.out
@@ -349,65 +349,6 @@ numpy==2.2.6
     #   tensorboardx
     #   torchmetrics
     #   transformers
-nvidia-cublas-cu12==12.8.4.1
-    # via
-    #   -r requirements.txt
-    #   nvidia-cudnn-cu12
-    #   nvidia-cusolver-cu12
-    #   torch
-nvidia-cuda-cupti-cu12==12.8.90
-    # via
-    #   -r requirements.txt
-    #   torch
-nvidia-cuda-nvrtc-cu12==12.8.93
-    # via
-    #   -r requirements.txt
-    #   torch
-nvidia-cuda-runtime-cu12==12.8.90
-    # via
-    #   -r requirements.txt
-    #   torch
-nvidia-cudnn-cu12==9.10.2.21
-    # via
-    #   -r requirements.txt
-    #   torch
-nvidia-cufft-cu12==11.3.3.83
-    # via
-    #   -r requirements.txt
-    #   torch
-nvidia-cufile-cu12==1.13.1.3
-    # via
-    #   -r requirements.txt
-    #   torch
-nvidia-curand-cu12==10.3.9.90
-    # via
-    #   -r requirements.txt
-    #   torch
-nvidia-cusolver-cu12==11.7.3.90
-    # via
-    #   -r requirements.txt
-    #   torch
-nvidia-cusparse-cu12==12.5.8.93
-    # via
-    #   -r requirements.txt
-    #   nvidia-cusolver-cu12
-    #   torch
-nvidia-cusparselt-cu12==0.7.1
-    # via
-    #   -r requirements.txt
-    #   torch
-nvidia-nccl-cu12==2.27.3
-    # via
-    #   -r requirements.txt
-    #   torch
-nvidia-nvjitlink-cu12==12.8.93
-    # via
-    #   -r requirements.txt
-    #   nvidia-cufft-cu12
-    #   nvidia-cusolver-cu12
-    #   nvidia-cusparse-cu12
-    #   torch
-nvidia-nvtx-cu12==12.8.90
     # via
     #   -r requirements.txt
     #   torch

--- a/requirements.txt
+++ b/requirements.txt
@@ -264,43 +264,6 @@ numpy==2.2.6
     #   tensorboardx
     #   torchmetrics
     #   transformers
-nvidia-cublas-cu12==12.8.4.1
-    # via
-    #   nvidia-cudnn-cu12
-    #   nvidia-cusolver-cu12
-    #   torch
-nvidia-cuda-cupti-cu12==12.8.90
-    # via torch
-nvidia-cuda-nvrtc-cu12==12.8.93
-    # via torch
-nvidia-cuda-runtime-cu12==12.8.90
-    # via torch
-nvidia-cudnn-cu12==9.10.2.21
-    # via torch
-nvidia-cufft-cu12==11.3.3.83
-    # via torch
-nvidia-cufile-cu12==1.13.1.3
-    # via torch
-nvidia-curand-cu12==10.3.9.90
-    # via torch
-nvidia-cusolver-cu12==11.7.3.90
-    # via torch
-nvidia-cusparse-cu12==12.5.8.93
-    # via
-    #   nvidia-cusolver-cu12
-    #   torch
-nvidia-cusparselt-cu12==0.7.1
-    # via torch
-nvidia-nccl-cu12==2.27.3
-    # via torch
-nvidia-nvjitlink-cu12==12.8.93
-    # via
-    #   nvidia-cufft-cu12
-    #   nvidia-cusolver-cu12
-    #   nvidia-cusparse-cu12
-    #   torch
-nvidia-nvtx-cu12==12.8.90
-    # via torch
 openai==1.101.0
     # via -r requirements-core.in
 opentelemetry-api==1.36.0


### PR DESCRIPTION
## Summary
- drop explicit `nvidia-*` packages and rely on upstream torch deps
- cache pip wheels in CI to speed up builds

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/ci_cpu.yml requirements-core.txt requirements-gpu.txt requirements.txt requirements.out` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68aef4905f58832dbb1e0fc9f4824248