### PR TITLE
Use validated fallback revision for model

### DIFF
--- a/server.py
+++ b/server.py
@@ -137,9 +137,9 @@ class ModelManager:
                 trust_remote_code=False,
                 cache_dir=cache_dir,
             )  # nosec
-            model_local = AutoModelForCausalLM.from_pretrained(  # nosec B611
+            model_local = AutoModelForCausalLM.from_pretrained(
                 fallback_model,
-                revision="5f91d94bd9cd7190a9f3216ff93cd1dd95f2c7be",
+                revision=fallback_revision,
                 trust_remote_code=False,
                 cache_dir=cache_dir,
                 local_files_only=True,


### PR DESCRIPTION
## Summary
- use validated fallback revision when loading fallback model
- remove Bandit suppression for fallback model load

## Testing
- `pre-commit run --files server.py` *(fails: NameError: name 'result' is not defined)*
- `pre-commit run --hook-stage manual --files server.py`
- `pytest` *(fails: NameError: name 'result' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68af09ecc658832d8f55a31e9a2c666d