### PR TITLE
Use environment-based revision for fallback model

### DIFF
--- a/server.py
+++ b/server.py
@@ -139,7 +139,7 @@ class ModelManager:
             )  # nosec
             model_local = AutoModelForCausalLM.from_pretrained(  # nosec B611
                 fallback_model,
-                revision="5f91d94bd9cd7190a9f3216ff93cd1dd95f2c7be",
+                revision=fallback_revision,
                 trust_remote_code=False,
                 cache_dir=cache_dir,
                 local_files_only=True,


### PR DESCRIPTION
## Summary
- Use `fallback_revision` variable when loading fallback model to honor environment override

## Testing
- `pytest -q` *(fails: NameError: name 'result' is not defined in trading_bot.py; IndentationError in tests/test_password_utils.py)*

------
https://chatgpt.com/codex/tasks/task_e_68af09f99f8c832d8570973dbb194a4e