### PR TITLE
Ensure logger level is set during configuration

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -117,6 +117,29 @@ def test_configure_logging_invalid_level(monkeypatch, tmp_path, caplog):
     for h in logger.handlers[:]:
         logger.removeHandler(h)
 
+
+def test_configure_logging_updates_level(monkeypatch, tmp_path):
+    import logging
+
+    monkeypatch.setenv("LOG_DIR", str(tmp_path))
+
+    logger = logging.getLogger("TradingBot")
+    for h in logger.handlers[:]:
+        logger.removeHandler(h)
+
+    monkeypatch.setenv("LOG_LEVEL", "WARNING")
+    utils.configure_logging()
+    assert logger.level == logging.WARNING
+    handler_count = len(logger.handlers)
+
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    utils.configure_logging()
+    assert logger.level == logging.DEBUG
+    assert len(logger.handlers) == handler_count
+
+    for h in logger.handlers[:]:
+        logger.removeHandler(h)
+
 def test_jit_stub_preserves_metadata(monkeypatch):
     if not hasattr(utils, "_numba_missing"):
         pytest.skip("numba is installed")

--- a/utils.py
+++ b/utils.py
@@ -24,6 +24,11 @@ def configure_logging() -> None:
     """Настроить переменные окружения и handlers для логирования."""
 
     level_name = os.getenv("LOG_LEVEL", "INFO").upper()
+    try:
+        logger.setLevel(level_name)
+    except ValueError:
+        logger.warning("LOG_LEVEL '%s' недопустим, используется INFO", level_name)
+        logger.setLevel(logging.INFO)
 
     log_dir = os.getenv("LOG_DIR", "/app/logs")
     fallback_dir = os.path.join(os.path.dirname(__file__), "logs")


### PR DESCRIPTION
## Summary
- Set the TradingBot logger level from `LOG_LEVEL`, warning on invalid names
- Add a regression test confirming repeated `configure_logging` calls update the level without duplicating handlers

## Testing
- `pytest tests/test_utils.py::test_logging_not_duplicated_on_reimport tests/test_utils.py::test_configure_logging_invalid_level tests/test_utils.py::test_configure_logging_updates_level tests/test_data_handler_service_logging.py::test_data_handler_service_does_not_configure_logging_on_import -q`

------
https://chatgpt.com/codex/tasks/task_e_68af09ff3d00832d81a88c3a0e1f5b59