### PR TITLE
Handle timeout in query_gpt thread execution

### DIFF
--- a/gpt_client.py
+++ b/gpt_client.py
@@ -200,9 +200,11 @@ def query_gpt(prompt: str) -> str:
             except Exception as exc:  # pragma: no cover - unexpected
                 result["error"] = exc
 
-        thread = threading.Thread(target=runner)
+        thread = threading.Thread(target=runner, daemon=True)
         thread.start()
-        thread.join()
+        thread.join(timeout)
+        if thread.is_alive():
+            raise GPTClientError("Timed out waiting for async task to finish")
         if "error" in result:
             raise result["error"]
         return result["value"]


### PR DESCRIPTION
## Summary
- add timeout to `_run_coro_in_thread`'s join and raise `GPTClientError` when exceeding it

## Testing
- `pytest tests/test_gpt_client.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af0a0648a8832da76eab3309597e95