### PR TITLE
Clear API credentials after creating Bybit client

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -192,7 +192,7 @@ def create_exchange() -> BybitSDKAsync:
         )
     client = BybitSDKAsync(api_key=api_key, api_secret=api_secret)
     # Best effort to clear sensitive credentials from memory
-    api_key = api_secret = None
+    del api_key, api_secret
     if "BYBIT_API_KEY" in os.environ:
         del os.environ["BYBIT_API_KEY"]
     if "BYBIT_API_SECRET" in os.environ:


### PR DESCRIPTION
## Summary
- remove local `api_key` and `api_secret` variables after initializing `BybitSDKAsync`

## Testing
- `pre-commit run --files data_handler.py` *(fails: NameError in trading_bot.safe_number)*

------
https://chatgpt.com/codex/tasks/task_e_68af0a10f4bc832db65c970484cd62a7