### PR TITLE
Handle invalid values in safe_number

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -40,6 +40,10 @@ T = TypeVar("T", int, float)
 def safe_number(env_var: str, default: T, cast: Callable[[str], T]) -> T:
     """Return ``env_var`` cast by ``cast`` or ``default`` on failure or invalid value."""
     value = os.getenv(env_var)
+    try:
+        result = cast(value) if value is not None else default
+    except (TypeError, ValueError):
+        return default
 
     if isinstance(result, float) and not math.isfinite(result):
         logger.warning(


### PR DESCRIPTION
## Summary
- Ensure safe_number casts environment variables inside a try/except and validates the result

## Testing
- `pytest` *(fails: IndentationError in tests/test_password_utils.py; ModuleNotFoundError: hypothesis)*

------
https://chatgpt.com/codex/tasks/task_e_68af0c1563cc832da0a913decedca4fa