### PR TITLE
Remove unused util_safe_int import

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -19,7 +19,7 @@ from tenacity import retry, stop_after_attempt, wait_exponential
 
 from bot.config import BotConfig
 from bot.gpt_client import GPTClientError, query_gpt_json_async
-from bot.utils import logger, suppress_tf_logs, safe_int as util_safe_int
+from bot.utils import logger, suppress_tf_logs
 
 CFG = BotConfig()
 
@@ -40,6 +40,16 @@ T = TypeVar("T", int, float)
 def safe_number(env_var: str, default: T, cast: Callable[[str], T]) -> T:
     """Return ``env_var`` cast by ``cast`` or ``default`` on failure or invalid value."""
     value = os.getenv(env_var)
+
+    if value is None:
+        return default
+    try:
+        result = cast(value)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid %s value '%s', using default %s", env_var, value, default
+        )
+        return default
 
     if isinstance(result, float) and not math.isfinite(result):
         logger.warning(


### PR DESCRIPTION
## Summary
- drop unused `safe_int` alias from `bot.utils`
- streamline `safe_number` to cast environment values safely

## Testing
- `flake8 trading_bot.py`
- `pre-commit run --files trading_bot.py` *(fails: ModuleNotFoundError: No module named 'hypothesis'; IndentationError in tests/test_password_utils.py)*

------
https://chatgpt.com/codex/tasks/task_e_68af0c1b76f0832d964ac6a43c2a5fd5