### PR TITLE
Refactor safe_number to avoid repeated casting

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -41,26 +41,20 @@ def safe_number(env_var: str, default: T, cast: Callable[[str], T]) -> T:
     """Return ``env_var`` cast by ``cast`` or ``default`` on failure or invalid value."""
     value = os.getenv(env_var)
     try:
-        result = cast(value) if value is not None else default
-    except (TypeError, ValueError):
-        return default
-
-    if value is None:
-        return default
-    try:
-        result = cast(value)
+        result = default if value is None else cast(value)
     except (TypeError, ValueError):
         logger.warning(
             "Invalid %s value '%s', using default %s", env_var, value, default
         )
         return default
 
+    if value is None:
+        return default
     if isinstance(result, float) and not math.isfinite(result):
         logger.warning(
             "Invalid %s value '%s', using default %s", env_var, value, default
         )
         return default
-
     if result <= 0:
         logger.warning(
             "Non-positive %s value '%s', using default %s", env_var, value, default


### PR DESCRIPTION
## Summary
- simplify safe_number by casting environment values only once
- keep validation checks after successful conversion

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas'; AttributeError: module 'httpx' has no attribute 'Response')*

------
https://chatgpt.com/codex/tasks/task_e_68af1a431d58832dadfbb0e747959879