### PR TITLE
Добавить types-requests в requirements-ci

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -14,5 +14,6 @@ flask>=3.1.1,<4
 pyarrow>=16.1.0
 python-dotenv>=1.0.1
 werkzeug>=3.1.3,<4
+types-requests
 mypy==1.17.1
 hypothesis>=6.0.0


### PR DESCRIPTION
## Summary
- add types-requests to CI requirements

## Testing
- `pip install -r requirements-ci.txt`
- `pytest -q` *(fails: tests/test_env_parsing.py::test_safe_int_invalid, tests/test_env_parsing.py::test_safe_float_invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68af1a24667c832d818dc5d678eb5b23