### PR TITLE
refactor: use ResponseReturnValue for Flask endpoints

### DIFF
--- a/services/data_handler_service.py
+++ b/services/data_handler_service.py
@@ -1,5 +1,6 @@
 """Simple reference data handler service fetching real prices from Bybit."""
 from flask import Flask, jsonify, request
+from flask.typing import ResponseReturnValue
 import logging
 import ccxt
 import os
@@ -39,7 +40,7 @@ CCXT_NETWORK_ERROR = getattr(ccxt, 'NetworkError', CCXT_BASE_ERROR)
 
 # Correct price endpoint without trailing whitespace
 @app.route('/price/<symbol>')
-def price(symbol: str):
+def price(symbol: str) -> ResponseReturnValue:
     if exchange is None:
         return jsonify({'error': 'exchange not initialized'}), 503
     try:
@@ -60,21 +61,21 @@ def price(symbol: str):
         return jsonify({'error': 'exchange error fetching price'}), 502
 
 @app.route('/ping')
-def ping():
+def ping() -> ResponseReturnValue:
     return jsonify({'status': 'ok'})
 
 
 @app.route('/health')
-def health():
+def health() -> ResponseReturnValue:
     return jsonify({'status': 'ok'})
 
 
 @app.errorhandler(413)
-def too_large(_):
+def too_large(_) -> ResponseReturnValue:
     return jsonify({'error': 'payload too large'}), 413
 
 @app.errorhandler(Exception)
-def handle_unexpected_error(exc: Exception):
+def handle_unexpected_error(exc: Exception) -> ResponseReturnValue:
     """Log unexpected errors and return a 500 response."""
     if isinstance(exc, HTTPException):
         return exc

--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -6,6 +6,7 @@ belong to a single class.
 """
 
 from flask import Flask, request, jsonify
+from flask.typing import ResponseReturnValue
 import numpy as np
 import joblib
 import os
@@ -50,7 +51,7 @@ def _load_model() -> None:
 
 
 @app.route('/train', methods=['POST'])
-def train() -> tuple:
+def train() -> ResponseReturnValue:
     data = request.get_json(force=True)
     # ``features`` may contain multiple attributes such as price, volume and
     # technical indicators.  Ensure the array is always two-dimensional so the
@@ -85,7 +86,7 @@ def train() -> tuple:
 
 
 @app.route('/predict', methods=['POST'])
-def predict() -> tuple:
+def predict() -> ResponseReturnValue:
     data = request.get_json(force=True)
     features = data.get('features')
     if features is None:
@@ -110,12 +111,12 @@ def predict() -> tuple:
 
 
 @app.route('/ping')
-def ping() -> tuple:
+def ping() -> ResponseReturnValue:
     return jsonify({'status': 'ok'})
 
 
 @app.errorhandler(413)
-def too_large(_):
+def too_large(_) -> ResponseReturnValue:
     return jsonify({'error': 'payload too large'}), 413
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- import and use ResponseReturnValue in Flask services
- annotate endpoints to return ResponseReturnValue

## Testing
- `mypy services/data_handler_service.py services/model_builder_service.py services/trade_manager_service.py`
- `pytest -q` *(fails: AssertionError: assert 'Invalid X_INT' in '')*

------
https://chatgpt.com/codex/tasks/task_e_68af1a33e7c4832d89dbd487d94a5d0c