### PR TITLE
Handle invalid timeout env var

### DIFF
--- a/http_client.py
+++ b/http_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from contextlib import contextmanager
 from functools import wraps
@@ -10,7 +11,15 @@ from typing import Generator
 import httpx
 import requests
 
-DEFAULT_TIMEOUT = float(os.getenv("MODEL_DOWNLOAD_TIMEOUT", "30"))
+DEFAULT_TIMEOUT_STR = os.getenv("MODEL_DOWNLOAD_TIMEOUT", "30")
+try:
+    DEFAULT_TIMEOUT = float(DEFAULT_TIMEOUT_STR)
+except ValueError:
+    logging.warning(
+        "Invalid MODEL_DOWNLOAD_TIMEOUT '%s'; using default timeout 30s",
+        DEFAULT_TIMEOUT_STR,
+    )
+    DEFAULT_TIMEOUT = 30.0
 
 
 @contextmanager


### PR DESCRIPTION
## Summary
- default timeout conversion now wrapped in try/except
- log warning and fallback to 30s when MODEL_DOWNLOAD_TIMEOUT is invalid

## Testing
- `pytest` *(fails: AssertionError in tests/test_env_parsing.py::test_safe_int_invalid, tests/test_env_parsing.py::test_safe_float_invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68af1a3feb5c832d864d0b289a8b32b8