### PR TITLE
feat: add context manager for httpx client

### DIFF
--- a/http_client.py
+++ b/http_client.py
@@ -33,7 +33,14 @@ def get_requests_session(
         session.close()
 
 
-def get_httpx_client(timeout: float = DEFAULT_TIMEOUT, **kwargs) -> httpx.Client:
+@contextmanager
+def get_httpx_client(
+    timeout: float = DEFAULT_TIMEOUT, **kwargs
+) -> Generator[httpx.Client, None, None]:
     """Return an :class:`httpx.Client` with a default timeout."""
     kwargs.setdefault("timeout", timeout)
-    return httpx.Client(**kwargs)
+    client = httpx.Client(**kwargs)
+    try:
+        yield client
+    finally:
+        client.close()


### PR DESCRIPTION
## Summary
- add `get_httpx_client` context manager mirroring `get_requests_session`

## Testing
- `pre-commit run flake8 --files http_client.py`
- `pytest tests/test_gpt_client.py::test_parse_gpt_response_success -q`


------
https://chatgpt.com/codex/tasks/task_e_68af1a415fa0832da7cd984c5acb3564