### PR TITLE
Use async DNS resolution in GPT client

### DIFF
--- a/gpt_client.py
+++ b/gpt_client.py
@@ -83,9 +83,12 @@ async def _fetch_response(
 ) -> bytes:
     """Resolve hostname, verify IP and return response bytes."""
     try:
+        loop = asyncio.get_running_loop()
         current_ips = {
             info[4][0]
-            for info in socket.getaddrinfo(hostname, None, family=socket.AF_UNSPEC)
+            for info in await loop.getaddrinfo(
+                hostname, None, family=socket.AF_UNSPEC
+            )
         }
     except socket.gaierror as exc:
         logger.error(
@@ -188,7 +191,6 @@ def query_gpt(prompt: str) -> str:
     """
     if len(prompt.encode("utf-8")) > MAX_PROMPT_BYTES:
         raise GPTClientError("Prompt exceeds maximum length")
-
     url, timeout, hostname, allowed_ips = _get_api_url_timeout()
 
     def _run_coro_in_thread(coro: Coroutine[Any, Any, bytes]) -> bytes:
@@ -250,8 +252,9 @@ async def query_gpt_async(prompt: str) -> str:
     """
     if len(prompt.encode("utf-8")) > MAX_PROMPT_BYTES:
         raise GPTClientError("Prompt exceeds maximum length")
-
-    url, timeout, hostname, allowed_ips = _get_api_url_timeout()
+    url, timeout, hostname, allowed_ips = await asyncio.to_thread(
+        _get_api_url_timeout
+    )
 
     @retry(
         stop=stop_after_attempt(3),

--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -317,7 +317,13 @@ def test_query_gpt_private_fqdn_allowed(monkeypatch):
         assert host == "foo.local"
         return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.1", 0))]
 
+    async def fake_async_getaddrinfo(
+        self, host, port, family=0, type=0, proto=0, flags=0
+    ):
+        return fake_getaddrinfo(host, port, family, type, proto, flags)
+
     monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+    monkeypatch.setattr(asyncio.AbstractEventLoop, "getaddrinfo", fake_async_getaddrinfo)
 
     def fake_stream(self, *args, **kwargs):
         content = json.dumps({"choices": [{"text": "ok"}]}).encode()


### PR DESCRIPTION
## Summary
- resolve API hostnames asynchronously to avoid blocking event loop
- load API config via `asyncio.to_thread` in async client
- adapt tests to mock event loop DNS lookup

## Testing
- `pytest tests/test_gpt_client.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af1a4423a0832dbd1350f29305c025