### PR TITLE
ci: tighten venv setup and fix safe_number

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,6 @@ jobs:
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ matrix.device }}-${{ hashFiles('requirements-ci.txt', 'requirements-cpu.txt') }}
-      - name: Prepare virtualenv directory
-        run: mkdir -p /mnt/venv
       - name: Cache virtualenv
         id: cache-venv
         uses: actions/cache@v4
@@ -86,7 +84,7 @@ jobs:
           key: ${{ runner.os }}-venv-${{ matrix.device }}-${{ hashFiles('requirements-ci.txt', 'requirements-cpu.txt') }}
       - name: Set up virtual environment
         run: |
-          if [ ! -d /mnt/venv ]; then
+          if [ ! -f /mnt/venv/bin/activate ]; then
             python -m venv /mnt/venv
             source /mnt/venv/bin/activate
             mkdir -p /mnt/tmp /mnt/pip-cache
@@ -181,8 +179,6 @@ jobs:
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ matrix.device }}-${{ hashFiles('requirements-ci.txt', 'requirements-cpu.txt') }}
-      - name: Prepare virtualenv directory
-        run: mkdir -p /mnt/venv
       - name: Cache virtualenv
         id: cache-venv
         uses: actions/cache@v4
@@ -191,7 +187,7 @@ jobs:
           key: ${{ runner.os }}-venv-${{ matrix.device }}-${{ hashFiles('requirements-ci.txt', 'requirements-cpu.txt') }}
       - name: Set up virtual environment
         run: |
-          if [ ! -d /mnt/venv ]; then
+          if [ ! -f /mnt/venv/bin/activate ]; then
             python -m venv /mnt/venv
             source /mnt/venv/bin/activate
             mkdir -p /mnt/tmp /mnt/pip-cache

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -40,14 +40,17 @@ T = TypeVar("T", int, float)
 def safe_number(env_var: str, default: T, cast: Callable[[str], T]) -> T:
     """Return ``env_var`` cast by ``cast`` or ``default`` on failure or invalid value."""
     value = os.getenv(env_var)
+    if value is None:
+        return default
+
+    try:
+        result = cast(value)
     except (TypeError, ValueError):
         logger.warning(
             "Invalid %s value '%s', using default %s", env_var, value, default
         )
         return default
 
-    if value is None:
-        return default
     if isinstance(result, float) and not math.isfinite(result):
         logger.warning(
             "Invalid %s value '%s', using default %s", env_var, value, default


### PR DESCRIPTION
## Summary
- avoid pre-creating venv and check for existing activate script
- correct safe_number helper to handle invalid env var values

## Testing
- `python -m flake8 .`
- `pytest` *(fails: No module named 'hypothesis')*


------
https://chatgpt.com/codex/tasks/task_e_68af3d86a970832d9a3bb0f906307b22