### PR TITLE
chore: simplify bandit workflow

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -32,36 +32,6 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           persist-credentials: false
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
-      - name: Clean Docker dir
-        run: sudo rm -rf /var/lib/docker/*
-      - name: Prepare build volume
-        run: |
-          if [ -e /dev/buildvg/buildlv ]; then
-            sudo wipefs -a /dev/buildvg/buildlv || true
-          else
-            echo "Device /dev/buildvg/buildlv not found, skipping wipefs"
-          fi
-            sudo swapoff /mnt/swapfile || true
-            sudo rm -f /mnt/swapfile || true
-            sudo rm -rf /mnt/* || true
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v10
-        with:
-          root-reserve-mb: 1024
-          temp-reserve-mb: 100
-          swap-size-mb: 4096
-          build-mount-path: /mnt
-          pv-loop-path: /root-pv.img
-          tmp-pv-loop-path: /mnt/tmp-pv.img
       - name: Bandit Scan
         uses: shundor/python-bandit-scan@ab1d87dfccc5a0ffab88be3aaac6ffe35c10d6cd
         with: # optional arguments


### PR DESCRIPTION
## Summary
- remove build space cleanup steps from Bandit workflow

## Testing
- `pre-commit run flake8 --files .github/workflows/bandit.yml`
- `pre-commit run --files .github/workflows/bandit.yml` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68af3fa70628832d868aad3b8b5eb3c9