### PR TITLE
Remove slow filesystem scan from CI Dockerfile

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -12,7 +12,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     python3 python3-venv build-essential linux-libc-dev libgcrypt20 \
     && python3 -m venv /venv \
     && /venv/bin/python -m pip install --no-cache-dir --upgrade --break-system-packages pip==25.2 \
-    && find / -xdev -type l -lname "*..*" -print \
     && apt-get purge -y --auto-remove build-essential \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && ldconfig


### PR DESCRIPTION
## Summary
- drop unnecessary symlink scan from CI Dockerfile

## Testing
- `pytest` *(fails: KeyboardInterrupt after ~110s; 258 passed, 2 skipped)*
- `docker build -f Dockerfile.ci -t bot-ci .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68af401e49e8832d943ad74fdd6a9c4c