### PR TITLE
Защита флага торговли с помощью asyncio.Lock

### DIFF
--- a/tests/test_trading_bot.py
+++ b/tests/test_trading_bot.py
@@ -877,3 +877,26 @@ def test_run_once_logs_prediction(monkeypatch, caplog):
         asyncio.run(trading_bot.run_once_async())
 
     assert "Prediction: buy" in caplog.messages
+
+
+@pytest.mark.asyncio
+async def test_trading_enabled_parallel():
+    await trading_bot.set_trading_enabled(False)
+
+    async def enable():
+        for _ in range(100):
+            await trading_bot.set_trading_enabled(True)
+            await asyncio.sleep(0)
+
+    async def disable():
+        for _ in range(100):
+            await trading_bot.set_trading_enabled(False)
+            await asyncio.sleep(0)
+
+    await asyncio.gather(
+        *(enable() for _ in range(5)),
+        *(disable() for _ in range(5)),
+    )
+
+    await trading_bot.set_trading_enabled(True)
+    assert await trading_bot.get_trading_enabled() is True

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -1847,17 +1847,17 @@ async def create_trade_manager() -> TradeManager | None:
                 import trading_bot as tb
 
                 if text.startswith("/start"):
-                    tb.trading_enabled = True
+                    await tb.set_trading_enabled(True)
                     await telegram_bot.send_message(
                         chat_id=msg.chat_id, text="Trading enabled"
                     )
                 elif text.startswith("/stop"):
-                    tb.trading_enabled = False
+                    await tb.set_trading_enabled(False)
                     await telegram_bot.send_message(
                         chat_id=msg.chat_id, text="Trading disabled"
                     )
                 elif text.startswith("/status"):
-                    status = "enabled" if tb.trading_enabled else "disabled"
+                    status = "enabled" if await tb.get_trading_enabled() else "disabled"
                     positions = []
                     if trade_manager is not None:
                         try:

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -163,7 +163,21 @@ DEFAULT_SERVICE_CHECK_RETRIES = 30
 DEFAULT_SERVICE_CHECK_DELAY = 2.0
 
 # Global flag toggled via Telegram commands to enable/disable trading
-trading_enabled: bool = True
+_TRADING_ENABLED: bool = True
+_TRADING_ENABLED_LOCK = asyncio.Lock()
+
+
+async def get_trading_enabled() -> bool:
+    """Return the current trading enabled state."""
+    async with _TRADING_ENABLED_LOCK:
+        return _TRADING_ENABLED
+
+
+async def set_trading_enabled(value: bool) -> None:
+    """Set the trading enabled state to ``value``."""
+    global _TRADING_ENABLED
+    async with _TRADING_ENABLED_LOCK:
+        _TRADING_ENABLED = value
 
 # Shared HTTP client for outgoing requests
 HTTP_CLIENT: httpx.AsyncClient | None = None


### PR DESCRIPTION
## Summary
- Добавлен asyncio.Lock и функции get/set для флага `trading_enabled`
- TradeManager использует новые функции вместо прямого доступа к переменной
- Добавлен тест параллельного переключения торговли

## Testing
- `pytest tests/test_trading_bot.py::test_trading_enabled_parallel -q`
- `pytest tests/test_trade_manager.py::test_utils_injected_before_trade_manager_import -q`


------
https://chatgpt.com/codex/tasks/task_e_68af40217250832daea3c7486574d21b