### PR TITLE
feat: improve GPT OSS configuration and allow localhost http

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,9 @@ GPU-зависимости вынесены в отдельный файл `requ
     - `GPT_OSS_API` — базовый адрес сервиса [GPT OSS](https://github.com/jina-ai/gpt-oss)
       (без суффикса `/completions`), к которому обращаются функции
       `query_gpt` и `query_gpt_async`. Переменная обязательна; при её отсутствии
-      эти функции завершатся ошибкой. Например:
+      будет выброшено исключение с подсказкой по настройке. Для локального сервера
+      допустим адрес `http://localhost`, во всех остальных случаях следует
+      использовать HTTPS. Например:
 
       ```python
       from bot.gpt_client import query_gpt
@@ -151,9 +153,9 @@ GPU-зависимости вынесены в отдельный файл `requ
       ```
 
     - `GPT_OSS_WAIT_TIMEOUT` — время ожидания запуска сервера GPT OSS в
-      секундах (по умолчанию `30`).
-    - `GPT_OSS_TIMEOUT` — таймаут запроса к GPT OSS API в секундах (по
-      умолчанию `5`). Используется функциями `query_gpt` и `query_gpt_async`.
+      секундах (по умолчанию `300`).
+    - `GPT_OSS_TIMEOUT` — таймаут каждого запроса к GPT OSS API в секундах
+      (по умолчанию `5`). Используется функциями `query_gpt` и `query_gpt_async`.
 
      В `docker-compose.yml` теперь есть сервис `gptoss`,
      запускающий образ `ghcr.io/openaccess-ai-collective/gpt-oss:cpu-latest` на порту `8003`

--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -143,6 +143,19 @@ async def test_insecure_url(monkeypatch, func, client_cls):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("func, client_cls", QUERIES)
+async def test_localhost_allowed(monkeypatch, func, client_cls):
+    monkeypatch.setenv("GPT_OSS_API", "http://localhost")
+
+    def fake_stream(self, *args, **kwargs):
+        content = json.dumps({"choices": [{"text": "ok"}]}).encode()
+        return DummyStream(content=content)
+
+    monkeypatch.setattr(client_cls, "stream", fake_stream)
+    assert await run_query(func, "hi") == "ok"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("func, client_cls", QUERIES)
 @pytest.mark.parametrize("ip", [
     "127.0.0.1",
     "10.0.0.1",


### PR DESCRIPTION
## Summary
- allow http://localhost in GPT client without rejecting HTTP
- raise a helpful error when GPT_OSS_API is missing
- document GPT_OSS_API, GPT_OSS_TIMEOUT and GPT_OSS_WAIT_TIMEOUT

## Testing
- `pytest tests/test_gpt_client.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68af48e915a4832daa7a1f3c98e4f763