### PR TITLE
Use full (symbol, timestamp) index for positions

### DIFF
--- a/position_manager.py
+++ b/position_manager.py
@@ -75,18 +75,12 @@ class PositionManager:
                 continue
             current_price = df["close"].iloc[-1]
 
-            if (
-                "symbol" in self.trade_manager.positions.index.names
-                and symbol in self.trade_manager.positions.index.get_level_values("symbol")
-            ):
+            if self.trade_manager._has_position(symbol):
                 res = self.trade_manager.check_stop_loss_take_profit(symbol, current_price)
                 if inspect.isawaitable(res):
                     await res
 
-            if (
-                "symbol" in self.trade_manager.positions.index.names
-                and symbol in self.trade_manager.positions.index.get_level_values("symbol")
-            ):
+            if self.trade_manager._has_position(symbol):
                 res = self.trade_manager.check_trailing_stop(symbol, current_price)
                 if inspect.isawaitable(res):
                     await res

--- a/simulation.py
+++ b/simulation.py
@@ -60,11 +60,11 @@ class HistoricalSimulator:
                 continue
             price = df["close"].iloc[-1]
             idx_names = getattr(self.trade_manager.positions.index, "names", [])
-            if "symbol" in idx_names and symbol in self.trade_manager.positions.index.get_level_values("symbol"):
+            if self.trade_manager._has_position(symbol):
                 await self.trade_manager.check_trailing_stop(symbol, price)
-            if "symbol" in idx_names and symbol in self.trade_manager.positions.index.get_level_values("symbol"):
+            if self.trade_manager._has_position(symbol):
                 await self.trade_manager.check_stop_loss_take_profit(symbol, price)
-            if "symbol" in idx_names and symbol in self.trade_manager.positions.index.get_level_values("symbol"):
+            if self.trade_manager._has_position(symbol):
                 await self.trade_manager.check_exit_signal(symbol, price)
 
     async def run(self, start_ts: pd.Timestamp, end_ts: pd.Timestamp, speed: float = 1.0) -> None:

--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -319,6 +319,27 @@ def test_open_position_skips_existing():
     assert len(tm.positions) == 1
 
 
+def test_open_position_uses_multiindex():
+    dh = DummyDataHandler()
+    tm = TradeManager(make_config(), dh, None, None, None)
+
+    async def fake_compute(symbol, vol):
+        return 0.01
+
+    tm.compute_risk_per_trade = fake_compute
+
+    async def run():
+        await tm.open_position("BTCUSDT", "buy", 100, {})
+        await tm.open_position("BTCUSDT", "buy", 100, {})
+
+    import asyncio
+    asyncio.run(run())
+
+    assert isinstance(tm.positions.index, pd.MultiIndex)
+    assert tm.positions.index.names == ["symbol", "timestamp"]
+    assert len(tm.positions) == 1
+
+
 def test_open_position_concurrent_single_entry():
     dh = DummyDataHandler()
     tm = TradeManager(make_config(), dh, None, None, None)


### PR DESCRIPTION
## Summary
- Track positions using complete (symbol, timestamp) index and central `_has_position` helper
- Adjust position and simulation managers to rely on the multi-index aware check
- Add regression test ensuring multi-index creation and duplicate prevention

## Testing
- `pytest tests/test_trade_manager.py::test_open_position_skips_existing tests/test_trade_manager.py::test_open_position_uses_multiindex -q`
- `pytest tests/test_trade_manager.py::test_trailing_stop_to_breakeven -q`
- `pytest tests/test_simulation.py::test_simulator_trailing_stop -q`

------
https://chatgpt.com/codex/tasks/task_e_68af48d8a844832da92b9ba7f6866a20