### PR TITLE
Локальное логирование ошибок Telegram и предупреждение о неактивности

### DIFF
--- a/tests/test_trading_bot.py
+++ b/tests/test_trading_bot.py
@@ -94,6 +94,15 @@ async def test_send_telegram_alert_hides_token(monkeypatch, caplog):
 
 
 @pytest.mark.asyncio
+async def test_send_telegram_alert_without_env(monkeypatch, caplog):
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("TELEGRAM_CHAT_ID", raising=False)
+    with caplog.at_level(logging.WARNING):
+        await trading_bot.send_telegram_alert("hi")
+    assert "hi" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_send_trade_timeout_env(monkeypatch):
     called = {}
 

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -1848,14 +1848,20 @@ async def create_trade_manager() -> TradeManager | None:
 
                 if text.startswith("/start"):
                     await tb.set_trading_enabled(True)
-                    await telegram_bot.send_message(
-                        chat_id=msg.chat_id, text="Trading enabled"
-                    )
+                    try:
+                        await telegram_bot.send_message(
+                            chat_id=msg.chat_id, text="Trading enabled"
+                        )
+                    except Exception as exc:
+                        logger.error("Failed to send Telegram message: %s", exc)
                 elif text.startswith("/stop"):
                     await tb.set_trading_enabled(False)
-                    await telegram_bot.send_message(
-                        chat_id=msg.chat_id, text="Trading disabled"
-                    )
+                    try:
+                        await telegram_bot.send_message(
+                            chat_id=msg.chat_id, text="Trading disabled"
+                        )
+                    except Exception as exc:
+                        logger.error("Failed to send Telegram message: %s", exc)
                 elif text.startswith("/status"):
                     status = "enabled" if await tb.get_trading_enabled() else "disabled"
                     positions = []
@@ -1870,7 +1876,10 @@ async def create_trade_manager() -> TradeManager | None:
                     message = f"Trading {status}"
                     if positions:
                         message += "\n" + "\n".join(str(p) for p in positions)
-                    await telegram_bot.send_message(chat_id=msg.chat_id, text=message)
+                    try:
+                        await telegram_bot.send_message(chat_id=msg.chat_id, text=message)
+                    except Exception as exc:
+                        logger.error("Failed to send Telegram message: %s", exc)
 
             threading.Thread(
                 target=lambda: asyncio.run(listener.listen(handle_command)),


### PR DESCRIPTION
## Summary
- Логируем предупреждения при отсутствии TELEGRAM_* и при неудачных отправках
- Предупреждаем о неактивности Telegram при запуске бота
- Тестируем, что без переменных окружения сообщение не теряется

## Testing
- `pytest tests/test_trading_bot.py -q`
- `pytest tests/test_trade_manager.py::test_utils_injected_before_trade_manager_import -q`
- `pytest tests/test_telegram_logger.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af48efb070832d8d9ad0e81dd0f057