### PR TITLE
Use lock to guard default config loading

### DIFF
--- a/tests/test_load_defaults_thread_safe.py
+++ b/tests/test_load_defaults_thread_safe.py
@@ -1,0 +1,29 @@
+import io
+import threading
+from bot import config
+
+
+def test_load_defaults_thread_safe(monkeypatch):
+    calls = 0
+
+    def fake_open(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return io.StringIO("{}")
+
+    monkeypatch.setattr(config, "DEFAULTS", None)
+    monkeypatch.setattr("builtins.open", fake_open)
+
+    barrier = threading.Barrier(5)
+
+    def worker():
+        barrier.wait()
+        config.load_defaults()
+
+    threads = [threading.Thread(target=worker) for _ in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert calls == 1


### PR DESCRIPTION
## Summary
- protect `load_defaults` with a threading lock
- add regression test ensuring concurrent loads read the file once

## Testing
- `pytest tests/test_load_defaults_thread_safe.py tests/test_load_defaults_error.py tests/test_config_list_parsing.py tests/test_config_logging.py tests/test_config_type_validation.py tests/test_config_path_validation.py tests/test_env_parsing.py tests/test_config_ws_subscription_batch_size.py`


------
https://chatgpt.com/codex/tasks/task_e_68af4ad5cc30832d8cec2d28a465c8f3