### PR TITLE
feat: upgrade tar and openssl packages in gptoss Dockerfile

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -2,6 +2,7 @@ FROM python:3.11-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libtbbmalloc2 libnuma1 curl git \
+    && apt-get install --only-upgrade -y tar openssl libssl3 \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONUNBUFFERED=1 HF_HOME=/workspace/hf-cache


### PR DESCRIPTION
## Summary
- upgrade tar, openssl, and libssl3 packages during gptoss Docker build to ensure latest security patches

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'hypothesis')*
- `docker run --rm gptoss-test tar --version` *(fails: Cannot connect to the Docker daemon)*
- `docker run --rm gptoss-test openssl version` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68af4ddc0968832db8797bb796e8d97e