### PR TITLE
chore: upgrade pam packages

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -2,6 +2,8 @@ FROM python:3.11-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libtbbmalloc2 libnuma1 curl git \
+    && apt-get install -y --only-upgrade \
+    libpam0g libpam-modules libpam-modules-bin libpam-runtime \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONUNBUFFERED=1 HF_HOME=/workspace/hf-cache


### PR DESCRIPTION
## Summary
- upgrade libpam packages during gptoss image build

## Testing
- `SKIP=pytest pre-commit run --files Dockerfile.gptoss`
- `pytest tests/test_safe_html_parser_hypothesis.py -q`
- `apt-cache policy libpam0g`


------
https://chatgpt.com/codex/tasks/task_e_68af4ddb98f4832da3b9810618f3b184