### PR TITLE
Load env vars when importing services

### DIFF
--- a/services/data_handler_service.py
+++ b/services/data_handler_service.py
@@ -6,6 +6,8 @@ import ccxt
 import os
 from dotenv import load_dotenv
 from werkzeug.exceptions import HTTPException
+
+load_dotenv()
 app = Flask(__name__)
 app.config["MAX_CONTENT_LENGTH"] = 1 * 1024 * 1024  # 1 MB limit
 
@@ -86,7 +88,6 @@ def handle_unexpected_error(exc: Exception) -> ResponseReturnValue:
 if __name__ == "__main__":
     from bot.utils import configure_logging
 
-    load_dotenv()
     configure_logging()
     host = os.getenv("HOST", "127.0.0.1")
     port = int(os.getenv("PORT", "8000"))

--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -15,6 +15,7 @@ from dotenv import load_dotenv
 from sklearn.linear_model import LogisticRegression
 from utils import validate_host, safe_int
 
+load_dotenv()
 app = Flask(__name__)
 app.config["MAX_CONTENT_LENGTH"] = 1 * 1024 * 1024  # 1 MB limit
 
@@ -122,7 +123,6 @@ def too_large(_) -> ResponseReturnValue:
 if __name__ == '__main__':
     from bot.utils import configure_logging
 
-    load_dotenv()
     configure_logging()
     host = validate_host()
     port = safe_int(os.getenv("PORT", "8000"))

--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -13,6 +13,7 @@ from dotenv import load_dotenv
 import logging
 from utils import validate_host, safe_int
 
+load_dotenv()
 app = Flask(__name__)
 app.config["MAX_CONTENT_LENGTH"] = 1 * 1024 * 1024  # 1 MB limit
 
@@ -291,7 +292,6 @@ def handle_unexpected_error(exc: Exception) -> ResponseReturnValue:
 if __name__ == '__main__':
     from utils import configure_logging
 
-    load_dotenv()
     configure_logging()
     host = validate_host()
     port = safe_int(os.getenv("PORT", "8002"))


### PR DESCRIPTION
## Summary
- ensure DataHandler, ModelBuilder, and TradeManager services load environment variables on import

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af4fcf5ea0832dbcaefead3e4a0f69