### PR TITLE
chore: run dependabot via script

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -22,7 +22,7 @@ jobs:
           echo "json=$(jq -c '.' github_registries_proxy.json)" >> $GITHUB_OUTPUT
 
       - name: Run Dependabot
-        run: scripts/run_dependabot.sh
+        run: bash scripts/run_dependabot.sh
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
           TOKEN: ${{ secrets.TOKEN }}


### PR DESCRIPTION
## Summary
- ensure Dependabot workflow calls bash script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hypothesis')*


------
https://chatgpt.com/codex/tasks/task_e_68af5ba684d0832db92b91ac7393f126