### PR TITLE
Document PAT token requirements and test dependabot script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,9 +45,10 @@ Commit both the `.in` and generated `.txt` files when updating.
 ## Repository secrets
 
 Some GitHub Actions workflows pull container images from GitHub Container Registry
-(GHCR). These workflows expect a secret named `TOKEN` that provides a personal
-access token with the `read:packages` scope so the runner can authenticate and
-download images from GHCR.
+(GHCR) and trigger Dependabot runs. These workflows expect a secret named
+`TOKEN` that provides a personal access token with the `repo` and
+`security_events` scopes so the runner can authenticate and interact with the
+GitHub API.
 
 ## CI troubleshooting
 

--- a/scripts/run_dependabot.sh
+++ b/scripts/run_dependabot.sh
@@ -8,7 +8,7 @@ fi
 repo="${GITHUB_REPOSITORY}"
 
 if [[ -z "${TOKEN:-}" ]]; then
-    echo "TOKEN is not set; cannot trigger Dependabot" >&2
+    echo "TOKEN is not set; export a PAT with repo and security_events scopes" >&2
     exit 1
 fi
 token="${TOKEN}"

--- a/tests/test_run_dependabot_script.py
+++ b/tests/test_run_dependabot_script.py
@@ -1,0 +1,15 @@
+import os
+import subprocess
+from pathlib import Path
+
+def test_run_dependabot_requires_token():
+    script = Path(__file__).resolve().parents[1] / "scripts" / "run_dependabot.sh"
+    env = os.environ.copy()
+    env["GITHUB_REPOSITORY"] = "owner/repo"
+    env.pop("TOKEN", None)
+    proc = subprocess.run([
+        "bash",
+        str(script),
+    ], capture_output=True, text=True, env=env)
+    assert proc.returncode != 0
+    assert "TOKEN is not set" in proc.stderr


### PR DESCRIPTION
## Summary
- document required `TOKEN` secret scopes for Dependabot
- add friendly message when `TOKEN` not set
- test Dependabot helper script for missing token

## Testing
- `SKIP=pytest pre-commit run --files CONTRIBUTING.md scripts/run_dependabot.sh tests/test_run_dependabot_script.py`
- `pytest tests/test_run_dependabot_script.py`


------
https://chatgpt.com/codex/tasks/task_e_68af5ba95c54832da6b06555be6fc11d