### PR TITLE
fix: update pytest cache option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
           find . -type d -name '__pycache__' -exec rm -rf {} +
           find . -name '*.pyc' -delete
       - name: Run unit tests
-        run: pytest -m "not integration" --cache-dir=/mnt/pytest_cache
+        run: pytest -m "not integration" -o cache_dir=/mnt/pytest_cache
       - name: Cleanup buildx
         run: docker buildx prune -af || true
 
@@ -202,6 +202,6 @@ jobs:
           find . -type d -name '__pycache__' -exec rm -rf {} +
           find . -name '*.pyc' -delete
       - name: Run integration tests
-        run: pytest -m integration --cache-dir=/mnt/pytest_cache
+        run: pytest -m integration -o cache_dir=/mnt/pytest_cache
       - name: Cleanup buildx
         run: docker buildx prune -af || true


### PR DESCRIPTION
## Summary
- use supported `-o cache_dir` option for pytest cache path

## Testing
- `flake8 .`
- `pytest -m "not integration" -o cache_dir=/tmp/pytest_cache`


------
https://chatgpt.com/codex/tasks/task_e_68aff21b4784832daf26a2cd962cd4ab