### PR TITLE
ci: add requests dependency

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -14,6 +14,7 @@ flask>=3.1.1,<4
 pyarrow>=16.1.0
 python-dotenv>=1.0.1
 werkzeug>=3.1.3,<4
+requests>=2.32.5
 types-requests
 mypy==1.17.1
 hypothesis>=6.0.0


### PR DESCRIPTION
## Summary
- add requests>=2.32.5 alongside types-requests in CI requirements

## Testing
- `pip install -r requirements-ci.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68affef81d94832d829dcc54cbfcdbf2