### PR TITLE
Add gymnasium to CI requirements

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -11,6 +11,7 @@ tenacity>=8.5,<10
 fastapi==0.116.1
 fastapi-csrf-protect==1.0.6
 flask>=3.1.1,<4
+gymnasium>=1.2.0
 pyarrow>=16.1.0
 python-dotenv>=1.0.1
 werkzeug>=3.1.3,<4


### PR DESCRIPTION
## Summary
- add gymnasium>=1.2.0 to requirements-ci.txt

## Testing
- `pip install -r requirements-ci.txt`
- `pytest` (interrupted after 263 passed, 2 skipped, 17 deselected)


------
https://chatgpt.com/codex/tasks/task_e_68affefa5910832d90b2716257fe5adb