### PR TITLE
Pin gymnasium dependency and install early in CI

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -11,7 +11,7 @@ tenacity>=8.5,<10
 fastapi==0.116.1
 fastapi-csrf-protect==1.0.6
 flask>=3.1.1,<4
-gymnasium>=1.2.0
+gymnasium==1.2.0
 pyarrow>=16.1.0
 python-dotenv>=1.0.1
 werkzeug>=3.1.3,<4

--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -1,3 +1,4 @@
 # CPU-specific dependencies
 # Install torch separately with CPU wheels
 torch==2.8.0
+gymnasium==1.2.0

--- a/scripts/install-test-deps.sh
+++ b/scripts/install-test-deps.sh
@@ -3,7 +3,8 @@ set -e
 # Install Python packages needed for running the test suite.
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
-
+# Ensure gymnasium is available before importing model_builder
+python -m pip install --no-cache-dir gymnasium==1.2.0
 python -m pip install --no-cache-dir -r "$REPO_ROOT/requirements-ci.txt"
 
 # Install GPU requirements only when explicitly requested.


### PR DESCRIPTION
## Summary
- pin gymnasium==1.2.0 in CI and CPU requirement files
- install gymnasium before importing model_builder during CI setup

## Testing
- `./scripts/install-test-deps.sh`
- `pytest tests/test_model_builder_import.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b002a1f064832d9ef44b5c2574e99f