### PR TITLE
Add requests dependency for CI tests

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -15,7 +15,7 @@ gymnasium>=1.2.0
 pyarrow>=16.1.0
 python-dotenv>=1.0.1
 werkzeug>=3.1.3,<4
-requests>=2.32.5
+requests>=2.32.0
 types-requests
 mypy==1.17.1
 hypothesis>=6.0.0


### PR DESCRIPTION
## Summary
- ensure requests>=2.32.0 is listed in CI requirements

## Testing
- `pip install -r requirements-ci.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b002a105e0832dace1a2938bb22cb7