### PR TITLE
fix: pin git version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,7 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y --no-install
     && openssl version
 
 # Копируем исходный код в /app/bot
-RUN apt-get update && apt-get install -y git curl \
+RUN apt-get update && apt-get install -y git=1:2.43.0-1ubuntu7.3 curl \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY . /app/bot
 


### PR DESCRIPTION
## Summary
- pin Ubuntu git package version in Dockerfile for reproducible builds

## Testing
- `docker build -t bot:latest .` (fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)
- `trivy fs .`

------
https://chatgpt.com/codex/tasks/task_e_68b01ef69194832dbd0ef9d0391020ee