### PR TITLE
fix openssl package versions in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y --no-install
     gnupg \
     libgcrypt20 \
     libpam0g \
-    libssl3t64 \
-    openssl \
+    libssl3t64=3.0.13-0ubuntu3.5 \
+    openssl=3.0.13-0ubuntu3.5 \
     build-essential \
     curl \
     python3-dev \
@@ -88,8 +88,8 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y --no-install
     gnupg \
     libgcrypt20 \
     libpam0g \
-    libssl3t64 \
-    openssl \
+    libssl3t64=3.0.13-0ubuntu3.5 \
+    openssl=3.0.13-0ubuntu3.5 \
     tar \
     zlib1g \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
## Summary
- pin libssl3t64 and openssl to 3.0.13-0ubuntu3.5 in build and runtime stages

## Testing
- `pre-commit run --files Dockerfile` *(fails: ModuleNotFoundError: No module named 'hypothesis')*
- `docker build -t bot:latest .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*

------
https://chatgpt.com/codex/tasks/task_e_68b01ef9388c832db4baea76faf9476c