### PR TITLE
chore: update gnupg and dirmngr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y --no-install
     tzdata \
     linux-libc-dev \
     coreutils \
-    gnupg \
+    gnupg=2.4.4-2ubuntu17.3 \
+    dirmngr=2.4.4-2ubuntu17.3 \
     libgcrypt20 \
     libpam0g \
     libssl3t64 \
@@ -85,7 +86,8 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y --no-install
     python3 \
     libpython3.12-stdlib \
     coreutils \
-    gnupg \
+    gnupg=2.4.4-2ubuntu17.3 \
+    dirmngr=2.4.4-2ubuntu17.3 \
     libgcrypt20 \
     libpam0g \
     libssl3t64 \


### PR DESCRIPTION
## Summary
- pin gnupg to 2.4.4-2ubuntu17.3 and ensure dirmngr is updated in both build and runtime stages

## Testing
- `pre-commit run --hook-stage manual flake8 --files Dockerfile`
- `docker build -t bot:latest .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*
- `python -m gptoss_check.main` *(skipped: Переменная окружения GPT_OSS_API не установлена)*

------
https://chatgpt.com/codex/tasks/task_e_68b01ef71974832d8ff7a67ca6b40c88