### PR TITLE
Load .env in data handler service

### DIFF
--- a/services/data_handler_service.py
+++ b/services/data_handler_service.py
@@ -8,6 +8,8 @@ import os
 from dotenv import load_dotenv
 from werkzeug.exceptions import HTTPException
 
+load_dotenv()
+
 app = Flask(__name__)
 app.config["MAX_CONTENT_LENGTH"] = 1 * 1024 * 1024  # 1 MB limit
 


### PR DESCRIPTION
## Summary
- load dotenv in data handler service to populate Bybit API keys

## Testing
- `SKIP=pytest pre-commit run --files services/data_handler_service.py`
- `pytest tests/test_data_handler_service_logging.py tests/test_data_handler_service_not_found.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b048cca298832db99fcaa951d50dad