### PR TITLE
Ensure model loads before first request

### DIFF
--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -50,6 +50,10 @@ def _load_model() -> None:
             app.logger.exception("Failed to load model: %s", exc)
             _model = None
 
+if hasattr(app, "before_first_request"):
+    app.before_first_request(_load_model)  # type: ignore[attr-defined]
+else:  # pragma: no cover - Flask 3 removed before_first_request
+    _load_model()
 
 @app.route('/train', methods=['POST'])
 def train() -> ResponseReturnValue:


### PR DESCRIPTION
## Summary
- register model loading before the first request in `model_builder_service`
- add fallback for Flask 3 where `before_first_request` is removed

## Testing
- `PYTHONPATH=/workspace MODEL_FILE=model.pkl gunicorn services.model_builder_service:app --bind 127.0.0.1:8000 --log-level info &`
- `curl -s -X POST http://127.0.0.1:8000/predict -H 'Content-Type: application/json' -d '{"features":[1.0]}'`
- `kill 5263`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b048d1f25c832d941988d5d8c9e778