### PR TITLE
Добавить закрытие соединения с биржей при остановке приложения

### DIFF
--- a/services/data_handler_service.py
+++ b/services/data_handler_service.py
@@ -40,6 +40,18 @@ else:
                 if exchange is None:
                     init_exchange()
 
+def close_exchange(_: Exception | None = None) -> None:
+    """Закрыть соединение с биржей при завершении контекста приложения."""
+    global exchange
+    if exchange is not None:
+        close_method = getattr(exchange, "close", None)
+        if callable(close_method):
+            close_method()
+        exchange = None
+
+if hasattr(app, "teardown_appcontext"):
+    app.teardown_appcontext(close_exchange)
+
 CCXT_BASE_ERROR = getattr(ccxt, 'BaseError', Exception)
 CCXT_NETWORK_ERROR = getattr(ccxt, 'NetworkError', CCXT_BASE_ERROR)
 


### PR DESCRIPTION
## Summary
- Закрыта биржа при завершении контекста приложения
- Регистрация функции закрытия через `teardown_appcontext`

## Testing
- `pytest tests/test_data_handler_service_logging.py::test_data_handler_service_does_not_configure_logging_on_import tests/test_data_handler_service_not_found.py::test_unknown_route_returns_404 -q`

------
https://chatgpt.com/codex/tasks/task_e_68b048d4e884832d82b77284bb1e3131