### PR TITLE
ci: restore apt install steps in Dockerfile.ci

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -7,6 +7,9 @@ FROM ubuntu:24.04 AS builder
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Обновление linux-libc-dev устраняет CVE-2025-21976, а libgcrypt20 — CVE-2024-2236
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    python3 python3-venv build-essential linux-libc-dev libgcrypt20 git=1:2.43.0-1ubuntu7.3 \
+    && apt-get install -y --no-install-recommends --only-upgrade gnupg dirmngr \
     && python3 -m venv /venv \
     && apt-get purge -y --auto-remove build-essential \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
@@ -30,6 +33,11 @@ FROM ubuntu:24.04 AS runtime
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Устанавливаем только необходимые пакеты выполнения
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    libssl3t64=3.0.13-0ubuntu3.5 \
+    python3.12-minimal=3.12.3-1ubuntu0.8 \
+    && apt-get install -y --only-upgrade openssl libssl3t64 \
+    && apt-get purge -y git \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
## Summary
- reinstate apt-get install with required packages for builder stage in Dockerfile.ci
- add missing apt setup for runtime stage ensuring chained commands belong to single RUN

## Testing
- `pre-commit run flake8 --files Dockerfile.ci`
- `pytest tests/test_safe_html_parser_hypothesis.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0a4436170832db34d8f2d44a89223