### PR TITLE
Use atomic file writes and add recovery tests

### DIFF
--- a/model_builder.py
+++ b/model_builder.py
@@ -810,12 +810,21 @@ class ModelBuilder:
                 "threshold_offset": self.threshold_offset,
                 "base_thresholds": self.base_thresholds,
             }
-            with open(self.state_file, "wb") as f:
+            tmp_file = f"{self.state_file}.tmp"
+            with open(tmp_file, "wb") as f:
                 joblib.dump(state, f)
+            os.replace(tmp_file, self.state_file)
             self.last_save_time = time.time()
             logger.info("Состояние ModelBuilder сохранено")
         except (OSError, ValueError) as e:
             logger.exception("Ошибка сохранения состояния ModelBuilder: %s", e)
+            try:
+                if os.path.exists(tmp_file):
+                    os.remove(tmp_file)
+            except OSError as cleanup_err:
+                logger.exception(
+                    "Не удалось удалить временный файл %s: %s", tmp_file, cleanup_err
+                )
             raise
 
     def load_state(self):

--- a/tests/test_state_recovery.py
+++ b/tests/test_state_recovery.py
@@ -1,0 +1,119 @@
+import os
+import types
+import logging
+import pandas as pd
+import pytest
+from bot.config import BotConfig
+
+
+def _make_positions(symbol: str, ts: str) -> pd.DataFrame:
+    idx = pd.MultiIndex.from_tuples(
+        [(symbol, pd.Timestamp(ts, tz="UTC"))], names=["symbol", "timestamp"]
+    )
+    return pd.DataFrame(
+        [
+            {
+                "symbol": symbol,
+                "side": "long",
+                "size": 1.0,
+                "entry_price": 100.0,
+                "tp_multiplier": 0.0,
+                "sl_multiplier": 0.0,
+                "stop_loss_price": 90.0,
+                "highest_price": 100.0,
+                "lowest_price": 100.0,
+                "breakeven_triggered": False,
+            }
+        ],
+        index=idx,
+    )
+
+
+def test_trade_manager_save_recovery(tmp_path, monkeypatch, caplog):
+    monkeypatch.setenv("TEST_MODE", "1")
+    from bot.trade_manager import TradeManager
+
+    cfg = BotConfig(cache_dir=str(tmp_path))
+    dh = types.SimpleNamespace(exchange=types.SimpleNamespace(), usdt_pairs=["BTCUSDT"])
+    tm = TradeManager(cfg, dh, object(), None, None)
+
+    tm.positions = _make_positions("BTCUSDT", "2020-01-01")
+    tm.returns_by_symbol = {"BTCUSDT": [(0.0, 0.1)]}
+    tm.positions_changed = True
+    tm.last_save_time -= tm.save_interval + 1
+    tm.save_state()
+
+    tm.positions = _make_positions("BTCUSDT", "2020-01-02")
+    tm.returns_by_symbol = {"BTCUSDT": [(1.0, 0.2)]}
+    tm.positions_changed = True
+    tm.last_save_time -= tm.save_interval + 1
+
+    real_replace = os.replace
+
+    def fail_replace(src, dst):
+        raise OSError("boom")
+
+    monkeypatch.setattr(os, "replace", fail_replace)
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(OSError):
+            tm.save_state()
+        assert any("Failed to save state" in r.message for r in caplog.records)
+    monkeypatch.setattr(os, "replace", real_replace)
+
+    tm.positions = pd.DataFrame()
+    tm.returns_by_symbol = {}
+    tm.load_state()
+    assert "BTCUSDT" in tm.positions.index.get_level_values("symbol")
+    assert tm.returns_by_symbol["BTCUSDT"][0][1] == 0.1
+
+    tm.positions = _make_positions("BTCUSDT", "2020-01-03")
+    tm.returns_by_symbol = {"BTCUSDT": [(2.0, 0.3)]}
+    tm.positions_changed = True
+    tm.last_save_time -= tm.save_interval + 1
+    tm.save_state()
+    tm.positions = pd.DataFrame()
+    tm.returns_by_symbol = {}
+    tm.load_state()
+    assert tm.returns_by_symbol["BTCUSDT"][0][1] == 0.3
+
+
+def test_model_builder_save_recovery(tmp_path, monkeypatch, caplog):
+    monkeypatch.setenv("TEST_MODE", "1")
+    from bot.model_builder import ModelBuilder
+
+    cfg = BotConfig(cache_dir=str(tmp_path))
+    dh = types.SimpleNamespace(usdt_pairs=["BTCUSDT"])
+    mb = ModelBuilder(cfg, dh, object())
+
+    mb.base_thresholds["BTCUSDT"] = 0.5
+    mb.last_save_time -= mb.save_interval + 1
+    mb.save_state()
+
+    mb.base_thresholds["BTCUSDT"] = 0.6
+    mb.last_save_time -= mb.save_interval + 1
+
+    real_replace = os.replace
+
+    def fail_replace(src, dst):
+        raise OSError("boom")
+
+    monkeypatch.setattr(os, "replace", fail_replace)
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(OSError):
+            mb.save_state()
+        assert any(
+            "Ошибка сохранения состояния ModelBuilder" in r.message for r in caplog.records
+        )
+    monkeypatch.setattr(os, "replace", real_replace)
+
+    mb.base_thresholds.clear()
+    mb.load_state()
+    assert mb.base_thresholds["BTCUSDT"] == 0.5
+
+    mb.base_thresholds["BTCUSDT"] = 0.7
+    mb.last_save_time -= mb.save_interval + 1
+    mb.save_state()
+    mb.base_thresholds.clear()
+    mb.load_state()
+    assert mb.base_thresholds["BTCUSDT"] == 0.7
+


### PR DESCRIPTION
## Summary
- write model and trade state via temp files then atomically replace
- log and clean up on failed writes
- add tests for state recovery after save failure

## Testing
- `SKIP=pytest pre-commit run --files model_builder.py trade_manager.py tests/test_state_recovery.py`
- `pytest tests/test_state_recovery.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0a491c4a0832d83538e5c2dcfb0f7