### PR TITLE
feat: improve telegram logging with retries

### DIFF
--- a/config.json
+++ b/config.json
@@ -105,5 +105,8 @@
     "early_stopping_patience": 3,
     "reversal_margin": 0.05,
     "prediction_target": "direction",
-    "trading_fee": 0.0
+    "trading_fee": 0.0,
+    "enable_notifications": true,
+    "save_unsent_telegram": false,
+    "unsent_telegram_path": "unsent_telegram.log"
 }

--- a/config.py
+++ b/config.py
@@ -169,6 +169,9 @@ class BotConfig:
     ema_weight: float = _get_default("ema_weight", 0.2)
     early_stopping_patience: int = _get_default("early_stopping_patience", 3)
     balance_key: Optional[str] = _get_default("balance_key", None)
+    enable_notifications: bool = _get_default("enable_notifications", True)
+    save_unsent_telegram: bool = _get_default("save_unsent_telegram", False)
+    unsent_telegram_path: str = _get_default("unsent_telegram_path", "unsent_telegram.log")
 
     def __post_init__(self) -> None:
         if self.ws_subscription_batch_size is None:

--- a/data_handler.py
+++ b/data_handler.py
@@ -897,20 +897,35 @@ class DataHandler:
             config.get("max_symbols"),
             GPU_AVAILABLE,
         )
-        if not os.environ.get("TELEGRAM_BOT_TOKEN") or not os.environ.get(
-            "TELEGRAM_CHAT_ID"
-        ):
-            logger.warning(
-                "TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID not set; Telegram alerts will not be sent"
-            )
         self.config = config
         self.exchange = exchange or create_exchange()
         self.pro_exchange = pro_exchange
-        self.telegram_logger = TelegramLogger(
-            telegram_bot,
-            chat_id,
-            max_queue_size=config.get("telegram_queue_size"),
-        )
+        if (
+            not config.enable_notifications
+            or not os.environ.get("TELEGRAM_BOT_TOKEN")
+            or not os.environ.get("TELEGRAM_CHAT_ID")
+        ):
+            logger.warning(
+                "Telegram notifications disabled; messages will not be sent"
+            )
+            async def _noop(*_, **__):
+                pass
+
+            self.telegram_logger = types.SimpleNamespace(
+                send_telegram_message=_noop,
+            )
+        else:
+            unsent_path = None
+            if config.save_unsent_telegram:
+                unsent_path = os.path.join(
+                    config.log_dir, config.unsent_telegram_path
+                )
+            self.telegram_logger = TelegramLogger(
+                telegram_bot,
+                chat_id,
+                max_queue_size=config.get("telegram_queue_size"),
+                unsent_path=unsent_path,
+            )
         self.feature_callback = feature_callback
         self.trade_callback = trade_callback
         self.cache = HistoricalDataCache(config["cache_dir"])

--- a/telegram_logger.py
+++ b/telegram_logger.py
@@ -1,0 +1,215 @@
+"""Асинхронный логгер для отправки сообщений в Telegram.
+
+Реализует очередь сообщений и повторные попытки с экспоненциальной
+задержкой. При неудачной отправке сообщение можно сохранить во
+внешний файл для последующей обработки.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import threading
+import time
+from typing import Optional
+
+import httpx
+try:  # pragma: no cover - optional dependency
+    from telegram.error import BadRequest, Forbidden, RetryAfter
+except Exception as exc:  # pragma: no cover - missing telegram
+    logging.getLogger("TradingBot").error("Telegram package not available: %s", exc)
+
+    class _TelegramError(Exception):
+        pass
+
+    BadRequest = Forbidden = RetryAfter = _TelegramError  # type: ignore
+
+
+logger = logging.getLogger("TradingBot")
+
+
+class TelegramLogger(logging.Handler):
+    """Handler для пересылки логов и сообщений в Telegram."""
+
+    _queue: asyncio.Queue | None = None
+    _worker_task: asyncio.Task | None = None
+    _worker_lock = asyncio.Lock()
+    _bot = None
+    _stop_event: asyncio.Event | None = None
+
+    def __init__(
+        self,
+        bot,
+        chat_id,
+        level: int = logging.NOTSET,
+        max_queue_size: int | None = None,
+        unsent_path: Optional[str] = None,
+    ) -> None:
+        super().__init__(level)
+        self.bot = bot
+        self.chat_id = chat_id
+        self.unsent_path = unsent_path
+        self.last_message_time = 0.0
+        self.message_interval = 1800
+        self.message_lock = asyncio.Lock()
+
+        if TelegramLogger._queue is None:
+            TelegramLogger._queue = asyncio.Queue(maxsize=max_queue_size or 0)
+            TelegramLogger._bot = bot
+            TelegramLogger._stop_event = asyncio.Event()
+            if os.getenv("TEST_MODE") != "1":
+                try:
+                    loop = asyncio.get_running_loop()
+                    TelegramLogger._worker_task = loop.create_task(self._worker())
+                except RuntimeError:
+                    threading.Thread(
+                        target=lambda: asyncio.run(self._worker()),
+                        daemon=True,
+                    ).start()
+
+        self.last_sent_text = ""
+
+    async def _worker(self) -> None:
+        while True:
+            if TelegramLogger._queue is None or TelegramLogger._stop_event is None:
+                return
+            if TelegramLogger._stop_event.is_set():
+                return
+            queue = TelegramLogger._queue
+            try:
+                item = await asyncio.wait_for(queue.get(), 1.0)
+            except asyncio.TimeoutError:
+                continue
+            chat_id, text, urgent = item
+            if chat_id is None:
+                queue.task_done()
+                return
+            try:
+                await self._send(text, chat_id, urgent)
+            except (RetryAfter, Forbidden, BadRequest, httpx.HTTPError) as exc:
+                logger.error("Ошибка отправки сообщения в Telegram: %s", exc)
+                if self.unsent_path:
+                    self._save_unsent(chat_id, text)
+            except Exception:
+                logger.exception("Непредвиденная ошибка отправки Telegram")
+                raise
+            finally:
+                queue.task_done()
+            await asyncio.sleep(1)
+
+    async def _send(self, message: str, chat_id: int | str, urgent: bool) -> None:
+        async with self.message_lock:
+            if (
+                not urgent
+                and time.time() - self.last_message_time < self.message_interval
+            ):
+                logger.debug(
+                    "Сообщение Telegram пропущено из-за интервала: %s...",
+                    message[:100],
+                )
+                return
+
+            parts = [message[i : i + 500] for i in range(0, len(message), 500)]
+            for part in parts:
+                if part == self.last_sent_text:
+                    logger.debug("Повторное сообщение Telegram пропущено")
+                    continue
+
+                delay = 1
+                for attempt in range(5):
+                    try:
+                        result = await TelegramLogger._bot.send_message(
+                            chat_id=chat_id, text=part
+                        )
+                        if not getattr(result, "message_id", None):
+                            logger.error(
+                                "Telegram message response without message_id"
+                            )
+                        else:
+                            self.last_sent_text = part
+                        self.last_message_time = time.time()
+                        break
+                    except RetryAfter as e:
+                        wait_time = getattr(e, "retry_after", delay)
+                        logger.warning("Flood control: ожидание %sс", wait_time)
+                        await asyncio.sleep(wait_time)
+                        delay = min(delay * 2, 60)
+                    except httpx.HTTPError as e:
+                        logger.warning(
+                            "HTTP ошибка Telegram: %s. Попытка %s/5",
+                            e,
+                            attempt + 1,
+                        )
+                        if attempt < 4:
+                            await asyncio.sleep(delay)
+                            delay = min(delay * 2, 60)
+                        else:
+                            raise
+                    except (BadRequest, Forbidden) as e:
+                        logger.error("Ошибка Telegram: %s", e)
+                        raise
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as e:
+                        logger.exception("Ошибка отправки сообщения Telegram: %s", e)
+                        raise
+
+    def _save_unsent(self, chat_id: int | str, text: str) -> None:
+        try:
+            with open(self.unsent_path, "a", encoding="utf-8") as f:
+                f.write(f"{chat_id}\t{text}\n")
+        except OSError as exc:  # pragma: no cover - file system errors
+            logger.error("Не удалось сохранить сообщение Telegram: %s", exc)
+
+    async def send_telegram_message(self, message: str, urgent: bool = False) -> None:
+        if TelegramLogger._queue is None:
+            logger.warning("TelegramLogger queue is None, message dropped")
+            return
+        msg = message[:4096]
+        try:
+            TelegramLogger._queue.put_nowait((self.chat_id, msg, urgent))
+        except asyncio.QueueFull:
+            logger.warning("Очередь Telegram переполнена, сообщение пропущено")
+
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - logging
+        try:
+            msg = self.format(record)
+            try:
+                loop = asyncio.get_running_loop()
+                loop.create_task(self.send_telegram_message(msg))
+            except RuntimeError:
+                try:
+                    loop = asyncio.get_event_loop()
+                    if loop.is_running():
+                        loop.create_task(self.send_telegram_message(msg))
+                    else:
+                        raise RuntimeError
+                except RuntimeError:
+                    threading.Thread(
+                        target=lambda: asyncio.run(self.send_telegram_message(msg)),
+                        daemon=True,
+                    ).start()
+        except (ValueError, RuntimeError) as exc:
+            logger.error("Ошибка в TelegramLogger: %s", exc)
+
+    @classmethod
+    async def shutdown(cls) -> None:
+        if cls._stop_event is None:
+            return
+        if cls._queue is not None:
+            try:
+                cls._queue.put_nowait((None, "", False))
+            except asyncio.QueueFull:
+                pass
+        cls._stop_event.set()
+        if cls._worker_task is not None:
+            cls._worker_task.cancel()
+            try:
+                await cls._worker_task
+            except asyncio.CancelledError:
+                pass
+            cls._worker_task = None
+        cls._queue = None
+        cls._stop_event = None
+

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -177,7 +177,11 @@ class TradeManager:
         self.data_handler = data_handler
         self.model_builder = model_builder
         self.rl_agent = rl_agent
-        if not os.environ.get("TELEGRAM_BOT_TOKEN") or not os.environ.get("TELEGRAM_CHAT_ID"):
+        if (
+            not config.enable_notifications
+            or not os.environ.get("TELEGRAM_BOT_TOKEN")
+            or not os.environ.get("TELEGRAM_CHAT_ID")
+        ):
             logger.warning(
                 "TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID not set; Telegram alerts will not be sent"
             )
@@ -190,10 +194,16 @@ class TradeManager:
                 send_telegram_message=_noop,
             )
         else:
+            unsent_path = None
+            if config.save_unsent_telegram:
+                unsent_path = os.path.join(
+                    config.log_dir, config.unsent_telegram_path
+                )
             self.telegram_logger = TelegramLogger(
                 telegram_bot,
                 chat_id,
                 max_queue_size=config.get("telegram_queue_size"),
+                unsent_path=unsent_path,
             )
         self.positions = pd.DataFrame(
             columns=[


### PR DESCRIPTION
## Summary
- move TelegramLogger into dedicated module with exponential backoff and optional persistence of unsent messages
- allow running without Telegram notifications via config flag
- wire new logger and settings into data handler and trade manager

## Testing
- `pytest tests/test_telegram_logger.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0a49b3654832da2366511196bbfb2