### PR TITLE
Import HTTP client helpers in data handler

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from trading_bot import get_http_client, close_http_client
+
 import os
 
 if os.getenv("TEST_MODE") == "1":  # pragma: no cover - test stubs


### PR DESCRIPTION
## Summary
- import get_http_client and close_http_client from trading_bot to resolve undefined names

## Testing
- `flake8 data_handler.py`

------
https://chatgpt.com/codex/tasks/task_e_68b0b1a9d638832d81879abbeeb4d28e