### PR TITLE
fix: add missing imports in data handler

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -78,11 +78,16 @@ except ImportError as exc:  # pragma: no cover - optional dependency missing
     raise ImportError("ray is required for distributed computations") from exc
 from dotenv import load_dotenv
 from flask import Flask, jsonify
+from pydantic import BaseSettings, Field, ValidationError, field_validator
 
 from bot.config import BotConfig
 from bot.optimizer import ParameterOptimizer
 from bot.strategy_optimizer import StrategyOptimizer
 from bot.cache import HistoricalDataCache
+from bot.http_client import (
+    get_async_http_client as get_http_client,
+    close_async_http_client as close_http_client,
+)
 from bot.utils import BybitSDKAsync, TelegramLogger, bybit_interval
 from bot.utils import calculate_volume_profile as utils_volume_profile
 from bot.utils import (


### PR DESCRIPTION
## Summary
- import pydantic settings in DataHandler
- include http client helpers to avoid F821

## Testing
- `flake8 data_handler.py`
- `pytest -q` *(fails: `pydantic.errors.PydanticImportError: BaseSettings has been moved to the pydantic-settings package`, `ModuleNotFoundError: No module named 'hypothesis'`, `AttributeError: module 'httpx' has no attribute 'BaseTransport'`)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b1a62aa4832da9bf6e1a8014e5e5