### PR TITLE
ci: install gnupg without forced upgrade

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -9,7 +9,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Обновление linux-libc-dev устраняет CVE-2025-21976, а libgcrypt20 — CVE-2024-2236
 RUN apt-get update && apt-get install --no-install-recommends -y \
     python3 python3-venv build-essential linux-libc-dev libgcrypt20 git=1:2.43.0-1ubuntu7.3 \
-    && apt-get install -y --no-install-recommends --only-upgrade gnupg dirmngr \
+    && apt-get install -y --no-install-recommends gnupg dirmngr \
     && python3 -m venv /venv \
     && apt-get purge -y --auto-remove build-essential \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
## Summary
- remove `--only-upgrade` when installing gnupg and dirmngr in builder stage

## Testing
- `pre-commit run --files Dockerfile.ci` *(fails: module 'httpx' has no attribute 'BaseTransport')*
- `pytest` *(fails: module 'httpx' has no attribute 'BaseTransport')*
- `docker build -f Dockerfile.ci .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b1b889a4832da76a8210462aeb24