### PR TITLE
fix: add BaseSettings import to data handler

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -17,6 +17,8 @@ import time
 import types
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List
 from pathlib import Path
+from pydantic import Field, field_validator
+from pydantic_settings import BaseSettings
 
 try:  # pragma: no cover - optional dependency
     import pandas as pd  # type: ignore


### PR DESCRIPTION
## Summary
- import BaseSettings and Pydantic helpers for DataHandler

## Testing
- `pytest` *(fails: AttributeError: module 'httpx' has no attribute 'BaseTransport')*

------
https://chatgpt.com/codex/tasks/task_e_68b0b1c9e9ec832d8d4d5d7c4b67afcd