### PR TITLE
feat: add GPT advice model fields

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -36,8 +36,9 @@ GPT_ADVICE: dict[str, float | str | None] = {
 
 class GPTAdviceModel(BaseModel):
 
-
-
+    signal: str | None = None
+    tp_mult: float | None = None
+    sl_mult: float | None = None
 
 class ServiceUnavailableError(Exception):
     """Raised when required services are not reachable."""


### PR DESCRIPTION
## Summary
- define signal, tp_mult, and sl_mult fields in GPTAdviceModel for GPT output typing

## Testing
- `pre-commit run --files trading_bot.py` *(fails: ImportError circular import)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b6cf3ba8832da782b6a05bd69fb8