### PR TITLE
Remove duplicate Pydantic import

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -23,7 +23,6 @@ from tenacity import retry, stop_after_attempt, wait_exponential
 from bot.config import BotConfig
 from bot.gpt_client import GPTClientError, query_gpt_json_async
 from bot.utils import logger, suppress_tf_logs
-from pydantic import BaseModel, ValidationError
 
 CFG = BotConfig()
 


### PR DESCRIPTION
## Summary
- remove redundant duplicate import of `BaseModel` and `ValidationError` in `trading_bot.py`

## Testing
- `pytest` *(fails: IndentationError in trading_bot.py; ModuleNotFoundError: hypothesis)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b6d2607c832d8cb9f191f42ff812