### PR TITLE
Установить curl до первого использования

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y --no-install
     build-essential \
     ca-certificates \
     wget \
+    curl \
     python3-dev \
     python3-venv \
     python3-pip \


### PR DESCRIPTION
## Summary
- Добавлен curl в список пакетов apt-get install на этапе сборки, чтобы curl был доступен перед первым использованием.

## Testing
- `pytest` (ошибка IndentationError: expected an indented block)


------
https://chatgpt.com/codex/tasks/task_e_68b0b6e8a924832da19dbb719ae61800