### PR TITLE
Restore GPTAdviceModel and resolve circular imports

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -1,6 +1,5 @@
 """Main entry point for the trading bot."""
 
-from data_handler import get_settings
 from pydantic import BaseModel, ValidationError
 
 import atexit
@@ -12,6 +11,7 @@ import time
 from collections import deque
 from contextlib import suppress
 from pathlib import Path
+from typing import Awaitable, Callable, Literal, Optional, TypeVar
 
 from model_builder_client import schedule_retrain
 
@@ -33,6 +33,9 @@ GPT_ADVICE: dict[str, float | str | None] = {
 
 
 class GPTAdviceModel(BaseModel):
+    signal: Optional[Literal["buy", "sell", "hold"]] = None
+    tp_mult: float | None = None
+    sl_mult: float | None = None
 
 class ServiceUnavailableError(Exception):
     """Raised when required services are not reachable."""
@@ -904,6 +907,8 @@ async def main_async() -> None:
 
 
 def main() -> None:
+    from data_handler import get_settings  # local import to avoid circular dependency
+
     load_dotenv()
     try:
         cfg = get_settings()


### PR DESCRIPTION
## Summary
- define `GPTAdviceModel` fields to resolve indentation error
- import typing helpers and move `get_settings` import into `main`

## Testing
- `flake8 trading_bot.py`
- `pytest` *(fails: `PydanticImportError: BaseSettings has been moved to the pydantic-settings package`)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ba01a5a8832d865ec2ef17540631