### PR TITLE
Добавлен импорт типов для trading_bot

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -2,6 +2,8 @@
 
 from pydantic import BaseModel, ValidationError
 
+from typing import Callable, TypeVar
+from typing import Awaitable
 import atexit
 import asyncio
 import math


### PR DESCRIPTION
## Summary
- добавить импорт `Callable` и `TypeVar`
- добавить недостающий импорт `Awaitable`

## Testing
- `pytest` *(падает: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_68b1f4e32f34832daf31170142693c56