### PR TITLE
Ensure base SHA retrieval and token setup

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -35,10 +35,14 @@ jobs:
       - name: Generate diff
         if: success()
         env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           base_sha=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
             https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER | jq -r .base.sha)
+          if [ -z "$base_sha" ] || [ "$base_sha" = "null" ]; then
+            echo "Error: failed to retrieve base SHA" >&2
+            exit 1
+          fi
           git fetch origin $base_sha
           git diff $base_sha...HEAD -- 'bot/**/*.py' > diff.patch
           head -c 200000 diff.patch > diff.trunc && mv diff.trunc diff.patch


### PR DESCRIPTION
## Summary
- use built-in `secrets.GITHUB_TOKEN` for diff generation job
- add check to stop when `base_sha` can't be fetched

## Testing
- `pre-commit run --files .github/workflows/gptoss_review.yml` *(fails: module 'httpx' has no attribute 'Response')*

------
https://chatgpt.com/codex/tasks/task_e_68b1f5843448832dab7fd548f21329b6