### PR TITLE
test: use fixture for CSRF_SECRET

### DIFF
--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -1,13 +1,15 @@
-import os
 import logging
 import pytest
-
-os.environ["CSRF_SECRET"] = "testsecret"
 
 pytest.importorskip("transformers")
 
 import server
 from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def csrf_secret(monkeypatch):
+    monkeypatch.setenv("CSRF_SECRET", "testsecret")
 
 
 def make_client(monkeypatch):
@@ -20,13 +22,13 @@ def make_client(monkeypatch):
     return TestClient(server.app)
 
 
-def test_completions_requires_key(monkeypatch):
+def test_completions_requires_key(monkeypatch, csrf_secret):
     with make_client(monkeypatch) as client:
         resp = client.post("/v1/completions", json={"prompt": "hi"})
         assert resp.status_code == 401
 
 
-def test_chat_completions_requires_key(monkeypatch):
+def test_chat_completions_requires_key(monkeypatch, csrf_secret):
     with make_client(monkeypatch) as client:
         resp = client.post(
             "/v1/chat/completions",
@@ -35,7 +37,7 @@ def test_chat_completions_requires_key(monkeypatch):
         assert resp.status_code == 401
 
 
-def test_check_api_key_masks_sensitive_headers(monkeypatch, caplog):
+def test_check_api_key_masks_sensitive_headers(monkeypatch, csrf_secret, caplog):
     with make_client(monkeypatch) as client:
         headers = {
             "Authorization": "Bearer secret-token",


### PR DESCRIPTION
## Summary
- add pytest fixture to set CSRF_SECRET
- remove module-level env change in auth tests

## Testing
- `pytest tests/test_server_auth.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1f912f59c832d8a3b2a9dad850b6a