### PR TITLE
refactor: remove duplicate typing imports

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -2,8 +2,6 @@
 
 from pydantic import BaseModel, ValidationError
 
-from typing import Callable, TypeVar
-from typing import Awaitable
 import atexit
 import asyncio
 import math


### PR DESCRIPTION
## Summary
- remove redundant typing imports in `trading_bot.py`

## Testing
- `flake8 trading_bot.py && echo "flake8 passed"`


------
https://chatgpt.com/codex/tasks/task_e_68b1fa059e20832db9b58c2c41904be1