### PR TITLE
Add dependency submission workflow and update project modules

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,21 @@
+name: Dependency Submission
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install build deps
+        run: pip install --upgrade pip build
+      - name: Validate project
+        run: python -m build
+      - name: Submit dependency snapshot
+        uses: advanced-security/python-dependency-submission@v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,11 @@ dependencies = ["flask>=3.0.2"]
 [tool.setuptools]
 packages = ["services"]
 py-modules = [
+  "cache",
   "config",
   "data_handler",
   "gpt_client",
+  "http_client",
   "model_builder",
   "model_builder_client",
   "optimizer",
@@ -29,6 +31,7 @@ py-modules = [
   "server",
   "simulation",
   "strategy_optimizer",
+  "telegram_logger",
   "trade_manager",
   "trading_bot",
   "utils"


### PR DESCRIPTION
## Summary
- add dependency submission workflow to build and submit Python project dependencies
- list all project modules in pyproject.toml

## Testing
- `python -m build`
- `pytest` *(fails: AttributeError: module 'httpx' has no attribute 'Response')*

------
https://chatgpt.com/codex/tasks/task_e_68b1f9dc9f38832d87b1afc4c4f6ee77