### PR TITLE
refactor: consolidate typing imports

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -2,8 +2,7 @@
 
 from pydantic import BaseModel, ValidationError
 
-from typing import Callable, TypeVar
-from typing import Awaitable
+from typing import Awaitable, Callable, TypeVar
 import atexit
 import asyncio
 import math
@@ -13,7 +12,6 @@ import time
 from collections import deque
 from contextlib import suppress
 from pathlib import Path
-from typing import Awaitable, Callable, TypeVar
 
 from model_builder_client import schedule_retrain
 


### PR DESCRIPTION
## Summary
- tidy `trading_bot.py` imports and remove duplicates

## Testing
- `flake8 trading_bot.py`
- `pytest` *(fails: ImportError: cannot import name 'field_validator' from 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68b1f8a63a10832d9dd8871915e0b219