### PR TITLE
chore: pin workflow actions

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -20,8 +20,8 @@ jobs:
     env:
       CUDA_VISIBLE_DEVICES: ${{ matrix.device == 'gpu' && '0' || '' }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Get pip cache dir

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,8 +10,8 @@ jobs:
     env:
       TEST_MODE: "1"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- pin actions/checkout and actions/setup-python to stable commit SHAs in tests and CI CPU workflows

## Testing
- `pre-commit run --files .github/workflows/tests.yml .github/workflows/ci_cpu.yml` *(fails: ImportError: cannot import name 'ema_fast' from 'bot.data_handler'; ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_68b1fc7be210832d806794eb595ca3dc