### PR TITLE
Use pkill for reliable mock server shutdown

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -67,5 +67,5 @@ jobs:
       - name: Stop mock server
         if: always()
         run: |
-          kill $(cat server.pid)
+          pkill -F server.pid || true
           rm server.pid


### PR DESCRIPTION
## Summary
- stop CI CPU mock server with `pkill -F server.pid || true`

## Testing
- `pre-commit run --files .github/workflows/ci_cpu.yml` *(fails: cannot import 'IndicatorsCache', missing 'ema_fast')*

------
https://chatgpt.com/codex/tasks/task_e_68b1fc813c44832d87a0074e6bf49983