### PR TITLE
fix: ensure independent docker builds with full logs

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,6 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
         include:
           - file: Dockerfile.cpu
@@ -104,6 +105,7 @@ jobs:
       - name: Build and push Docker image
         run: |
           docker buildx build \
+            --progress=plain \
             -f ${{ matrix.file }} \
             -t docker.io/${{ secrets.AVERINALEKS }}/${{ matrix.image }}:latest \
             --push \


### PR DESCRIPTION
## Summary
- disable matrix fail-fast in Docker publish workflow
- show full Docker build logs via --progress=plain

## Testing
- `yamllint .github/workflows/docker-publish.yml` *(fails: missing document start, truthy value, bracket spacing, line length)*

------
https://chatgpt.com/codex/tasks/task_e_68b1fe308e74832d9b5818336402c371