### PR TITLE
ci: use env vars for docker login

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -77,7 +77,7 @@ jobs:
           sudo systemctl start docker
 
       - name: Login to Docker Hub
-        run: docker login -u ${{ secrets.AVERINALEKS }} -p ${{ secrets.BOT }}
+        run: echo "${{ secrets.BOT }}" | docker login --username "${{ secrets.AVERINALEKS }}" --password-stdin
 
       - name: Prepare buildx cache directory
         run: mkdir -p /mnt/.buildx-cache
@@ -105,7 +105,7 @@ jobs:
         run: |
           docker buildx build \
             -f ${{ matrix.file }} \
-            -t docker.io/${{ secrets.AVERINALEKS }}/${{ matrix.image }}:latest \
+            -t docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ matrix.image }}:latest \
             --push \
             --cache-from type=local,src=/mnt/.buildx-cache \
             --cache-to type=local,dest=/mnt/.buildx-cache-new,mode=max \


### PR DESCRIPTION
## Summary
- use password-stdin login for Docker Hub
- reference Docker Hub creds via environment variables in build stage

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml` *(fails: ImportError: cannot import name 'IndicatorsCache' from 'bot.data_handler'; ModuleNotFoundError: No module named 'hypothesis')*
- `pytest` *(fails: ImportError: cannot import name 'IndicatorsCache' from 'bot.data_handler'; ModuleNotFoundError: No module named 'hypothesis')*


------
https://chatgpt.com/codex/tasks/task_e_68b1fe2b8e48832d9544262d8dbca3c4