### PR TITLE
chore: simplify security upgrade step

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -112,8 +112,7 @@ jobs:
             .
 
       - name: Apply security upgrades in built image
-        run: |
-          docker run --rm ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.image }}:latest bash -lc "apt-get update && apt-get upgrade -y && apt-get clean && rm -rf /var/lib/apt/lists/*"
+        run: docker run --rm docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ matrix.image }}:latest bash -lc "apt-get update && apt-get upgrade -y && apt-get clean && rm -rf /var/lib/apt/lists/*"
         working-directory: bot
 
       - name: Move Docker layer cache


### PR DESCRIPTION
## Summary
- streamline Docker security upgrade run command

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml` *(fails: ImportError: cannot import name 'IndicatorsCache' from 'bot.data_handler')*


------
https://chatgpt.com/codex/tasks/task_e_68b1fe206198832d869550bd72561c89