### PR TITLE
chore: remove proxy step from dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -16,14 +16,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Read registries proxy
-        id: read_proxy
-        run: |
-          echo "json=$(jq -c '.' github_registries_proxy.json)" >> $GITHUB_OUTPUT
-
       - name: Run Dependabot
         run: bash scripts/run_dependabot.sh
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
           TOKEN: ${{ secrets.TOKEN }}
-          GITHUB_REGISTRIES_PROXY: "${{ steps.read_proxy.outputs.json }}"


### PR DESCRIPTION
## Summary
- remove `Read registries proxy` step and unused env variable from dependabot workflow

## Testing
- `pytest -q` *(fails: ImportError cannot import name 'IndicatorsCache' and ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_68b1ffec571c832d83a8948a1c2d99e6