### PR TITLE
Activate venv before installing pip-tools

### DIFF
--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -71,7 +71,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install build twine
       - name: Install pip-tools
-        run: pip install pip-tools==7.5.0
+        run: |
+          source /mnt/venv/bin/activate
+          pip install pip-tools==7.5.0
       - name: Generate dependency lock
         run: |
           source /mnt/venv/bin/activate


### PR DESCRIPTION
## Summary
- ensure pip-tools installs into the venv created earlier

## Testing
- `pre-commit run --files .github/workflows/submit-pypi.yml` *(fails: ImportError: cannot import name 'IndicatorsCache')*

------
https://chatgpt.com/codex/tasks/task_e_68b200053a18832d912ff8ea923e7055