### PR TITLE
Use PATH for venv in PyPI workflow

### DIFF
--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -62,33 +62,29 @@ jobs:
           python-version-file: .python-version
       - name: Create virtual environment
         run: |
-          python -m venv /mnt/venv && source /mnt/venv/bin/activate
+          python -m venv /mnt/venv
       - name: Add venv to PATH
         run: echo "/mnt/venv/bin" >> $GITHUB_PATH
       - name: Install build tools
         run: |
-          source /mnt/venv/bin/activate
           python -m pip install --upgrade pip
           pip install build twine
       - name: Install pip-tools
         run: pip install pip-tools==7.5.0
       - name: Generate dependency lock
         run: |
-          source /mnt/venv/bin/activate
           pip-compile --strip-extras -o requirements.out requirements.txt
       - name: Copy project to /mnt
         run: rsync -a . /mnt/project
       - name: Check dependencies
         working-directory: /mnt/project
         run: |
-          source /mnt/venv/bin/activate
           pip-compile --dry-run -o requirements.out requirements.txt
       - name: Return generated files
         if: always()
         run: rsync -a /mnt/project/requirements.out requirements.out || true
       - name: Build package
         run: |
-          source /mnt/venv/bin/activate
           python -m build
       - name: Publish to PyPI
         if: env.TOKENPYPI != ''


### PR DESCRIPTION
## Summary
- use venv path instead of activation in submit-pypi workflow

## Testing
- `python -m pre_commit run --files .github/workflows/submit-pypi.yml` (failed: Segmentation fault)`

------
https://chatgpt.com/codex/tasks/task_e_68b2000b5170832dacb80f565618562f