### PR TITLE
Validate PyPI token before publish step

### DIFF
--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -15,6 +15,11 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: Validate token
+        run: |
+          if [ -z "$TOKENPYPI" ]; then
+            echo "TOKENPYPI not set" && exit 1
+          fi
       - name: Select branch
         id: select-branch
         run: |


### PR DESCRIPTION
## Summary
- fail early if `TOKENPYPI` is missing in submit workflow

## Testing
- `pre-commit run --files .github/workflows/submit-pypi.yml` *(fails: ImportError: cannot import name 'IndicatorsCache')*

------
https://chatgpt.com/codex/tasks/task_e_68b2001634f4832dbdf617f5c5730a17