### PR TITLE
chore: drop OIDC permission from PyPI workflow

### DIFF
--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -12,7 +12,6 @@ jobs:
     env:
       TOKENPYPI: ${{ secrets.TOKENPYPI }}
     permissions:
-      id-token: write
       contents: read
     steps:
       - name: Select branch


### PR DESCRIPTION
## Summary
- remove unused `id-token: write` permission from PyPI publish workflow

## Testing
- `pre-commit run --files .github/workflows/submit-pypi.yml` *(fails: ImportError: cannot import name 'ema_fast' from 'bot.data_handler')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_68b20024a77c832d8106d1c1030788e1