### PR TITLE
chore: set working directory for docker build step

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -103,6 +103,7 @@ jobs:
         working-directory: bot
 
       - name: Build and push Docker image
+        working-directory: bot
         run: |
           docker buildx build \
             --progress=plain \


### PR DESCRIPTION
## Summary
- ensure docker build step runs inside repository by setting working directory

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml` *(fails: ImportError: cannot import name 'IndicatorsCache' from 'bot.data_handler'; ModuleNotFoundError: No module named 'hypothesis')*


------
https://chatgpt.com/codex/tasks/task_e_68b20d45ad54832da48abea7b20b2c74