### PR TITLE
ci: trigger on push and pull_request events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ permissions:
 # include the correlation ID from the run's raw logs.
 
 on:
+  push:
+    branches: ["main"]
+  pull_request:
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary
- enable CI workflow on push to main, pull_request, and workflow_dispatch

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(fails: ImportError: IndicatorsCache and ema_fast)*
- `pytest -q` *(fails: ImportError: IndicatorsCache and ema_fast)*

------
https://chatgpt.com/codex/tasks/task_e_68b20d8e9968832db90e0fc503445590