### PR TITLE
ci: install pip-audit from requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,6 @@ jobs:
       - name: Audit dependencies
         working-directory: /mnt
         run: |
-          pip install pip-audit
           pip-audit -f json -o pip-audit.json
       - name: Upload pip-audit report
         if: always()

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -19,3 +19,4 @@ requests>=2.32.0
 types-requests
 mypy==1.17.1
 hypothesis>=6.0.0
+pip-audit


### PR DESCRIPTION
## Summary
- add pip-audit to CI requirements
- use preinstalled pip-audit in workflow

## Testing
- `pip install -r requirements-ci.txt`
- `pytest -q` *(fails: ImportError: cannot import name 'IndicatorsCache')*

------
https://chatgpt.com/codex/tasks/task_e_68b20d9297a0832d9e5e313840ca5288