### PR TITLE
Use pip cache dir in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,13 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
+      - name: Get pip cache dir
+        id: pip-cache
+        run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
       - name: Cache pip
         uses: actions/cache@v4
         with:
-          path: ~/.cache/pip
+          path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements-ci.txt', 'requirements-cpu.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-


### PR DESCRIPTION
## Summary
- cache pip using `pip cache dir` for dynamic location

## Testing
- `pre-commit run --files .github/workflows/tests.yml` *(fails: ImportError: cannot import name 'IndicatorsCache' from 'bot.data_handler')*

------
https://chatgpt.com/codex/tasks/task_e_68b20dab07e8832da8125368005bd1be