### PR TITLE
ci: add TEST_MODE env to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
 
 env:
   PYTHONPYCACHEPREFIX: /mnt/pycache
+  TEST_MODE: "1"
 
 jobs:
   unit:
@@ -121,6 +122,8 @@ jobs:
     name: Integration tests
     runs-on: ubuntu-24.04
     needs: unit
+    env:
+      TEST_MODE: "1"
     strategy:
       matrix:
         device: [cpu]

--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -9,6 +9,7 @@ on:
 env:
   GPT_OSS_API: http://127.0.0.1:8009
   GPT_OSS_TIMEOUT: 5
+  TEST_MODE: "1"
 
 jobs:
   lint-type-test:


### PR DESCRIPTION
## Summary
- add TEST_MODE=1 to ci and ci_cpu workflows

## Testing
- `TEST_MODE=1 pytest -q` *(fails: ImportError: cannot import name 'IndicatorsCache', ModuleNotFoundError: No module named 'hypothesis')*


------
https://chatgpt.com/codex/tasks/task_e_68b20db32d78832d9a362bd3145dae8b