### PR TITLE
Install torch CPU wheel in CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,9 @@ jobs:
         run: python -m pip install --upgrade pip
       - name: Install requirements-ci
         run: pip install -r requirements-ci.txt
+      - name: Install PyTorch CPU wheel
+        run: |
+          pip install torch==2.3.0 --index-url https://download.pytorch.org/whl/cpu
       - name: Install requirements-cpu
         run: pip install -r requirements-cpu.txt
       - name: Run tests

--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -1,4 +1,3 @@
 # CPU-specific dependencies
 # Install torch separately with CPU wheels
-torch==2.8.0
 gymnasium==1.2.0


### PR DESCRIPTION
## Summary
- install torch==2.3.0 from CPU wheel in tests workflow
- drop torch from requirements-cpu

## Testing
- `pytest` *(fails: ImportError: cannot import name 'IndicatorsCache')*

------
https://chatgpt.com/codex/tasks/task_e_68b20dcc0138832db34ba060f78d4379