### PR TITLE
chore: update release drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,8 +16,8 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@v7
         with:
           config-name: release-drafter.yml
         env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- update release drafter workflow to v7
- use default GITHUB_TOKEN

## Testing
- `pre-commit run --files .github/workflows/release-drafter.yml` (fails: ImportError during pytest)
- `pytest` (fails: ImportError: cannot import name 'IndicatorsCache', ModuleNotFoundError: No module named 'hypothesis')


------
https://chatgpt.com/codex/tasks/task_e_68b20f98bc98832dab1ced1ab5eab9c3