### PR TITLE
ci: ожидание мок-сервера перед тестами

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -54,7 +54,7 @@ jobs:
           HTTPServer(('127.0.0.1', 8009), Handler).serve_forever()
           PY
           echo $! > server.pid
-          sleep 1
+          until curl -sf http://127.0.0.1:8009 >/dev/null; do sleep 0.5; done
       - name: Run flake8
         run: flake8 .
       - name: Run mypy


### PR DESCRIPTION
## Summary
- добавлен цикл ожидания запуска мок-сервера в CI перед выполнением flake8/mypy/pytest

## Testing
- `flake8 .`
- `mypy .` *(прервано: Interrupted)*
- `pytest` *(ошибки импорта)*

------
https://chatgpt.com/codex/tasks/task_e_68b20db712e8832d908a778c30c60e81