### PR TITLE
fix tests workflow configuration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,11 +16,15 @@ jobs:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
+          python-version: ${{ matrix.python-version }}
+      - name: Get pip cache dir
+        id: pip-cache
+        run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
       - name: Cache pip
         uses: actions/cache@v4
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements-ci.txt', 'requirements-cpu.txt') }}
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements-ci.txt', 'requirements-cpu.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
       - name: Upgrade pip


### PR DESCRIPTION
## Summary
- fix GitHub Actions tests workflow configuration

## Testing
- `pre-commit run --files .github/workflows/tests.yml` *(fails: ImportError: cannot import name 'IndicatorsCache' from 'bot.data_handler')*
- `pytest` *(fails: ImportError: cannot import name 'IndicatorsCache' from 'bot.data_handler')*

------
https://chatgpt.com/codex/tasks/task_e_68b210ec01a8832d9d42d6f6e355fd96