### PR TITLE
Fail on Trivy vulnerabilities

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -106,10 +106,10 @@ jobs:
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH
-          ignore-unfixed: true
           # ignore-unlikely-affected: true  # enable once Trivy >= v0.66 is available
           limit-severities-for-sarif: CRITICAL
           scanners: vuln
+          exit-code: 1
 
       - name: Show Trivy scan results
         run: cat trivy-results.sarif


### PR DESCRIPTION
## Summary
- make Trivy scan fail on any vulnerability

## Testing
- `pytest` *(fails: cannot import name 'IndicatorsCache' from 'bot.data_handler')*


------
https://chatgpt.com/codex/tasks/task_e_68b210f550e0832d8ec3be91b9848f9e