### PR TITLE
chore: pin pip-audit version in CI requirements

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -19,4 +19,4 @@ requests>=2.32.0
 types-requests
 mypy==1.17.1
 hypothesis>=6.0.0
-pip-audit
+pip-audit==2.9.0


### PR DESCRIPTION
## Summary
- pin pip-audit to the current stable version in CI requirements

## Testing
- `pytest -q` *(fails: cannot import IndicatorsCache; No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_68b210fa91bc832da98476a26461635b