### PR TITLE
Add permissions for dependency submission workflow

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: write
+  security-events: write
+
 jobs:
   dependency-submission:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add explicit write permissions to dependency submission workflow

## Testing
- `pytest -q` *(fails: cannot import IndicatorsCache; missing hypothesis)*

------
https://chatgpt.com/codex/tasks/task_e_68b215282a5c832d92094ba335df9986