### PR TITLE
chore(ci): pin python version for dependency submission

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.11'
       - name: Install build deps
         run: pip install --upgrade pip build
       - name: Validate project


### PR DESCRIPTION
## Summary
- use Python 3.11 for dependency submission workflow

## Testing
- `pre-commit run --files .github/workflows/dependency-submission.yml` *(fails: ImportError: cannot import name 'IndicatorsCache')*


------
https://chatgpt.com/codex/tasks/task_e_68b2152df268832d9441714eafbd4d98