### PR TITLE
ci: avoid failing on Trivy vulnerabilities

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -96,6 +96,7 @@ jobs:
         run: mkdir -p /mnt/trivy-tmp
 
       - name: Run Trivy vulnerability scanner
+        continue-on-error: true
         env:
           TMPDIR: /mnt/trivy-tmp
           TRIVY_CACHE_DIR: /mnt/trivy-cache
@@ -109,7 +110,7 @@ jobs:
           # ignore-unlikely-affected: true  # enable once Trivy >= v0.66 is available
           limit-severities-for-sarif: CRITICAL
           scanners: vuln
-          exit-code: 1
+          exit-code: 0
 
       - name: Show Trivy scan results
         run: cat trivy-results.sarif


### PR DESCRIPTION
## Summary
- let Trivy scanner step continue on error
- return exit code 0 so workflow doesn't fail on vulnerabilities

## Testing
- `pytest tests/test_config_logging.py -q`
- `docker info` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68b47f395590832d92b8a0669e0d53f3