### PR TITLE
ci: checkout repo in unit and integration jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       matrix:
         device: [cpu]
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-env
       - name: Audit dependencies
         working-directory: /mnt
@@ -58,6 +59,7 @@ jobs:
       matrix:
         device: [cpu]
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-env
       - name: Remove test caches
         run: |


### PR DESCRIPTION
## Summary
- checkout repository before using local actions in unit and integration CI jobs

## Testing
- `pytest` *(fails: ImportError cannot import IndicatorsCache)*

------
https://chatgpt.com/codex/tasks/task_e_68b47f54d838832d89c62b6ba3899957