### PR TITLE
chore: remove dependency snapshot step

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -21,5 +21,3 @@ jobs:
         run: pip install --upgrade pip build
       - name: Validate project
         run: python -m build
-      - name: Submit dependency snapshot
-        uses: advanced-security/python-dependency-submission@v1


### PR DESCRIPTION
## Summary
- remove advanced-security dependency submission step from workflow

## Testing
- `pre-commit run --files .github/workflows/dependency-submission.yml` *(fails: ImportError: cannot import name 'IndicatorsCache')*

------
https://chatgpt.com/codex/tasks/task_e_68b47f6a15f4832dbf3e002f4e709331