### PR TITLE
fix: use GITHUB_TOKEN in review workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.TOKEN }}
         run: |
-          base_sha=$(curl -s -H "Authorization: token $TOKEN" \
+          base_sha=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
             https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER | jq -r .base.sha)
           if [ -z "$base_sha" ] || [ "$base_sha" = "null" ]; then
             echo "Error: failed to retrieve base SHA" >&2


### PR DESCRIPTION
## Summary
- use GITHUB_TOKEN when fetching base SHA in review workflow

## Testing
- `pre-commit run --files .github/workflows/gptoss_review.yml` *(fails: ImportError: cannot import name 'IndicatorsCache')*

------
https://chatgpt.com/codex/tasks/task_e_68b47f70ac10832daab0dd774da47526