### PR TITLE
fix: use default GitHub token

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -20,4 +20,4 @@ jobs:
         with:
           config-name: release-drafter.yml
         env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- use the default GitHub token in release drafter workflow

## Testing
- `pre-commit run --files .github/workflows/release-drafter.yml` *(fails: ImportError: cannot import name 'ema_fast' from 'bot.data_handler'; ModuleNotFoundError: No module named 'hypothesis')*
- `pytest` *(fails: ImportError: cannot import name 'ema_fast' from 'bot.data_handler'; ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_68b47f98a278832dbb6cfee06be6f085