### PR TITLE
test: mock dockerhub push

### DIFF
--- a/tests/test_dockerhub_push.py
+++ b/tests/test_dockerhub_push.py
@@ -1,16 +1,24 @@
 import os
-import shutil
 import subprocess
+from unittest.mock import MagicMock, call
 
 import pytest
 
 
-@pytest.mark.skipif(shutil.which("docker") is None, reason="Docker is not installed")
-@pytest.mark.skipif(
-    not os.getenv("AVERINALEKS") or not os.getenv("BOT"),
-    reason="Environment variables AVERINALEKS and BOT must be set for Docker Hub",
-)
-def test_build_and_push(tmp_path):
+@pytest.fixture
+def docker_env(monkeypatch):
+    monkeypatch.setenv("AVERINALEKS", "fake_user")
+    monkeypatch.setenv("BOT", "fake_password")
+
+
+@pytest.fixture
+def run_mock(monkeypatch):
+    mock = MagicMock()
+    monkeypatch.setattr(subprocess, "run", mock)
+    return mock
+
+
+def test_build_and_push(tmp_path, docker_env, run_mock):
     dockerfile = tmp_path / "Dockerfile"
     dockerfile.write_text("FROM alpine:3.18\nRUN echo test > /test.txt\n")
     image = f"{os.environ['AVERINALEKS']}/bot-test-image:latest"
@@ -22,3 +30,13 @@ def test_build_and_push(tmp_path):
         check=True,
     )
     subprocess.run(["docker", "push", image], check=True)
+
+    assert run_mock.call_args_list == [
+        call(["docker", "build", "-t", image, str(tmp_path)], check=True),
+        call(
+            ["docker", "login", "-u", os.environ["AVERINALEKS"], "--password-stdin"],
+            input=os.environ["BOT"].encode(),
+            check=True,
+        ),
+        call(["docker", "push", image], check=True),
+    ]


### PR DESCRIPTION
## Summary
- replace subprocess.run with mocks in DockerHub push test
- add fixture providing fake AVERINALEKS and BOT env vars

## Testing
- `pytest tests/test_dockerhub_push.py::test_build_and_push -q`


------
https://chatgpt.com/codex/tasks/task_e_68b480d6f9e8832d92a0670c04ee2f49