### PR TITLE
Use monkeypatch for CSRF secret in server tests

### DIFF
--- a/tests/test_server_csrf_unexpected.py
+++ b/tests/test_server_csrf_unexpected.py
@@ -1,7 +1,4 @@
-import os
 import pytest
-
-os.environ["CSRF_SECRET"] = "testsecret"
 
 pytest.importorskip("transformers")
 
@@ -18,6 +15,7 @@ def make_client(monkeypatch):
 
     monkeypatch.setattr(server.model_manager, "load_model", dummy_load_model)
     monkeypatch.setenv("API_KEYS", "testkey")
+    monkeypatch.setenv("CSRF_SECRET", "testsecret")
     original_keys = server.API_KEYS.copy()
     server.API_KEYS.clear()
     try:

--- a/tests/test_server_request_validation.py
+++ b/tests/test_server_request_validation.py
@@ -1,8 +1,4 @@
-import os
 import pytest
-
-os.environ["CSRF_SECRET"] = "testsecret"
-
 pytest.importorskip("transformers")
 pytest.importorskip("fastapi_csrf_protect")
 
@@ -23,6 +19,7 @@ def make_client(monkeypatch):
 
     monkeypatch.setattr(server.model_manager, "load_model", dummy_load_model)
     monkeypatch.setenv("API_KEYS", "testkey")
+    monkeypatch.setenv("CSRF_SECRET", "testsecret")
     original_keys = server.API_KEYS.copy()
     server.API_KEYS.clear()
     try:


### PR DESCRIPTION
## Summary
- remove global CSRF_SECRET assignments in server tests
- use monkeypatch to set CSRF_SECRET per test

## Testing
- `pytest tests/test_server_csrf_unexpected.py tests/test_server_request_validation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b480d7c620832d8603a8ecd9d2309b