### PR TITLE
Add CSRF secret to CI and stabilize server tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ on:
 env:
   PYTHONPYCACHEPREFIX: /mnt/pycache
   TEST_MODE: "1"
+  CSRF_SECRET: testsecret
 
 jobs:
   unit:

--- a/tests/test_server_csrf_unexpected.py
+++ b/tests/test_server_csrf_unexpected.py
@@ -1,7 +1,9 @@
+import os
 import pytest
 
 pytest.importorskip("transformers")
 
+os.environ.setdefault("CSRF_SECRET", "testsecret")
 import server
 from contextlib import contextmanager
 from fastapi.testclient import TestClient
@@ -15,7 +17,6 @@ def make_client(monkeypatch):
 
     monkeypatch.setattr(server.model_manager, "load_model", dummy_load_model)
     monkeypatch.setenv("API_KEYS", "testkey")
-    monkeypatch.setenv("CSRF_SECRET", "testsecret")
     original_keys = server.API_KEYS.copy()
     server.API_KEYS.clear()
     try:

--- a/tests/test_server_request_validation.py
+++ b/tests/test_server_request_validation.py
@@ -1,7 +1,9 @@
+import os
 import pytest
 pytest.importorskip("transformers")
 pytest.importorskip("fastapi_csrf_protect")
 
+os.environ.setdefault("CSRF_SECRET", "testsecret")
 import server
 from contextlib import contextmanager
 from fastapi.testclient import TestClient
@@ -19,7 +21,6 @@ def make_client(monkeypatch):
 
     monkeypatch.setattr(server.model_manager, "load_model", dummy_load_model)
     monkeypatch.setenv("API_KEYS", "testkey")
-    monkeypatch.setenv("CSRF_SECRET", "testsecret")
     original_keys = server.API_KEYS.copy()
     server.API_KEYS.clear()
     try:


### PR DESCRIPTION
## Summary
- set CSRF_SECRET in CI workflow
- ensure server tests set CSRF_SECRET before importing server

## Testing
- `flake8 tests/test_server_request_validation.py tests/test_server_csrf_unexpected.py .github/workflows/ci.yml` *(command not found: flake8)*
- `pytest tests/test_server_request_validation.py tests/test_server_csrf_unexpected.py tests/test_server_missing_api_keys.py tests/test_server_model_loading.py -vv`
- `python - <<'PY'
import os
os.environ['CSRF_SECRET']='testsecret'
import server
print('import ok')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b48c8bfc8c832d9ed85125cecdf5d2