### PR TITLE
chore: checkout repo for release drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,8 +16,8 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: release-drafter/release-drafter@v7
         with:
           config-name: release-drafter.yml
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}


### PR DESCRIPTION
## Summary
- add actions/checkout before release drafter step
- provide token via `with` block

## Testing
- `pytest -q` *(fails: fixture 'csrf_secret' not found, module 'bot.data_handler' missing attributes)*
- `act -l` *(command not found: act)*
- `apt-get install -y act` *(E: Unable to locate package act)*

------
https://chatgpt.com/codex/tasks/task_e_68b48c53dcd8832db524e3aea925f7c8