### PR TITLE
fix: replace TOKEN with GITHUB_TOKEN in workflows

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -38,7 +38,7 @@ jobs:
           # exit with 0, even with results found
           exit_zero: false # fail when issues are found
           # Github token of the repository (automatically created by Github)
-          GITHUB_TOKEN: ${{ secrets.TOKEN }} # Needed to get PR information.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information.
           # File or directory to run bandit on
           # path: # optional, default is .
           # Report only issues of a given severity level or higher. Can be LOW, MEDIUM or HIGH. Default is UNDEFINED (everything)

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -20,4 +20,4 @@ jobs:
         run: bash scripts/run_dependabot.sh
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
-          TOKEN: ${{ secrets.TOKEN }}
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -36,7 +36,7 @@ jobs:
         id: generate-diff
         if: success()
         env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           base_sha=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
             https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER | jq -r .base.sha)

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           gitleaks_args: --no-git --redact --report-format=sarif --report-path=results.sarif
         env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF report
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -71,8 +71,8 @@ jobs:
 
       - name: Login to GHCR
         env:
-          CR_PAT: ${{ secrets.TOKEN }}
-        run: echo "$CR_PAT" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$GITHUB_TOKEN" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Cleanup before Trivy scan
         run: |


### PR DESCRIPTION
## Summary
- replace deprecated secrets.TOKEN usages with built-in secrets.GITHUB_TOKEN
- switch GHCR login in Trivy workflow to use GITHUB_TOKEN

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml .github/workflows/bandit.yml .github/workflows/secret-scan.yml .github/workflows/gptoss_review.yml .github/workflows/trivy.yml`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b48da610a8832d93fd37eb8efa7edf