### PR TITLE
fix: use checkout v4 in workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - uses: github/codeql-action/init@v3

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Run Dependabot
         run: bash scripts/run_dependabot.sh

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -21,7 +21,7 @@ jobs:
   gitleaks:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -27,7 +27,7 @@ jobs:
           else
             echo "ref=main" >> "$GITHUB_OUTPUT"
           fi
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           ref: ${{ steps.select-branch.outputs.ref }}
       - name: Free disk space


### PR DESCRIPTION
## Summary
- use actions/checkout v4 instead of v5

## Testing
- `pytest -q` *(fails: fixture 'csrf_secret' not found; AttributeError: module 'bot.data_handler' has no attribute 'atr_fast')*

------
https://chatgpt.com/codex/tasks/task_e_68b48d912d98832dbf93cb0b8368b80b