### PR TITLE
Remove upgrade flag for gnupg and dirmngr

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -2,7 +2,7 @@ FROM python:3.11-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libtbbmalloc2 libnuma1 curl git \
-    && apt-get install -y --no-install-recommends --only-upgrade gnupg dirmngr \
+    && apt-get install -y --no-install-recommends gnupg dirmngr \
     && rm -rf /var/lib/apt/lists/* \
     && gpg --version \
     && dirmngr --version


### PR DESCRIPTION
## Summary
- install gnupg and dirmngr without the `--only-upgrade` flag in `Dockerfile.gptoss`

## Testing
- `SKIP=pytest pre-commit run --files Dockerfile.gptoss`
- `pytest` *(fails: AttributeError: module 'bot.data_handler' has no attribute 'get_http_client', TypeError, AssertionError, etc.)*
- `docker build -f Dockerfile.gptoss -t test-gptoss .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*
- `gh workflow run "Build and Push Docker image"` *(fails: gh auth login needed)*

------
https://chatgpt.com/codex/tasks/task_e_68b48d5603c0832daafe6555cfd021e7