### PR TITLE
refactor: remove checkout from setup env action

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -6,10 +6,6 @@ runs:
     - name: Initial cleanup
       shell: bash
       run: docker system prune -af && sudo rm -rf /tmp/*
-    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
-      with:
-        persist-credentials: false
-        fetch-depth: 0
     - name: Cleanup git submodules
       shell: bash
       run: >-


### PR DESCRIPTION
## Summary
- remove checkout step from setup-env composite action
- keep jobs using actions/checkout@v4 before setup-env

## Testing
- `pre-commit run --hook-stage manual --files .github/actions/setup-env/action.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b491b9615c832dbab48acbb5f97e43