### PR TITLE
Разделена очистка в Trivy workflow на две команды

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -28,8 +28,11 @@ jobs:
     name: Build
     runs-on: ubuntu-24.04
     steps:
-      - name: Initial cleanup
-        run: docker system prune -af && sudo rm -rf /tmp/*
+      - name: Initial cleanup - Docker
+        continue-on-error: true
+        run: sudo docker system prune -af || true
+      - name: Initial cleanup - Temp
+        run: sudo rm -rf /tmp/*
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
@@ -133,7 +136,8 @@ jobs:
           path: /mnt/trivy-cache
           key: ${{ runner.os }}-trivy-cache-${{ github.sha }}
 
-      - name: Cleanup after Trivy scan
-        run: |
-          docker system prune -af || true
-          sudo rm -rf /tmp/* /mnt/trivy-tmp || true
+      - name: Cleanup after Trivy scan - Docker
+        continue-on-error: true
+        run: sudo docker system prune -af || true
+      - name: Cleanup after Trivy scan - Temp
+        run: sudo rm -rf /tmp/* /mnt/trivy-tmp


### PR DESCRIPTION
## Summary
- разделена ранняя и финальная очистка на отдельные команды
- добавлен `sudo` и `continue-on-error` для Docker-пруна

## Testing
- `SKIP=pytest pre-commit run --files .github/workflows/trivy.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b491bab690832d9bc4a0177c88b59f