### PR TITLE
fix release-drafter workflow trigger

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,7 +1,7 @@
 ---
 name: Release Drafter
 
-'on':
+on:
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary
- fix quoting of `on` key in release drafter workflow

## Testing
- `pre-commit run --files .github/workflows/release-drafter.yml` *(failed: no output, process hung)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b49698e22c832d81513416fc103da3