### PR TITLE
chore: run CI on ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   unit:
     name: Unit tests
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         device: [cpu]
@@ -52,7 +52,7 @@ jobs:
 
   integration:
     name: Integration tests
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: unit
     env:
       TEST_MODE: "1"


### PR DESCRIPTION
## Summary
- run unit and integration tests on `ubuntu-latest`

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(fails: KeyboardInterrupt)*
- `pytest -m "not integration" -q` *(fails: fixture 'csrf_secret' not found, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b495d851b8832dbe2c09fcbd3d1b0d