### PR TITLE
chore: pin GitHub Actions to specific SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         device: [cpu]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - uses: ./.github/actions/setup-env
       - name: Audit dependencies
         working-directory: /mnt
@@ -34,7 +34,7 @@ jobs:
           pip-audit -f json -o pip-audit.json
       - name: Upload pip-audit report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: pip-audit-report
           path: /mnt/pip-audit.json
@@ -60,7 +60,7 @@ jobs:
       matrix:
         device: [cpu]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - uses: ./.github/actions/setup-env
       - name: Remove test caches
         run: |


### PR DESCRIPTION
## Summary
- pin checkout and upload-artifact actions to exact commit SHAs in CI workflow

## Testing
- `pytest -q` *(fails: AttributeError, TypeError, AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_68b495dae88c832d8c77805bc4c05106