### PR TITLE
refactor: reuse test cache cleanup action

### DIFF
--- a/.github/actions/clear-test-caches/action.yml
+++ b/.github/actions/clear-test-caches/action.yml
@@ -1,0 +1,11 @@
+name: Clear test caches
+description: Remove pytest and Python caches
+runs:
+  using: composite
+  steps:
+    - name: Remove caches
+      shell: bash
+      run: |
+        rm -rf /mnt/pytest_cache .pytest_cache .cache
+        find . -type d -name '__pycache__' -exec rm -rf {} +
+        find . -name '*.pyc' -delete

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,7 @@ jobs:
       - name: Run flake8
         run: flake8 .
       - name: Remove test caches
-        run: |
-          rm -rf /mnt/pytest_cache .pytest_cache .cache
-          find . -type d -name '__pycache__' -exec rm -rf {} +
-          find . -name '*.pyc' -delete
+        uses: ./.github/actions/clear-test-caches
       - name: Run unit tests
         run: pytest -m "not integration" -o cache_dir=/mnt/pytest_cache
       - name: Cleanup buildx
@@ -63,10 +60,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-env
       - name: Remove test caches
-        run: |
-          rm -rf /mnt/pytest_cache .pytest_cache .cache
-          find . -type d -name '__pycache__' -exec rm -rf {} +
-          find . -name '*.pyc' -delete
+        uses: ./.github/actions/clear-test-caches
       - name: Run integration tests
         run: pytest -m integration -o cache_dir=/mnt/pytest_cache
       - name: Cleanup buildx


### PR DESCRIPTION
## Summary
- extract test cache cleanup into composite action
- reuse action in unit and integration jobs

## Testing
- `pre-commit run --hook-stage manual --files .github/actions/clear-test-caches/action.yml .github/workflows/ci.yml`
- `bash -c "rm -rf /mnt/pytest_cache .pytest_cache .cache; find . -type d -name '__pycache__' -exec rm -rf {} +; find . -name '*.pyc' -delete" && echo 'cache clean script executed'`


------
https://chatgpt.com/codex/tasks/task_e_68b495dd4b00832d9159b7a5447923da