### PR TITLE
chore: rely on global test mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,6 @@ jobs:
     name: Integration tests
     runs-on: ubuntu-24.04
     needs: unit
-    env:
-      TEST_MODE: "1"
     strategy:
       matrix:
         device: [cpu]


### PR DESCRIPTION
## Summary
- remove redundant TEST_MODE override from integration CI job

## Testing
- `SKIP=pytest pre-commit run --files .github/workflows/ci.yml`
- `TEST_MODE=1 pytest -m integration -o cache_dir=/tmp/pytest_cache` *(fails: AssertionError / TypeError)*
- `TEST_MODE=1 pytest tests/test_http_client_shared.py::test_shared_http_client_cleanup -o cache_dir=/tmp/pytest_cache` *(fails: AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_68b495dedbe4832da8ca539c83a00576