### PR TITLE
ci: use secrets token for release drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -20,4 +20,5 @@ jobs:
       - uses: release-drafter/release-drafter@v7
         with:
           config-name: release-drafter.yml
-          token: ${{ github.token }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- use GITHUB_TOKEN secret for Release Drafter workflow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4969a5b54832d955f6eafc5314062