### PR TITLE
chore: remove checkout from release drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,7 +16,6 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
       - uses: release-drafter/release-drafter@v7
         with:
           config-name: release-drafter.yml


### PR DESCRIPTION
## Summary
- remove redundant `actions/checkout` step from release drafter workflow

## Testing
- `pre-commit run --files .github/workflows/release-drafter.yml`
- `pytest -q` *(fails: KeyboardInterrupt, but 53 passed, 3 skipped, 17 deselected before interruption)*

------
https://chatgpt.com/codex/tasks/task_e_68b4969b8d2c832d854960665349c9d7