### PR TITLE
chore: use distinct tags for cpu and gptoss images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,13 +18,13 @@ jobs:
       matrix:
         include:
           - file: Dockerfile.cpu
-            image: myapp
+            image: myapp-cpu
             artifact: trivy-report-cpu
           - file: Dockerfile.ci
             image: myapp-ci
             artifact: trivy-report-ci
           - file: Dockerfile.gptoss
-            image: myapp
+            image: myapp-gptoss
             artifact: trivy-report-gptoss
     env:
       DOCKERHUB_USERNAME: ${{ secrets.AVERINALEKS }}


### PR DESCRIPTION
## Summary
- publish CPU and GPTOSS Docker images under unique repository names

## Testing
- `pre-commit run flake8 --files .github/workflows/docker-publish.yml`
- `pytest tests/test_dockerhub_push.py::test_build_and_push -q`
- `act -n -j build -P ubuntu-24.04=ghcr.io/catthehacker/ubuntu:full-24.04` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ab1d37f4832d8a68c83458891233