### PR TITLE
chore: use build-push action

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -103,25 +103,17 @@ jobs:
         working-directory: bot
 
       - name: Build and push Docker image
-        working-directory: bot
-        run: |
-          docker buildx build \
-            --progress=plain \
-            -f ${{ matrix.file }} \
-            -t docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ matrix.image }}:latest \
-            --push \
-            --cache-from type=local,src=/mnt/.buildx-cache \
-            --cache-to type=local,dest=/mnt/.buildx-cache-new,mode=max \
-            .
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: bot/${{ matrix.file }}
+          push: true
+          tags: docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ matrix.image }}:latest
+          cache-from: type=local,src=/mnt/.buildx-cache
+          cache-to: type=local,dest=/mnt/.buildx-cache-new,mode=max
 
       - name: Apply security upgrades in built image
         run: docker run --rm docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ matrix.image }}:latest bash -lc "apt-get update && apt-get upgrade -y && apt-get clean && rm -rf /var/lib/apt/lists/*"
-        working-directory: bot
-
-      - name: Move Docker layer cache
-        run: |
-          rm -rf /mnt/.buildx-cache
-          mv /mnt/.buildx-cache-new /mnt/.buildx-cache
         working-directory: bot
 
       - name: Set up Trivy


### PR DESCRIPTION
## Summary
- use docker/build-push-action to build and push images
- drop manual docker cache move step

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ab18a738832d80c0e1c85dac79a2