### PR TITLE
ci: fix release drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,17 +5,17 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize, edited]
-
-permissions:
-  contents: write
-  pull-requests: read
 
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
     steps:
+      - uses: actions/checkout@v4
       - uses: release-drafter/release-drafter@v7
         with:
           config-name: release-drafter.yml


### PR DESCRIPTION
## Summary
- run release-drafter on pull_request events
- check out repository before drafting release
- set permissions within update_release_draft job

## Testing
- `pre-commit run --files .github/workflows/release-drafter.yml` *(fails: Interrupted)*
- `act -j update_release_draft -W .github/workflows/release-drafter.yml` *(fails: no Docker connection)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ab4edfe4832d8f625114bf07aff0