### PR TITLE
fix: create ray jars directory before commons-lang3 download

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -25,6 +25,7 @@ RUN python3 -m venv $VIRTUAL_ENV && \
     $VIRTUAL_ENV/bin/pip install --no-cache-dir 'pip>=24.0' 'setuptools<81' wheel && \
     $VIRTUAL_ENV/bin/pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -r requirements-core.txt && \
     RAY_JARS_DIR=$($VIRTUAL_ENV/bin/python -c "import os, ray; print(os.path.join(os.path.dirname(ray.__file__), 'jars'))") && \
+    mkdir -p "$RAY_JARS_DIR" && \
     rm -f "$RAY_JARS_DIR"/commons-lang3-*.jar && \
     curl -fsSL https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar -o "$RAY_JARS_DIR"/commons-lang3-3.18.0.jar && \
     $VIRTUAL_ENV/bin/pip freeze | grep -i '^nvidia-' | cut -d= -f1 | xargs -r $VIRTUAL_ENV/bin/pip uninstall -y && \


### PR DESCRIPTION
## Summary
- ensure Ray's `jars` folder exists before replacing commons-lang3

## Testing
- `pytest` *(fails: tests/test_http_client_shared.py::test_shared_http_client_cleanup, tests/test_server_csrf_unexpected.py::test_unexpected_csrf_error_returns_500, tests/test_server_missing_api_keys.py::test_missing_api_keys_causes_startup_failure, tests/test_server_request_validation.py::test_chat_completions_validation, tests/test_server_request_validation.py::test_completions_validation, tests/test_simulation.py::test_simulator_trailing_stop, tests/test_trade_features.py::test_stop_loss_closes_position, tests/test_server_auth.py::test_completions_requires_key, tests/test_server_auth.py::test_chat_completions_requires_key, tests/test_server_auth.py::test_check_api_key_masks_sensitive_headers, tests/test_trade_features.py::test_atr_calculation)*
- `docker build -f Dockerfile.cpu .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ab17617c832d8f52360a1dcacc17