### PR TITLE
ci: remove Python 3.12 from workflows

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -49,7 +49,7 @@ runs:
         echo "PIP_CACHE_DIR=/mnt/pip-cache" >> $GITHUB_ENV
     - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
-        python-version: '3.12'
+        python-version: '3.11'
     - name: Get pip cache dir
       id: pip-cache
       shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11']
     env:
       TEST_MODE: "1"
     steps:


### PR DESCRIPTION
## Summary
- limit test workflow to Python 3.10 and 3.11
- switch setup-env action to Python 3.11

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4abe296cc832dbcb7d4f3842e9455