### PR TITLE
Add default commands to Docker images

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -48,3 +48,5 @@ COPY --from=builder /app /app
 
 ENV PATH="/venv/bin:$PATH"
 
+CMD ["bash"]
+

--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -23,4 +23,6 @@ RUN pip install --no-cache-dir --upgrade pip \
 
 EXPOSE 8000
 
+CMD ["python", "-m", "http.server", "8000"]
+
 


### PR DESCRIPTION
## Summary
- ensure CI image launches into bash by default
- run HTTP server by default in gptoss image

## Testing
- `pre-commit run --files Dockerfile.ci Dockerfile.gptoss` *(interrupted: KeyboardInterrupt)*
- `docker build -f Dockerfile.ci -t bot-ci .` *(failed: Cannot connect to the Docker daemon)*
- `dockerd` *(failed: failed to mount overlay: operation not permitted)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ab1e77f4832d9d33d1f7384fa1f5