### PR TITLE
ci: upload pip-audit artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
           pip-audit -f json -o pip-audit.json
       - name: Upload pip-audit report
         if: always()
+        uses: actions/upload-artifact@v4
         with:
           name: pip-audit-report
           path: /mnt/pip-audit.json


### PR DESCRIPTION
## Summary
- ensure pip-audit report is uploaded in CI

## Testing
- `pytest` (segmentation fault: mlflow urllib3 request)

------
https://chatgpt.com/codex/tasks/task_e_68b4abe14d2c832db11e949c28b375e0