### PR TITLE
Pin upload-artifact action for pip-audit report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           pip-audit -f json -o pip-audit.json
       - name: Upload pip-audit report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pip-audit-report
           path: /mnt/pip-audit.json


### PR DESCRIPTION
## Summary
- pin `actions/upload-artifact` to a specific commit for the pip-audit report upload step

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(interrupted: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b54b3a094c832d99fca8a6843e02ae