### PR TITLE
ci: allow audit to fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - uses: ./.github/actions/setup-env
       - name: Audit dependencies
+        continue-on-error: true
         working-directory: /mnt
         run: |
           pip-audit -f json -o pip-audit.json


### PR DESCRIPTION
## Summary
- allow dependency audit step to continue on failure

## Testing
- `pre-commit run flake8 --files .github/workflows/ci.yml`
- `pre-commit run --files .github/workflows/ci.yml` *(fails: Interrupted (KeyboardInterrupt))*

------
https://chatgpt.com/codex/tasks/task_e_68b54b3f7d88832d98f96c94fc279c31