### PR TITLE
chore: downgrade release drafter action

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: read
     steps:
       - uses: actions/checkout@v4
-      - uses: release-drafter/release-drafter@v7
+      - uses: release-drafter/release-drafter@v6
         with:
           config-name: release-drafter.yml
         env:


### PR DESCRIPTION
## Summary
- use release-drafter action v6 instead of v7

## Testing
- `pre-commit run flake8 --files .github/workflows/release-drafter.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b54b49a510832da8aacdb9a8b3c65d