### PR TITLE
chore(ci): pin cache action to commit SHA

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -56,13 +56,13 @@ runs:
       shell: bash
       run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
     - name: Cache pip wheels
-      uses: actions/cache@v4
+      uses: actions/cache@638ed79f9dc94c1de1baef91bcab5edaa19451f4
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key: ${{ runner.os }}-pip-${{ matrix.device }}-${{ hashFiles('requirements-ci.txt', 'requirements-cpu.txt') }}
     - name: Cache virtualenv
       id: cache-venv
-      uses: actions/cache@v4
+      uses: actions/cache@638ed79f9dc94c1de1baef91bcab5edaa19451f4
       with:
         path: /mnt/venv
         key: ${{ runner.os }}-venv-${{ matrix.device }}-${{ hashFiles('requirements-ci.txt', 'requirements-cpu.txt') }}


### PR DESCRIPTION
## Summary
- pin actions/cache to a specific commit in setup-env composite action

## Testing
- `pytest -q` *(fails: fixture 'csrf_secret' not found and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b54b3cc84c832db7fc4a1777b6005b