### PR TITLE
chore: limit release drafter triggers

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, reopened, synchronize, edited]
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
## Summary
- limit Release Drafter workflow to push events on main

## Testing
- `pip install -r requirements-ci.txt`
- `pytest` *(fails: AttributeError: module 'bot.data_handler' has no attribute 'atr_fast', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b54b4c4e9c832dae5d747b4d28abec