### PR TITLE
ci: pin cache action to commit

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
         id: pip-cache
         run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
       - name: Cache pip
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements-ci.txt', 'requirements-cpu.txt') }}


### PR DESCRIPTION
## Summary
- pin actions/cache to a specific commit for the tests workflow

## Testing
- `pre-commit run --files .github/workflows/tests.yml`
- `pytest` *(fails: module attribute errors, assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b54b582874832da3b66c32a430cf65