### PR TITLE
Add pandas dependency for CI

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -9,6 +9,7 @@ fastapi==0.116.1
 fastapi-csrf-protect==1.0.6
 flask>=3.1.2,<4
 gymnasium==1.2.0
+pandas>=2.3.2
 pyarrow>=21.0.0
 python-dotenv>=1.1.1
 werkzeug>=3.1.3,<4


### PR DESCRIPTION
## Summary
- include pandas>=2.3.2 in CI requirements

## Testing
- `pip install -r requirements-ci.txt`


------
https://chatgpt.com/codex/tasks/task_e_68b54e1a9790832d83e8bf9e7590e182