### PR TITLE
Refactor long f-strings in trade_manager

### DIFF
--- a/trade_manager.py
+++ b/trade_manager.py
@@ -727,7 +727,10 @@ class TradeManager:
                 price,
             )
             await self.telegram_logger.send_telegram_message(
-                f"📈 {symbol} {side.upper()} size={size:.4f} @ {price:.2f} SL={stop_loss_price:.2f} TP={take_profit_price:.2f}",
+                (
+                    f"📈 {symbol} {side.upper()} size={size:.4f} @ {price:.2f} "
+                    f"SL={stop_loss_price:.2f} TP={take_profit_price:.2f}"
+                ),
                 urgent=True,
             )
         except (httpx.HTTPError, RuntimeError, ValueError, OSError) as e:
@@ -1190,7 +1193,10 @@ class TradeManager:
                                     retrained = await self._maybe_retrain_symbol(symbol)
                                     if retrained:
                                         await self.telegram_logger.send_telegram_message(
-                                            f"🔄 Retraining {symbol}: Sharpe={sharpe_ratio:.2f}, Volatility={volatility_change:.2f}"
+                                            (
+                                                f"🔄 Retraining {symbol}: Sharpe={sharpe_ratio:.2f}, "
+                                                f"Volatility={volatility_change:.2f}"
+                                            )
                                         )
                             if sharpe_ratio < self.config.get("min_sharpe_ratio", 0.5):
                                 logger.warning(


### PR DESCRIPTION
## Summary
- split long f-strings in `trade_manager.py` to respect line length limits

## Testing
- `flake8 trade_manager.py`
- `pytest -q` *(fails: fixture 'csrf_secret' not found, AttributeError: module 'bot.data_handler' has no attribute 'get_http_client')*

------
https://chatgpt.com/codex/tasks/task_e_68b54e1cfe2c832d81559a58026d12a9