### PR TITLE
chore(ci): use ubuntu-latest for docker workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -166,7 +166,7 @@ jobs:
 
   healthcheck:
     if: always()
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5


### PR DESCRIPTION
## Summary
- use ubuntu-latest in docker-publish build and healthcheck jobs

## Testing
- `pre-commit run flake8 --files .github/workflows/docker-publish.yml`
- `pytest tests/test_import_order.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b55103d280832da35ad779a6ee0be3