### PR TITLE
Remove redundant TEST_MODE cleanup

### DIFF
--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -1497,5 +1497,4 @@ def test_shutdown_handles_missing_is_initialized(monkeypatch):
 
 sys.modules.pop('utils', None)
 sys.modules.pop('bot.utils', None)
-os.environ.pop("TEST_MODE", None)
 

--- a/tests/test_trade_manager_loops.py
+++ b/tests/test_trade_manager_loops.py
@@ -246,4 +246,3 @@ async def test_process_symbol_data_fresh_error(monkeypatch):
     assert dh.exchange.orders == []
 
 sys.modules.pop('utils', None)
-os.environ.pop("TEST_MODE", None)


### PR DESCRIPTION
## Summary
- Drop manual TEST_MODE environment cleanup from trade manager tests
- Rely on existing fixtures for environment reset

## Testing
- `pytest tests/test_trade_manager.py -q`
- `pytest tests/test_trade_manager_loops.py -q`
- `pytest tests/test_cache.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b54e1bc158832d8d66d9a0be1a6335