### PR TITLE
chore: pin docker build-push action

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -103,7 +103,7 @@ jobs:
         working-directory: bot
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25
         with:
           context: .
           file: bot/${{ matrix.file }}


### PR DESCRIPTION
## Summary
- pin docker/build-push-action v5 to commit ca052bb54ab0790a636c9b5f226502c73d547a25

## Testing
- `SKIP=pytest pre-commit run --files .github/workflows/docker-publish.yml`
- `pytest test_stubs.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b55107fd58832d945a397a9e212d29