### PR TITLE
fix: correct docker build context

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -105,8 +105,8 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          context: .
-          file: bot/${{ matrix.file }}
+          context: bot
+          file: ${{ matrix.file }}
           push: true
           tags: docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ matrix.image }}:latest
           cache-from: type=local,src=/mnt/.buildx-cache


### PR DESCRIPTION
## Summary
- ensure docker build uses repository path

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b551047dc4832db33ce68b031f3e5d