### PR TITLE
fix: remove duplicate GITLEAKS_ARGS

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -30,7 +30,6 @@ jobs:
         env:
           GITLEAKS_ARGS: --no-git --redact --report-format=sarif --report-path=results.sarif
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_ARGS: --no-git --redact --report-format=sarif --report-path=results.sarif
       - name: Upload SARIF report
         if: always()
         uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
## Summary
- remove duplicated `GITLEAKS_ARGS` env definition from secret scan workflow

## Testing
- `gitleaks detect --no-git --redact --report-format=sarif --report-path=results.sarif`
- `act -n -j gitleaks` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68b551c4c6a0832db9d61d50b6e96aca