### PR TITLE
chore(ci): run pytest with stricter flags

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,4 +30,4 @@ jobs:
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
       - name: Run tests
-        run: pytest
+        run: pytest --maxfail=1 --disable-warnings -q


### PR DESCRIPTION
## Summary
- run pytest in workflow with maxfail and disable warnings

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(fails: module 'bot.data_handler' has no attribute 'get_http_client')*

------
https://chatgpt.com/codex/tasks/task_e_68b55ea3ae64832db94ac626fcf394eb