### PR TITLE
Run tests even if flake8 fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,11 @@ jobs:
           name: pip-audit-report
           path: /mnt/pip-audit.json
       - name: Run flake8
+        continue-on-error: true
         run: |
           set -o pipefail
           flake8 . | tee flake8.log
+          echo $? > flake8.exitcode
       - name: Upload flake8 log
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -50,8 +52,10 @@ jobs:
           name: flake8-log
           path: flake8.log
       - name: Remove test caches
+        if: always()
         uses: ./.github/actions/clear-test-caches
       - name: Run unit tests
+        if: always()
         run: |
           set -o pipefail
           pytest -m "not integration" -o cache_dir=/mnt/pytest_cache | tee pytest.log
@@ -62,12 +66,22 @@ jobs:
           name: unit-test-log
           path: pytest.log
       - name: Cleanup buildx
+        if: always()
         run: docker buildx prune -af || true
+      - name: Fail if flake8 failed
+        if: always()
+        run: |
+          code=$(cat flake8.exitcode)
+          if [ "$code" -ne 0 ]; then
+            echo "flake8 failed with exit code $code"
+            exit $code
+          fi
 
   integration:
     name: Integration tests
     runs-on: ubuntu-latest
     needs: unit
+    if: ${{ always() }}
     strategy:
       matrix:
         device: [cpu]
@@ -75,8 +89,10 @@ jobs:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - uses: ./.github/actions/setup-env
       - name: Remove test caches
+        if: always()
         uses: ./.github/actions/clear-test-caches
       - name: Run integration tests
+        if: always()
         run: |
           set -o pipefail
           pytest -m integration -o cache_dir=/mnt/pytest_cache | tee pytest.log
@@ -87,4 +103,5 @@ jobs:
           name: integration-test-log
           path: pytest.log
       - name: Cleanup buildx
+        if: always()
         run: docker buildx prune -af || true


### PR DESCRIPTION
## Summary
- allow flake8 to continue while capturing its exit code
- run unit and integration tests regardless of lint status
- fail workflow after tests if flake8 reported issues

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(failed: Interrupted (KeyboardInterrupt))*

------
https://chatgpt.com/codex/tasks/task_e_68b55e8bada0832d9015e10040063167