### PR TITLE
feat: ensure healthcheck depends on build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -169,6 +169,7 @@ jobs:
           docker system prune -af || true
 
   healthcheck:
+    needs: build
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- run healthcheck job after build even if build fails

## Testing
- `pytest` *(fails: AttributeError: module 'bot.data_handler' has no attribute 'get_http_client', TypeError: object.__init__() takes exactly one argument, TimeoutError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b55f83ef3c832d95915ccb60165250