### PR TITLE
Use env vars for Docker Hub login

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -78,7 +78,7 @@ jobs:
           sudo systemctl start docker
 
       - name: Login to Docker Hub
-        run: echo "${{ secrets.BOT }}" | docker login --username "${{ secrets.AVERINALEKS }}" --password-stdin
+        run: echo "$DOCKERHUB_TOKEN" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
 
       - name: Prepare buildx cache directory
         run: mkdir -p /mnt/.buildx-cache


### PR DESCRIPTION
## Summary
- reference DOCKERHUB_TOKEN and DOCKERHUB_USERNAME env vars in Docker Hub login step

## Testing
- `pre-commit run --hook-stage manual --files .github/workflows/docker-publish.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b55f929bd4832d9ab3ff54453e50b7