### PR TITLE
Install CI requirements in test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,9 @@ jobs:
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements-ci.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
-      - name: Upgrade pip
-        run: python -m pip install --upgrade pip
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-ci.txt
       - name: Run tests
         run: pytest --maxfail=1 --disable-warnings -q


### PR DESCRIPTION
## Summary
- Install requirements-ci.txt in tests workflow

## Testing
- `pip install -r requirements-ci.txt`
- `flake8 .`
- `mypy .` *(fails: Item "None" of "Any | None" has no attribute "send_message" in telegram_logger.py, etc.)*
- `pytest -q` *(fails: AttributeError: <class 'object'> has no attribute 'stream', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b5602b71ec832da57417750d83d3a3