### PR TITLE
chore(ci): test multiple python versions

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -1,5 +1,9 @@
 name: Setup environment
 description: Prepare Python environment with cached dependencies
+inputs:
+  python-version:
+    description: Python version to use
+    required: true
 runs:
   using: composite
   steps:
@@ -50,7 +54,7 @@ runs:
         echo "PIP_CACHE_DIR=/mnt/pip-cache" >> $GITHUB_ENV
     - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
-        python-version: '3.11'
+        python-version: ${{ inputs.python-version }}
     - name: Get pip cache dir
       id: pip-cache
       shell: bash
@@ -59,13 +63,13 @@ runs:
       uses: actions/cache@638ed79f9dc94c1de1baef91bcab5edaa19451f4
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-pip-${{ matrix.device }}-${{ hashFiles('requirements-ci.txt', 'requirements-cpu.txt') }}
+        key: ${{ runner.os }}-pip-${{ matrix.device }}-py${{ inputs.python-version }}-${{ hashFiles('requirements-ci.txt', 'requirements-cpu.txt') }}
     - name: Cache virtualenv
       id: cache-venv
       uses: actions/cache@638ed79f9dc94c1de1baef91bcab5edaa19451f4
       with:
         path: /mnt/venv
-        key: ${{ runner.os }}-venv-${{ matrix.device }}-${{ hashFiles('requirements-ci.txt', 'requirements-cpu.txt') }}
+        key: ${{ runner.os }}-venv-${{ matrix.device }}-py${{ inputs.python-version }}-${{ hashFiles('requirements-ci.txt', 'requirements-cpu.txt') }}
     - name: Set up virtual environment
       shell: bash
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        python-version: ['3.10', '3.11', '3.12']
         device: [cpu]
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - uses: ./.github/actions/setup-env
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Audit dependencies
         continue-on-error: true
         working-directory: /mnt
@@ -70,10 +73,13 @@ jobs:
     needs: unit
     strategy:
       matrix:
+        python-version: ['3.10', '3.11', '3.12']
         device: [cpu]
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - uses: ./.github/actions/setup-env
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Remove test caches
         uses: ./.github/actions/clear-test-caches
       - name: Run integration tests


### PR DESCRIPTION
## Summary
- test against Python 3.10–3.12 in CI
- allow choosing Python version in setup-env action

## Testing
- `python -m pytest -q` *(fails: fixture 'csrf_secret' not found and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b55e900518832d8a515e25d239bd46