### PR TITLE
Удалить скачивание артефакта в docker-publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -157,12 +157,6 @@ jobs:
         with:
           name: ${{ matrix.artifact }}
           path: bot/${{ matrix.artifact }}.txt
-
-      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
-        if: matrix.artifact == 'trivy-report-ci'
-        with:
-          name: trivy-report-ci
-          path: bot
       - name: Cleanup Docker
         run: |
           docker buildx prune -af || true


### PR DESCRIPTION
## Summary
- убрать ненужный шаг download-artifact из .github/workflows/docker-publish.yml

## Testing
- `pytest -q` *(падает: 9 failed, 226 passed, 4 skipped, 17 deselected, 4 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b55f99420c832daeb0d3115e3e0f15