### PR TITLE
ci: submit dependencies to GitHub

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -21,3 +21,7 @@ jobs:
         run: pip install --upgrade pip build
       - name: Validate project
         run: python -m build
+      - uses: advanced-security/dependency-submission-action@5530bab9ee4bbe66420ce8280624036c77f89746
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: ./


### PR DESCRIPTION
## Summary
- submit dependencies to GitHub after build validation

## Testing
- `pre-commit run --files .github/workflows/dependency-submission.yml` *(failed: Interrupted (KeyboardInterrupt))*

------
https://chatgpt.com/codex/tasks/task_e_68b5602b95ec832d8b125eb812a6f284