### PR TITLE
chore: pin workflow actions to commits

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -21,18 +21,18 @@ jobs:
   gitleaks:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4 08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@dcedce43c6f43de0b836d1fe38946645c9c638dc # v2 dcedce43c6f43de0b836d1fe38946645c9c638dc
         env:
           GITLEAKS_ARGS: --no-git --redact --report-format=sarif --report-path=results.sarif
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF report
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ad2a4837011b42f6947b78d6417e7c253b1c504b # v3 ad2a4837011b42f6947b78d6417e7c253b1c504b
         with:
           sarif_file: results.sarif
       - name: Cleanup buildx

--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -27,11 +27,11 @@ jobs:
           else
             echo "ref=main" >> "$GITHUB_OUTPUT"
           fi
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4 08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           ref: ${{ steps.select-branch.outputs.ref }}
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main 54081f138730dfa15788a46383842cd2f914a1be
         with:
           tool-cache: true
           android: true
@@ -52,7 +52,7 @@ jobs:
           sudo rm -f /mnt/swapfile || true
           sudo rm -rf /mnt/* || true
       - name: Maximize build space
-        uses: easimon/maximize-build-space@v10
+        uses: easimon/maximize-build-space@fc881a613ad2a34aca9c9624518214ebc21dfc0c # v10 fc881a613ad2a34aca9c9624518214ebc21dfc0c
         with:
           root-reserve-mb: 1024
           temp-reserve-mb: 100
@@ -61,7 +61,7 @@ jobs:
           pv-loop-path: /root-pv.img
           tmp-pv-loop-path: /mnt/tmp-pv.img
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5 a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version-file: .python-version
       - name: Create virtual environment
@@ -94,7 +94,7 @@ jobs:
           python -m build
       - name: Publish to PyPI
         if: env.TOKENPYPI != ''
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # release/v1 76f52bc884231f62b9a034ebfe128415bbaabdfc
         with:
           user: __token__
           password: ${{ env.TOKENPYPI }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -34,11 +34,11 @@ jobs:
       - name: Initial cleanup - Temp
         run: sudo rm -rf /tmp/*
       - name: Checkout code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4 08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           persist-credentials: false
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main 54081f138730dfa15788a46383842cd2f914a1be
         continue-on-error: true
         with:
           docker-images: true
@@ -56,7 +56,7 @@ jobs:
             sudo rm -f /mnt/swapfile || true
             sudo rm -rf /mnt/* || true
       - name: Maximize build space
-        uses: easimon/maximize-build-space@v10
+        uses: easimon/maximize-build-space@fc881a613ad2a34aca9c9624518214ebc21dfc0c # v10 fc881a613ad2a34aca9c9624518214ebc21dfc0c
         with:
           root-reserve-mb: 1024
           temp-reserve-mb: 100
@@ -88,7 +88,7 @@ jobs:
 
       - name: Cache Trivy vulnerability database
         id: trivy-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4 0400d5f644dc74513175e3cd8d07132dd4860809
         with:
           path: /mnt/trivy-cache
           key: ${{ runner.os }}-trivy-cache-${{ github.sha }}
@@ -103,7 +103,7 @@ jobs:
         env:
           TMPDIR: /mnt/trivy-tmp
           TRIVY_CACHE_DIR: /mnt/trivy-cache
-        uses: aquasecurity/trivy-action@0.32.0
+        uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4 # 0.32.0 dc5a429b52fcf669ce959baa2c2dd26090d2a6c4
         with:
           cache-dir: /mnt/trivy-cache
           image-ref: ghcr.io/${{ github.repository }}:${{ github.sha }}
@@ -119,19 +119,19 @@ jobs:
         run: cat trivy-results.sarif
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@d6c5e1b140009be28958d3837ed3be3fb637d8c0 # v3
+        uses: github/codeql-action/upload-sarif@d6c5e1b140009be28958d3837ed3be3fb637d8c0 # v3 d6c5e1b140009be28958d3837ed3be3fb637d8c0
         with:
           sarif_file: 'trivy-results.sarif'
 
       - name: Upload Trivy report artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4 ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: trivy-results
           path: trivy-results.sarif
 
       - name: Save Trivy cache
         if: steps.trivy-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4 0400d5f644dc74513175e3cd8d07132dd4860809
         with:
           path: /mnt/trivy-cache
           key: ${{ runner.os }}-trivy-cache-${{ github.sha }}


### PR DESCRIPTION
## Summary
- pin GitHub Actions in trivy.yml to specific commits
- pin GitHub Actions in secret-scan.yml and submit-pypi.yml to specific commits

## Testing
- `pre-commit run --files .github/workflows/trivy.yml .github/workflows/secret-scan.yml .github/workflows/submit-pypi.yml` *(fails: pytest KeyboardInterrupt)*
- `pytest -q` *(fail: 9 failed, 4 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b5602c4460832db7f36cfbf197708b