### PR TITLE
ci: capture flake8 exit code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,10 @@ jobs:
           name: pip-audit-report
           path: /mnt/pip-audit.json
       - name: Run flake8
-        continue-on-error: true
         run: |
           set -o pipefail
-          flake8 . | tee flake8.log
-          echo $? > flake8.exitcode
+          flake8 . | tee flake8.log || code=$?
+          exit $code
       - name: Upload flake8 log
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -75,14 +74,6 @@ jobs:
       - name: Cleanup buildx
         if: always()
         run: docker buildx prune -af || true
-      - name: Fail if flake8 failed
-        if: always()
-        run: |
-          code=$(cat flake8.exitcode)
-          if [ "$code" -ne 0 ]; then
-            echo "flake8 failed with exit code $code"
-            exit $code
-          fi
 
   integration:
     name: Integration tests


### PR DESCRIPTION
## Summary
- capture `flake8` exit code without `continue-on-error`
- drop redundant failure step for `flake8`

## Testing
- `pytest tests/test_env_parsing.py -q`
- `pytest -q` *(fails: 9 failed, 4 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b5728523d0832da8d6c620ce046bb1