### PR TITLE
feat(ci): parameterize device in setup-env

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -4,6 +4,9 @@ inputs:
   python-version:
     description: Python version to use
     required: true
+  device:
+    description: Target device
+    default: cpu
 runs:
   using: composite
   steps:
@@ -63,13 +66,13 @@ runs:
       uses: actions/cache@638ed79f9dc94c1de1baef91bcab5edaa19451f4
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-pip-${{ matrix.device }}-py${{ inputs.python-version }}-${{ hashFiles('requirements-ci.txt', 'requirements-cpu.txt') }}
+        key: ${{ runner.os }}-pip-${{ inputs.device }}-py${{ inputs.python-version }}-${{ hashFiles('requirements-ci.txt', 'requirements-cpu.txt') }}
     - name: Cache virtualenv
       id: cache-venv
       uses: actions/cache@638ed79f9dc94c1de1baef91bcab5edaa19451f4
       with:
         path: /mnt/venv
-        key: ${{ runner.os }}-venv-${{ matrix.device }}-py${{ inputs.python-version }}-${{ hashFiles('requirements-ci.txt', 'requirements-cpu.txt') }}
+        key: ${{ runner.os }}-venv-${{ inputs.device }}-py${{ inputs.python-version }}-${{ hashFiles('requirements-ci.txt', 'requirements-cpu.txt') }}
     - name: Set up virtual environment
       shell: bash
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: ./.github/actions/setup-env
         with:
           python-version: ${{ matrix.python-version }}
+          device: ${{ matrix.device }}
       - name: Audit dependencies
         id: audit
         continue-on-error: true
@@ -98,6 +99,7 @@ jobs:
       - uses: ./.github/actions/setup-env
         with:
           python-version: ${{ matrix.python-version }}
+          device: ${{ matrix.device }}
       - name: Remove test caches
         if: always()
         uses: ./.github/actions/clear-test-caches


### PR DESCRIPTION
## Summary
- allow setup-env action to accept device input and use it in cache keys
- pass device from CI workflow matrix when invoking setup-env

## Testing
- `yamllint .github/actions/setup-env/action.yml .github/workflows/ci.yml` *(fails: line length)*
- `pytest -q` *(fails: various import/fixture errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b5727a6230832d97cbd0c2d2a3e425