### PR TITLE
Handle async HTTP client close errors and cleanup tests

### DIFF
--- a/http_client.py
+++ b/http_client.py
@@ -86,7 +86,10 @@ async def close_async_http_client() -> None:
     if _ASYNC_CLIENT is not None:
         close = getattr(_ASYNC_CLIENT, "aclose", None)
         if callable(close):
-            await close()
+            try:
+                await close()
+            except Exception:
+                logging.exception("Failed to close async HTTP client")
         _ASYNC_CLIENT = None
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -522,3 +522,12 @@ def fast_sleep(monkeypatch):
 
     monkeypatch.setattr(time, "sleep", _sleep)
     return calls
+
+
+@pytest.fixture(autouse=True)
+async def _cleanup_async_http_client():
+    try:
+        yield
+    finally:
+        from bot.http_client import close_async_http_client
+        await close_async_http_client()


### PR DESCRIPTION
## Summary
- Обернуть закрытие асинхронного HTTP-клиента в try/except
- Очищать глобальный HTTP-клиент после каждого теста

## Testing
- `pytest tests/test_http_client_cleanup.py tests/test_trading_bot.py::test_close_http_client_resets_global -q`


------
https://chatgpt.com/codex/tasks/task_e_68b573118720832dba2ce7f8d5c013a4