### PR TITLE
chore: update dependency submission action to v1

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -21,7 +21,7 @@ jobs:
         run: pip install --upgrade pip build
       - name: Validate project
         run: python -m build
-      - uses: advanced-security/dependency-submission-action@5530bab9ee4bbe66420ce8280624036c77f89746
+      - uses: advanced-security/dependency-submission-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           path: ./


### PR DESCRIPTION
## Summary
- use v1 tag for dependency submission action

## Testing
- `pre-commit run flake8 --files .github/workflows/dependency-submission.yml`
- `pre-commit run --files .github/workflows/dependency-submission.yml` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b5729b6378832d8610d4d83b2260c4