### PR TITLE
chore: use github.token in dependency submission workflow

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -23,5 +23,5 @@ jobs:
         run: python -m build
       - uses: advanced-security/dependency-submission-action@5530bab9ee4bbe66420ce8280624036c77f89746
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           path: ./


### PR DESCRIPTION
## Summary
- use `github.token` for dependency submission action

## Testing
- `python -m pre_commit run --files .github/workflows/dependency-submission.yml` *(fails: KeyboardInterrupt)*
- `pytest -q` *(fails: 9 failed, 4 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b572951720832d98fa19a0de1ac177