### PR TITLE
Add strict error handling for mount dir prep

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -49,15 +49,16 @@ jobs:
           swap-storage: true
       - name: Prepare build mount dir
         run: |
+          set -euo pipefail
           sudo mkdir -p /mnt
           if [ -e /dev/buildvg/buildlv ]; then
             sudo wipefs -a /dev/buildvg/buildlv || true
           else
             echo "Device /dev/buildvg/buildlv not found, skipping wipefs"
           fi
-            sudo swapoff /mnt/swapfile || true
-            sudo rm -f /mnt/swapfile || true
-            sudo rm -rf /mnt/* || true
+          sudo swapoff /mnt/swapfile || true
+          sudo rm -f /mnt/swapfile || true
+          sudo rm -rf /mnt/* || true
       - name: Install LVM
         run: sudo apt-get update && sudo apt-get install -y lvm2
       - name: Maximize build space


### PR DESCRIPTION
## Summary
- ensure build mount prep step exits on errors
- align post-`fi` cleanup commands

## Testing
- `bash -xeuo pipefail <<'EOF'
sudo mkdir -p /mnt
if [ -e /dev/buildvg/buildlv ]; then
  sudo wipefs -a /dev/buildvg/buildlv || true
else
  echo "Device /dev/buildvg/buildlv not found, skipping wipefs"
fi
sudo swapoff /mnt/swapfile || true
sudo rm -f /mnt/swapfile || true
sudo rm -rf /mnt/* || true
EOF`
- `pre-commit run --files .github/workflows/docker-publish.yml` *(fails: Interrupted (^C))*
- `pytest -q` *(fails: module 'bot.data_handler' has no attribute 'get_http_client')*

------
https://chatgpt.com/codex/tasks/task_e_68b57325dc24832d9e131475f9bbb2d8