### PR TITLE
Добавлен запуск flake8 в CI перед тестами

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,5 +31,7 @@ jobs:
         run: python -m pip install --upgrade pip
       - name: Install dependencies
         run: python -m pip install -r requirements-ci.txt
+      - name: Run flake8
+        run: flake8 .
       - name: Run tests
         run: pytest --maxfail=1 --disable-warnings -q


### PR DESCRIPTION
## Summary
- запуск `flake8` в workflow `tests`

## Testing
- `python -m flake8 . && echo 'flake8 passed'`
- `pytest -q` *(failed: AttributeError: module 'bot.data_handler' has no attribute 'get_http_client')*

------
https://chatgpt.com/codex/tasks/task_e_68b5730e77c0832dae314b8b6d26b33a