### PR TITLE
chore: install dependencies in dependency submission workflow

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install build deps
-        run: pip install --upgrade pip build
+        run: pip install --upgrade pip build && pip install -r requirements.txt
       - name: Validate project
         run: python -m build
       - uses: advanced-security/dependency-submission-action@5530bab9ee4bbe66420ce8280624036c77f89746


### PR DESCRIPTION
## Summary
- ensure dependency submission workflow installs requirements.txt

## Testing
- `SKIP=pytest pre-commit run --files .github/workflows/dependency-submission.yml`
- `pytest -q` *(fails: fixture 'csrf_secret' not found, module attribute errors, assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b5729e696c832db12e7e9a2be922c2