### PR TITLE
Add numpy to CI requirements

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -18,4 +18,5 @@ setuptools>=80.9.0
 types-requests
 mypy==1.17.1
 hypothesis>=6.138.8
+numpy==2.2.6
 pip-audit==2.9.0


### PR DESCRIPTION
## Summary
- add numpy pin to CI requirements

## Testing
- `pip install -r requirements-ci.txt`
- `pytest` *(fails: AttributeError: module 'bot.data_handler' has no attribute 'atr_fast', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b5730946f0832d8c2b3f9851b8eb3f