### PR TITLE
chore: pin free disk space action

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: true
           android: true


### PR DESCRIPTION
## Summary
- pin `jlumbroso/free-disk-space` GitHub Action to commit `54081f1` (v1.3.1) for transparency and reproducibility

## Testing
- `pytest -q` *(fails: fixture 'csrf_secret' not found and other errors)*
- `pytest tests/test_server_auth.py::test_completions_requires_key -q` *(fails: fixture 'csrf_secret' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5734054d4832dae6ae9f191005ab0