### PR TITLE
Remove redundant Trivy setup in docker-publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -117,11 +117,6 @@ jobs:
           rm -rf /mnt/.buildx-cache
           mv /mnt/.buildx-cache-new /mnt/.buildx-cache
 
-      - name: Set up Trivy
-        uses: aquasecurity/setup-trivy@9ea583eb67910444b1f64abf338bd2e105a0a93d # v0.2.3
-        with:
-          version: v0.65.0
-
       - name: Cleanup before Trivy scan
         run: |
           sudo rm -rf /tmp/* || true


### PR DESCRIPTION
## Summary
- remove separate Trivy setup step
- rely on trivy-action to install version v0.65.0

## Testing
- `pytest tests/test_http_client_shared.py::test_shared_http_client_cleanup -q` *(fails: AttributeError: module 'bot.data_handler' has no attribute 'get_http_client')*

------
https://chatgpt.com/codex/tasks/task_e_68b5732dc9d0832da45638ee14c3e48b