### PR TITLE
chore: pin actions/checkout to v4.3.0 SHA

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Run Dependabot
         run: bash scripts/run_dependabot.sh

--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -20,7 +20,7 @@ jobs:
     env:
       PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           fetch-depth: 0
       - name: Start vLLM container


### PR DESCRIPTION
## Summary
- pin actions/checkout to commit 08eba0b27e820071cde6df949e0beb9ba4906955 (v4.3.0) in Dependabot and GPT-OSS review workflows

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml .github/workflows/gptoss_review.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b573423b1c832daa905556a47e1431