### PR TITLE
chore(ci): pin actions/cache to commit SHA

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -26,7 +26,7 @@ jobs:
         id: pip-cache
         run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
       - name: Cache pip wheels
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements-ci.txt') }}


### PR DESCRIPTION
## Summary
- pin actions/cache to commit 0400d5f644dc74513175e3cd8d07132dd4860809 in ci_cpu workflow

## Testing
- `pytest` *(fails: AttributeError: module 'bot.data_handler' has no attribute 'atr_fast', TypeError: object.__init__() takes exactly one argument (the instance to initialize))*

------
https://chatgpt.com/codex/tasks/task_e_68b5734bf9c8832db08f998412ffd5ff