### PR TITLE
Add UTF-8 encoding for legacy cache loading

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -235,7 +235,7 @@ class HistoricalDataCache:
                     symbol,
                     timeframe,
                 )
-                with gzip.open(legacy_json, "rt") as f:
+                with gzip.open(legacy_json, "rt", encoding="utf-8") as f:
                     payload = json.load(f)
                 data_json = payload.get("data")
                 data = pd.read_json(StringIO(data_json), orient="split")


### PR DESCRIPTION
## Summary
- ensure gzip cache reading uses UTF-8 encoding

## Testing
- `pytest tests/test_cache.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5734ec338832d98cbaedbe34a61fe