### PR TITLE
Remove extra workflow permissions

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: write
-  security-events: write
 
 jobs:
   dependency-submission:


### PR DESCRIPTION
## Summary
- minimize `dependency-submission` workflow permissions to only `contents: write`

## Testing
- `pre-commit run --files .github/workflows/dependency-submission.yml` *(fails: hook `pytest`)*
- `pytest` *(fails: 9 failed, 4 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b57298cb84832da064948f2e0af0bc