### PR TITLE
ci_cpu: add timeout for mock server

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -54,7 +54,7 @@ jobs:
           HTTPServer(('127.0.0.1', 8009), Handler).serve_forever()
           PY
           echo $! > server.pid
-          until curl -sf http://127.0.0.1:8009 >/dev/null; do sleep 0.5; done
+          timeout 30 bash -c 'until curl -sf http://127.0.0.1:8009 >/dev/null; do sleep 0.5; done'
       - name: Run flake8
         run: flake8 .
       - name: Run mypy


### PR DESCRIPTION
## Summary
- ensure mock server startup fails if unresponsive for 30s

## Testing
- `pytest -q` *(fails: AttributeError: module 'bot.data_handler' has no attribute 'get_http_client', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b5734d6440832d9ea88c5ff2e5d7c4