### PR TITLE
ci: stop mock server gracefully

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -64,5 +64,10 @@ jobs:
       - name: Stop mock server
         if: always()
         run: |
-          pkill -F server.pid || true
-          rm server.pid
+          if [ -f server.pid ]; then
+            pid=$(cat server.pid)
+            kill "$pid" || true
+            while kill -0 "$pid" 2>/dev/null; do sleep 0.5; done
+            rm server.pid
+            test ! -f server.pid
+          fi


### PR DESCRIPTION
## Summary
- остановить mock-сервер в CI через `kill` с ожиданием завершения процесса и удалением PID-файла

## Testing
- `pre-commit run --files .github/workflows/ci_cpu.yml` *(interrupted)*
- `pytest` *(fail: 9 failed, 4 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b573534618832db6ff5087443dff84