### PR TITLE
Add scikit-learn to CI requirements

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -14,6 +14,7 @@ pyarrow>=21.0.0
 python-dotenv>=1.1.1
 werkzeug>=3.1.3,<4
 requests>=2.32.5
+scikit-learn>=1.5
 setuptools>=80.9.0
 types-requests
 mypy==1.17.1


### PR DESCRIPTION
## Summary
- include scikit-learn>=1.5 in CI requirements

## Testing
- `python -m build`
- `pytest -m requires_sklearn -q`
- `PYTEST_ADDOPTS="-m requires_sklearn" python -m pre_commit run --files requirements-ci.txt`


------
https://chatgpt.com/codex/tasks/task_e_68b5730a11cc832d9c94dd034619869f