### PR TITLE
fix: clean secret scan workflow

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -26,13 +26,13 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@dcedce43c6f43de0b836d1fe38946645c9c638dc # v2 dcedce43c6f43de0b836d1fe38946645c9c638dc
+        uses: gitleaks/gitleaks-action@dcedce43c6f43de0b836d1fe38946645c9c638dc # v2
         env:
           GITLEAKS_ARGS: --no-git --redact --report-format=sarif --report-path=results.sarif
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF report
         if: always()
-        uses: github/codeql-action/upload-sarif@ad2a4837011b42f6947b78d6417e7c253b1c504b # v3 ad2a4837011b42f6947b78d6417e7c253b1c504b
+        uses: github/codeql-action/upload-sarif@ad2a4837011b42f6947b78d6417e7c253b1c504b # v3
         with:
           sarif_file: results.sarif
       - name: Cleanup buildx


### PR DESCRIPTION
## Summary
- tidy secret-scan workflow and remove stray SHA fragments
- keep action `uses` lines in a single line with commit SHA

## Testing
- `python - <<'PY'
import yaml
with open('.github/workflows/secret-scan.yml') as f:
    yaml.safe_load(f)
print('YAML OK')
PY`
- `pytest -q` *(fails: AttributeError: module 'bot.data_handler' has no attribute 'get_http_client')*

------
https://chatgpt.com/codex/tasks/task_e_68b5733f2800832da477903f441c1e30