### PR TITLE
Use workspace path for buildx cache

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -81,12 +81,14 @@ jobs:
         run: echo "$DOCKERHUB_TOKEN" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
 
       - name: Prepare buildx cache directory
-        run: mkdir -p /mnt/.buildx-cache
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/.buildx-cache"
+          chmod -R 777 "$GITHUB_WORKSPACE/.buildx-cache"
 
       - name: Cache Docker layers
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
         with:
-          path: /mnt/.buildx-cache
+          path: ${{ github.workspace }}/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
@@ -109,13 +111,13 @@ jobs:
           file: ${{ matrix.file }}
           push: true
           tags: docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ matrix.image }}:latest
-          cache-from: type=local,src=/mnt/.buildx-cache
-          cache-to: type=local,dest=/mnt/.buildx-cache-new,mode=max
+          cache-from: type=local,src=${{ github.workspace }}/.buildx-cache
+          cache-to: type=local,dest=${{ github.workspace }}/.buildx-cache-new,mode=max
 
       - name: Update buildx cache
         run: |
-          rm -rf /mnt/.buildx-cache
-          mv /mnt/.buildx-cache-new /mnt/.buildx-cache
+          rm -rf "$GITHUB_WORKSPACE/.buildx-cache"
+          mv "$GITHUB_WORKSPACE/.buildx-cache-new" "$GITHUB_WORKSPACE/.buildx-cache"
 
       - name: Set up Trivy
         uses: aquasecurity/setup-trivy@9ea583eb67910444b1f64abf338bd2e105a0a93d # v0.2.3


### PR DESCRIPTION
## Summary
- store buildx cache in `${{ github.workspace }}/.buildx-cache`
- adjust cache-from and cache-to paths
- ensure cache directory is writable

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml` *(pytest interrupted after long runtime)*


------
https://chatgpt.com/codex/tasks/task_e_68b5732aeb90832d98df44699fdafacf