### PR TITLE
Fix test utilities and restore CI stability

### DIFF
--- a/data_handler/__init__.py
+++ b/data_handler/__init__.py
@@ -1,6 +1,19 @@
 """Data handler package exposing main interfaces."""
+
 from .core import DataHandler
 from .api import api_app
 from .storage import DEFAULT_PRICE
+from .utils import atr_fast
+from bot.http_client import (
+    get_async_http_client as get_http_client,
+    close_async_http_client as close_http_client,
+)
 
-__all__ = ["DataHandler", "api_app", "DEFAULT_PRICE"]
+__all__ = [
+    "DataHandler",
+    "api_app",
+    "DEFAULT_PRICE",
+    "atr_fast",
+    "get_http_client",
+    "close_http_client",
+]

--- a/data_handler/utils.py
+++ b/data_handler/utils.py
@@ -1,4 +1,7 @@
 """Utility helpers for data handler."""
+
+from __future__ import annotations
+
 import pandas as pd
 
 
@@ -6,3 +9,25 @@ def expected_ws_rate(timeframe: str) -> int:
     """Return minimal websocket processing rate for timeframe."""
     seconds = pd.Timedelta(timeframe).total_seconds()
     return max(1, int(1800 / seconds))
+
+
+def atr_fast(high, low, close, window: int) -> "np.ndarray":
+    """Lightweight Average True Range implementation.
+
+    The real project previously exposed an optimised ATR routine that may have
+    relied on optional numeric libraries.  The tests only require behaviour
+    compatible with :func:`ta.volatility.average_true_range`, so we implement a
+    small pandas based version here which works with plain Python objects and
+    NumPy arrays.  The function returns a NumPy array for ease of use in the
+    rest of the codebase.
+    """
+
+    import numpy as np
+
+    h = pd.Series(high, dtype=float)
+    l = pd.Series(low, dtype=float)
+    c = pd.Series(close, dtype=float)
+    prev_close = c.shift(1)
+    tr = pd.concat([(h - l).abs(), (h - prev_close).abs(), (l - prev_close).abs()], axis=1).max(axis=1)
+    atr = tr.rolling(window, min_periods=1).mean()
+    return atr.to_numpy(np.float64, copy=False)

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -9,6 +9,7 @@ from contextlib import contextmanager
 from fastapi.testclient import TestClient
 
 
+@contextmanager
 def make_client(monkeypatch):
     def dummy_load_model():
         server.model_manager.tokenizer = object()

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -698,7 +698,13 @@ class TradeManager:
                 "highest_price": price if side == "buy" else float("inf"),
                 "lowest_price": price if side == "sell" else 0.0,
                 "breakeven_triggered": False,
-                "last_checked_ts": pd.Timestamp.utcnow().tz_localize(None).tz_localize("UTC"),
+                # ``last_checked_ts`` is initialised to the minimum timestamp so
+                # that risk-management routines run on the very next candle
+                # regardless of the historical data range. Previously this used
+                # the current time which could be ahead of the available data
+                # and caused checks like ``check_stop_loss_take_profit`` to
+                # return early, leaving positions open indefinitely in tests.
+                "last_checked_ts": pd.Timestamp.min.tz_localize("UTC"),
             }
             timestamp = new_position["last_checked_ts"]
             idx = (symbol, timestamp)


### PR DESCRIPTION
## Summary
- implement `atr_fast` helper and expose HTTP client utilities
- add CSRF secret fixture and contextmanager for server auth tests
- reset httpx stubs and initialize `last_checked_ts` safely in TradeManager

## Testing
- `pytest tests/test_server_auth.py::test_completions_requires_key tests/test_server_auth.py::test_chat_completions_requires_key tests/test_server_auth.py::test_check_api_key_masks_sensitive_headers tests/test_server_csrf_unexpected.py::test_unexpected_csrf_error_returns_500 tests/test_server_missing_api_keys.py::test_missing_api_keys_causes_startup_failure tests/test_server_request_validation.py::test_chat_completions_validation tests/test_server_request_validation.py::test_completions_validation tests/test_telegram_logger.py::test_worker_thread_stops_after_shutdown tests/test_telegram_logger.py::test_long_message_split_into_parts -q`
- `pytest tests/test_http_client_shared.py::test_shared_http_client_cleanup -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5a11b6e58832db35dcbafa702b0f1