### PR TITLE
Simplify dependency submission workflow

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -16,11 +16,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: Install build deps
-        run: pip install --upgrade pip build && pip install -r requirements.txt
-      - name: Validate project
-        run: python -m build
+      - name: Generate dependency report
+        run: |
+          pip install --upgrade pip
+          pip install --dry-run --report dependency-report.json -r requirements.txt
       - uses: advanced-security/dependency-submission-action@v1
         with:
           github-token: ${{ github.token }}
-          path: ./
+          path: dependency-report.json


### PR DESCRIPTION
## Summary
- use pip --dry-run to generate dependency report for submission
- avoid installing full dependency tree during dependency submission workflow

## Testing
- `pytest`
- `pre-commit run --files .github/workflows/dependency-submission.yml` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a1374b3c832d8b47c57335ed4c21