### PR TITLE
fix: handle dependency submission pip index

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Generate dependency report
         run: |
           pip install --upgrade pip
-          pip install --dry-run --report dependency-report.json -r requirements.txt
+          pip install --dry-run --report dependency-report.json --extra-index-url https://download.pytorch.org/whl/cpu -r requirements.txt
       - uses: advanced-security/dependency-submission-action@v1
         with:
-          github-token: ${{ github.token }}
+          token: ${{ github.token }}
           path: dependency-report.json


### PR DESCRIPTION
## Summary
- ensure dependency submission workflow uses PyTorch index for package resolution
- pass token to dependency submission action using `token` input

## Testing
- `pytest` *(fails: NameError: name 'Iterable' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b30e7450832d83caa11f4149cb8f