### PR TITLE
fix dependency submission workflow

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install --dry-run --report dependency-report.json --extra-index-url https://download.pytorch.org/whl/cpu -r requirements.txt
-      - uses: advanced-security/dependency-submission-action@v1
+      - uses: github/dependency-submission-action@v4
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           path: dependency-report.json


### PR DESCRIPTION
## Summary
- use official `github/dependency-submission-action@v4` with proper token

## Testing
- `pre-commit run --files .github/workflows/dependency-submission.yml` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b4ca5c58832db3d2d13b92e797f6