### PR TITLE
Use secure CSRF token and log Flask patch failure

### DIFF
--- a/fastapi_csrf_protect/__init__.py
+++ b/fastapi_csrf_protect/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import pytest
+import secrets
 
 
 class CsrfProtectError(Exception):
@@ -19,7 +20,8 @@ class CsrfProtect:
         return func
 
     def generate_csrf_tokens(self):
-        token = "token"
+        """Generate a cryptographically secure CSRF token."""
+        token = secrets.token_urlsafe()
         return token, token
 
     async def validate_csrf(self, request):

--- a/test_stubs.py
+++ b/test_stubs.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import os
 import sys
 import types
+import logging
 from types import ModuleType
 from typing import Any, Protocol, cast
 
@@ -240,8 +241,8 @@ def apply() -> None:
         Flask = cast(type[FlaskWithASGI], _Flask)
         if not hasattr(Flask, "asgi_app"):
             setattr(Flask, "asgi_app", property(lambda self: self.wsgi_app))
-    except Exception:
-        pass
+    except Exception as exc:  # pragma: no cover - best effort
+        logging.debug("Failed to patch Flask for ASGI support: %s", exc)
 
 
 apply()


### PR DESCRIPTION
## Summary
- use secrets.token_urlsafe to generate CSRF tokens
- log Flask patch failures instead of silently passing

## Testing
- `bandit -r fastapi_csrf_protect/__init__.py test_stubs.py`
- `pytest` (fails: ModuleNotFoundError and 19 other import errors)

------
https://chatgpt.com/codex/tasks/task_e_68b5b57a5510832d9f7cbfb2bb33045c