### PR TITLE
Fix dependency submission workflow token

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -22,5 +22,5 @@ jobs:
           pip install --dry-run --report dependency-report.json --extra-index-url https://download.pytorch.org/whl/cpu -r requirements.txt
       - uses: github/dependency-submission-action@v4
         with:
-          token: ${{ secrets.TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           path: dependency-report.json


### PR DESCRIPTION
## Summary
- use default `GITHUB_TOKEN` in dependency submission workflow

## Testing
- `pre-commit run --files .github/workflows/dependency-submission.yml` *(fails: No module named 'config', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b7422854832db2fca7981f9a1069