### PR TITLE
Обновлены названия секретов в workflow

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -38,7 +38,7 @@ jobs:
           # exit with 0, even with results found
           exit_zero: false # fail when issues are found
           # Github token of the repository (automatically created by Github)
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information.
+          GITHUB_TOKEN: ${{ secrets.TOKEN }} # Needed to get PR information.
           # File or directory to run bandit on
           # path: # optional, default is .
           # Report only issues of a given severity level or higher. Can be LOW, MEDIUM or HIGH. Default is UNDEFINED (everything)

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -20,4 +20,4 @@ jobs:
         run: bash scripts/run_dependabot.sh
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TOKEN: ${{ secrets.TOKEN }}

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -22,5 +22,5 @@ jobs:
           pip install --dry-run --report dependency-report.json --extra-index-url https://download.pytorch.org/whl/cpu -r requirements.txt
       - uses: github/dependency-submission-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.TOKEN }}
           path: dependency-report.json

--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -37,7 +37,7 @@ jobs:
         id: generate-diff
         if: success()
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}
         run: |
           base_sha=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
             https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER | jq -r .base.sha)

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -17,4 +17,4 @@ jobs:
         with:
           config-name: release-drafter.yml
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -29,7 +29,7 @@ jobs:
         uses: gitleaks/gitleaks-action@dcedce43c6f43de0b836d1fe38946645c9c638dc # v2
         env:
           GITLEAKS_ARGS: --no-git --redact --report-format=sarif --report-path=results.sarif
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}
       - name: Upload SARIF report
         if: always()
         uses: github/codeql-action/upload-sarif@ad2a4837011b42f6947b78d6417e7c253b1c504b # v3

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Login to GHCR
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}
         run: echo "$GITHUB_TOKEN" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Cleanup before Trivy scan


### PR DESCRIPTION
## Summary
- заменить использование `secrets.GITHUB_TOKEN` на `secrets.TOKEN` во всех workflow
- Docker publish workflow использует секреты `AVERINALEKS` и `BOT` для Docker Hub

## Testing
- `pytest` *(падает: IndentationError в trade_manager.py)*
- `pre-commit run --files .github/workflows/bandit.yml .github/workflows/dependabot.yml .github/workflows/dependency-submission.yml .github/workflows/gptoss_review.yml .github/workflows/release-drafter.yml .github/workflows/secret-scan.yml .github/workflows/trivy.yml` *(падает: IndentationError в trade_manager.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b5baccd174832d9245a3e619bc6a73