### PR TITLE
Fix stop-loss check timestamp comparison

### DIFF
--- a/trade_manager.py
+++ b/trade_manager.py
@@ -960,6 +960,7 @@ class TradeManager:
                 df = ohlcv.xs(symbol, level="symbol", drop_level=False)
                 current_ts = df.index.get_level_values("timestamp")[-1]
                 last_checked = position.get("last_checked_ts")
+                if pd.notna(last_checked) and last_checked >= current_ts:
                     return
                 self.positions.loc[
                     pd.IndexSlice[symbol, :], "last_checked_ts"


### PR DESCRIPTION
## Summary
- ensure stop-loss/take-profit check ignores already processed candles

## Testing
- `pre-commit run --files trade_manager.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5ba5bfff0832dac223bd7b415030b