### PR TITLE
fix stop-loss check timestamp

### DIFF
--- a/trade_manager.py
+++ b/trade_manager.py
@@ -960,6 +960,7 @@ class TradeManager:
                 df = ohlcv.xs(symbol, level="symbol", drop_level=False)
                 current_ts = df.index.get_level_values("timestamp")[-1]
                 last_checked = position.get("last_checked_ts")
+                if pd.notna(last_checked) and last_checked >= current_ts:
                     return
                 self.positions.loc[
                     pd.IndexSlice[symbol, :], "last_checked_ts"


### PR DESCRIPTION
## Summary
- prevent repeated stop-loss checks for earlier timestamps

## Testing
- `pytest`
- `pre-commit run --files trade_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5bdb1f288832dbe641fee41d95265