### PR TITLE
fix: handle last_checked timestamp

### DIFF
--- a/trade_manager.py
+++ b/trade_manager.py
@@ -960,6 +960,7 @@ class TradeManager:
                 df = ohlcv.xs(symbol, level="symbol", drop_level=False)
                 current_ts = df.index.get_level_values("timestamp")[-1]
                 last_checked = position.get("last_checked_ts")
+                if isinstance(last_checked, pd.Timestamp) and last_checked >= current_ts:
                     return
                 self.positions.loc[
                     pd.IndexSlice[symbol, :], "last_checked_ts"


### PR DESCRIPTION
## Summary
- avoid repeated SL/TP checks using proper `last_checked_ts`

## Testing
- `pre-commit run --files trade_manager.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5bdd69278832dae0fd5e1b263b076