### PR TITLE
Fix stop-loss check timing

### DIFF
--- a/trade_manager.py
+++ b/trade_manager.py
@@ -960,6 +960,7 @@ class TradeManager:
                 df = ohlcv.xs(symbol, level="symbol", drop_level=False)
                 current_ts = df.index.get_level_values("timestamp")[-1]
                 last_checked = position.get("last_checked_ts")
+                if isinstance(last_checked, pd.Timestamp) and last_checked >= current_ts:
                     return
                 self.positions.loc[
                     pd.IndexSlice[symbol, :], "last_checked_ts"


### PR DESCRIPTION
## Summary
- prevent repeated stop-loss evaluation when check timestamp is current or future

## Testing
- `pre-commit run --files trade_manager.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5be012d54832dbcee3b3ef16058f9