### PR TITLE
Fix import and Telegram logger condition

### DIFF
--- a/data_handler/__init__.py
+++ b/data_handler/__init__.py
@@ -1,5 +1,7 @@
 
 
+from collections.abc import Iterable
+
 import numpy as np
 
 from .core import DataHandler

--- a/telegram_logger.py
+++ b/telegram_logger.py
@@ -103,6 +103,7 @@ class TelegramLogger(logging.Handler):
     async def _send(self, message: str, chat_id: int | str, urgent: bool) -> None:
         async with self.message_lock:
             if (
+                not urgent
                 and time.time() - self.last_message_time < self.message_interval
             ):
                 logger.debug(


### PR DESCRIPTION
## Summary
- fix missing Iterable import in data handler
- repair TelegramLogger rate-limit condition

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5c491033c832d8fd6dd666a9b841d