### PR TITLE
chore: upgrade libpam0g

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
 - Update linux-libc-dev to 6.8.0-76.76 to mitigate CVE-2025-21976.
 - Update linux-libc-dev to a patched revision to close CVE-2025-21946.
 - Replace Ray's commons-lang3 JAR with version 3.18.0 to address vulnerabilities.
+- Explicitly upgrade libpam0g to mitigate CVE-2024-10963.

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y --no-install
     python3-pip \
     libssl-dev \
     libffi-dev \
+    libpam0g \
     libblas-dev \
     liblapack-dev \
     tar \
@@ -83,6 +84,7 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y --no-install
     libpython3.12-stdlib \
     coreutils \
     zlib1g \
+    libpam0g \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && ldconfig \
     && /app/venv/bin/python --version \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -10,6 +10,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install --no-install-recommends -y \
     python3 python3-venv build-essential linux-libc-dev libgcrypt20 git=1:2.43.0-1ubuntu7.3 \
     && apt-get install -y --no-install-recommends gnupg dirmngr \
+    && apt-get install -y --only-upgrade libpam0g \
     && python3 -m venv /venv \
     && apt-get purge -y --auto-remove build-essential \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
@@ -36,7 +37,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install --no-install-recommends -y \
     libssl3t64=3.0.13-0ubuntu3.5 \
     python3.12-minimal=3.12.3-1ubuntu0.8 \
-    && apt-get install -y --only-upgrade openssl libssl3t64 \
+    && apt-get install -y --only-upgrade openssl libssl3t64 libpam0g \
     && apt-get purge -y git \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -7,13 +7,13 @@ RUN apt-get update && apt-get dist-upgrade -y
 
 RUN apt-get install -y --no-install-recommends \
     linux-libc-dev \
-    libpam0g \
     libssl3t64 \
     python3.12-minimal \
     build-essential \
     curl \
     python3 python3-venv python3-dev \
     zlib1g-dev \
+    && apt-get install -y --only-upgrade libpam0g \
 
 WORKDIR /app
 
@@ -44,6 +44,7 @@ RUN apt-get install -y --no-install-recommends \
     curl \
     python3 \
     coreutils libgcrypt20 login passwd tar \
+    && apt-get install -y --only-upgrade libpam0g \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && python3 --version
 

--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -3,12 +3,13 @@ FROM python:3.11-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libtbbmalloc2 libnuma1 curl git \
     && apt-get install -y --no-install-recommends gnupg dirmngr \
+    && apt-get install -y --only-upgrade libpam0g \
     && rm -rf /var/lib/apt/lists/* \
     && gpg --version \
     && dirmngr --version
 
 # Ensure curl is up to date
-RUN apt-get update && apt-get install -y --only-upgrade curl \
+RUN apt-get update && apt-get install -y --only-upgrade curl libpam0g \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONUNBUFFERED=1 HF_HOME=/workspace/hf-cache


### PR DESCRIPTION
## Summary
- upgrade libpam0g in all Docker images
- document libpam0g upgrade for CVE-2024-10963

## Testing
- `pre-commit run flake8 --files Dockerfile Dockerfile.ci Dockerfile.cpu Dockerfile.gptoss CHANGELOG.md`
- `pytest` *(fails: tests/test_env_parsing.py, tests/test_force_cpu.py, tests/test_gpu_disabled.py, tests/test_http_client_cleanup.py, tests/test_http_client_shared.py, tests/test_indicators_gpu.py, tests/test_model_builder.py, tests/test_optimizer.py, tests/test_probability_threshold.py, tests/test_rl_agent.py, tests/test_run_async.py, tests/test_shap_cache.py, tests/test_strategy_optimizer.py, tests/test_telegram_logger.py, tests/test_trading_bot.py, tests/test_trading_env.py, tests/test_utils.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c92082ec832da8a54fe893605870