### PR TITLE
fix: remove unsupported fields from setup-env action

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -19,14 +19,14 @@ runs:
     - name: Free disk space
       shell: bash
       run: |
-        sudo rm -rf /usr/share/dotnet
-        sudo rm -rf /usr/local/lib/android
-        sudo rm -rf /opt/ghc
-        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-        sudo npm cache clean --force || true
-        sudo rm -rf /var/lib/docker/*
-      timeout-minutes: 4
-      continue-on-error: true
+        timeout 4m bash -c '
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          sudo npm cache clean --force || true
+          sudo rm -rf /var/lib/docker/*
+        ' || true
     - name: Prepare build volume
       shell: bash
       run: |


### PR DESCRIPTION
## Summary
- handle free disk space step without unsupported `timeout-minutes` and `continue-on-error`

## Testing
- `pre-commit run --files .github/actions/setup-env/action.yml` *(fails: Interrupted: 17 errors during collection)*
- `pytest` *(fails: Interrupted: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ca354450832d8d5d4c36326eb497