### PR TITLE
Fix indentation in Telegram logger message throttling

### DIFF
--- a/telegram_logger.py
+++ b/telegram_logger.py
@@ -102,6 +102,7 @@ class TelegramLogger(logging.Handler):
 
     async def _send(self, message: str, chat_id: int | str, urgent: bool) -> None:
         async with self.message_lock:
+            if not urgent and time.time() - self.last_message_time < self.message_interval:
                 logger.debug(
                     "Сообщение Telegram пропущено из-за интервала: %s...",
                     message[:100],


### PR DESCRIPTION
## Summary
- fix indentation in TelegramLogger to respect message throttling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5c4cdaaf4832d97cfccba965ec137