### PR TITLE
Use component detection action for dependency submission

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -7,20 +7,14 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   dependency-submission:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Component detection
+        uses: advanced-security/component-detection-dependency-submission-action@v0.1.0
         with:
-          python-version: '3.11'
-      - name: Generate dependency report
-        run: |
-          pip install --upgrade pip
-          pip install --dry-run --report dependency-report.json --extra-index-url https://download.pytorch.org/whl/cpu -r requirements.txt
-      - uses: github/dependency-submission-action@v4
-        with:
-          token: ${{ secrets.TOKEN }}
-          path: dependency-report.json
+          detectorArgs: Pip=EnableIfDefaultOff


### PR DESCRIPTION
## Summary
- replace deprecated dependency submission action with `advanced-security/component-detection-dependency-submission-action`
- grant `id-token` permission required by the new action

## Testing
- `pre-commit run --files .github/workflows/dependency-submission.yml` *(fails: IndentationError: unindent does not match any outer indentation level)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c9f1ec3c832d8d7f36351849adb7