### PR TITLE
Fix Telegram logger send logic and restore test suite

### DIFF
--- a/telegram_logger.py
+++ b/telegram_logger.py
@@ -102,6 +102,10 @@ class TelegramLogger(logging.Handler):
 
     async def _send(self, message: str, chat_id: int | str, urgent: bool) -> None:
         async with self.message_lock:
+            if (
+                not urgent
+                and time.time() - self.last_message_time < self.message_interval
+            ):
                 logger.debug(
                     "Сообщение Telegram пропущено из-за интервала: %s...",
                     message[:100],
@@ -123,7 +127,7 @@ class TelegramLogger(logging.Handler):
                         result = await bot.send_message(chat_id=chat_id, text=part)
                         if not getattr(result, "message_id", None):
                             logger.error(
-                                "Telegram message response without message_id"
+                                "Telegram message response without message_id",
                             )
                         else:
                             self.last_sent_text = part
@@ -153,7 +157,6 @@ class TelegramLogger(logging.Handler):
                     except Exception as e:
                         logger.exception("Ошибка отправки сообщения Telegram: %s", e)
                         raise
-
     def _save_unsent(self, chat_id: int | str, text: str) -> None:
         if self.unsent_path is None:
             return


### PR DESCRIPTION
## Summary
- restore conditional send logic in `TelegramLogger._send` to avoid syntax error and enforce message interval

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5cadd8ec4832db0e0c3cb2e980b2b