### PR TITLE
Register requires_sklearn pytest marker

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,4 +4,5 @@ asyncio_mode = auto
 markers =
     integration: marks tests that require external services or slower integration steps
     asyncio: mark test as asyncio-based
+    requires_sklearn: marks tests that require scikit-learn
 


### PR DESCRIPTION
## Summary
- add `requires_sklearn` marker to pytest.ini to avoid warnings

## Testing
- `pytest tests/test_model_builder.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5d99a3f0c832d8eafecb0a7b04db3