### PR TITLE
Handle inline comments in gptoss_check config

### DIFF
--- a/gptoss_check/main.py
+++ b/gptoss_check/main.py
@@ -17,8 +17,11 @@ def _load_skip_flag(config_path: Path) -> bool:
         if not line or line.startswith("#"):
             continue
         key, _, value = line.partition("=")
-        if key.strip() == "skip_gptoss_check":
-            return value.strip().lower() in {"1", "true", "yes"}
+        key = key.strip().lower()
+        if key == "skip_gptoss_check":
+            # allow inline comments after the value, e.g. "true  # comment"
+            value = value.split("#", 1)[0].strip().lower()
+            return value in {"1", "true", "yes"}
     # By default run the check when the flag is absent
     return False
 

--- a/tests/test_gptoss_check.py
+++ b/tests/test_gptoss_check.py
@@ -3,6 +3,8 @@ import logging
 import sys
 import types
 
+from gptoss_check.main import _load_skip_flag
+
 _fake_client = types.ModuleType("gpt_client")
 
 
@@ -69,3 +71,9 @@ def test_run_without_api(monkeypatch, caplog):
     with caplog.at_level(logging.WARNING):
         check_code.run()
     assert "GPT_OSS_API" in caplog.text
+
+
+def test_skip_flag_accepts_inline_comment(tmp_path: Path) -> None:
+    cfg = tmp_path / "gptoss_check.config"
+    cfg.write_text("skip_gptoss_check=true # comment\n", encoding="utf-8")
+    assert _load_skip_flag(cfg) is True


### PR DESCRIPTION
## Summary
- Обработка флага `skip_gptoss_check` без учёта регистра и с поддержкой встроенных комментариев
- Расширены тесты `gptoss_check` для новой логики

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5db59f848832da2119f03b861fa08