### PR TITLE
test: register requires_sklearn marker

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,4 +4,5 @@ asyncio_mode = auto
 markers =
     integration: marks tests that require external services or slower integration steps
     asyncio: mark test as asyncio-based
+    requires_sklearn: marks tests that require scikit-learn
 


### PR DESCRIPTION
## Summary
- register custom `requires_sklearn` pytest marker to avoid warnings during tests

## Testing
- `flake8 .`
- `mypy .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5d90c1074832da7e25a20a28fb8a4