### PR TITLE
chore: improve dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -3,6 +3,7 @@ name: Dependabot
 permissions:
   contents: write
   pull-requests: write
+  security-events: write
 
 on:
   schedule:
@@ -20,4 +21,4 @@ jobs:
         run: bash scripts/run_dependabot.sh
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
-          TOKEN: ${{ secrets.TOKEN }}
+          TOKEN: ${{ secrets.TOKEN != '' && secrets.TOKEN || github.token }}

--- a/scripts/run_dependabot.sh
+++ b/scripts/run_dependabot.sh
@@ -7,11 +7,11 @@ if [[ -z "${GITHUB_REPOSITORY:-}" ]]; then
 fi
 repo="${GITHUB_REPOSITORY}"
 
-if [[ -z "${TOKEN:-}" ]]; then
-    echo "TOKEN is not set; export a PAT with repo and security_events scopes" >&2
+token="${TOKEN:-${GITHUB_TOKEN:-}}"
+if [[ -z "${token}" ]]; then
+    echo "TOKEN or GITHUB_TOKEN is not set; export a PAT with repo and security_events scopes" >&2
     exit 1
 fi
-token="${TOKEN}"
 
 for ecosystem in pip github-actions; do
   set +e


### PR DESCRIPTION
## Summary
- allow Dependabot workflow to fall back to `github.token`
- grant required security-events permission

## Testing
- `pre-commit run --hook-stage manual --files .github/workflows/dependabot.yml scripts/run_dependabot.sh`
- `pytest tests/test_run_dependabot_script.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5e0567e00832da7f3efb9bf03a870