### PR TITLE
Fix release drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   update_release_draft:
@@ -13,8 +17,9 @@ jobs:
       contents: write
       pull-requests: read
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - name: Update release draft
+        uses: release-drafter/release-drafter@v6
         with:
           config-name: release-drafter.yml
         env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- include pull_request and workflow_dispatch triggers in release-drafter workflow
- use GITHUB_TOKEN secret for release draft update

## Testing
- `pre-commit run flake8 --files .github/workflows/release-drafter.yml`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5e2ec3634832da49584be8e4c114e