### PR TITLE
fix: robust gptoss review workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -27,18 +27,23 @@ jobs:
       - name: Start vLLM container
         run: |
           docker run -d --rm --name gptoss -p 127.0.0.1:8000:8000 \
-            vllm/vllm-openai:latest --model "${{ vars.LLM_MODEL || 'Qwen/Qwen2.5-Coder-7B-Instruct' }}"
+            vllm/vllm-openai:latest --model "${{ vars.LLM_MODEL || 'Qwen/Qwen2.5-Coder-7B-Instruct' }}" --device cpu
       - name: Wait for LLM container
         run: |
           for i in {1..30}; do
-            curl -sf http://127.0.0.1:8000/v1/models && break
+            if curl -sf http://127.0.0.1:8000/v1/models; then
+              exit 0
+            fi
             sleep 1
           done
+          echo "LLM container failed to start" >&2
+          docker logs gptoss || true
+          exit 1
       - name: Generate diff
         id: generate-diff
         if: success()
         env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           base_sha=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
             https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER | jq -r .base.sha)


### PR DESCRIPTION
## Summary
- run vLLM container in CPU mode and fail fast if startup fails
- use default GITHUB_TOKEN for diff generation

## Testing
- `pre-commit run --files .github/workflows/gptoss_review.yml` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e2cf1fdc832d8d5f6db04a282cab