### PR TITLE
fix: adjust secret scan workflow

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -6,6 +6,7 @@
 name: Secret Scan
 
 permissions:
+  actions: read
   contents: read
   security-events: write
 
@@ -29,7 +30,7 @@ jobs:
         uses: gitleaks/gitleaks-action@dcedce43c6f43de0b836d1fe38946645c9c638dc # v2
         env:
           GITLEAKS_ARGS: --no-git --redact --report-format=sarif --report-path=results.sarif
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
       - name: Upload SARIF report
         if: always()
         uses: github/codeql-action/upload-sarif@ad2a4837011b42f6947b78d6417e7c253b1c504b # v3


### PR DESCRIPTION
## Summary
- grant actions read permission for secret scan
- use GitHub token for gitleaks action

## Testing
- `pre-commit run --hook-stage manual --files .github/workflows/secret-scan.yml`

------
https://chatgpt.com/codex/tasks/task_e_68b5e36edb24832da31b4ae6e1d3be19