### PR TITLE
fix: ignore GPT OSS in integration service checks

### DIFF
--- a/tests/test_integration_services.py
+++ b/tests/test_integration_services.py
@@ -162,6 +162,7 @@ def test_check_services_success(monkeypatch):
         monkeypatch.setenv('DATA_HANDLER_URL', f'http://localhost:{dh_port}')
         monkeypatch.setenv('MODEL_BUILDER_URL', f'http://localhost:{mb_port}')
         monkeypatch.setenv('TRADE_MANAGER_URL', f'http://localhost:{tm_port}')
+        monkeypatch.delenv('GPT_OSS_API', raising=False)
         monkeypatch.setenv('SERVICE_CHECK_RETRIES', '2')
         monkeypatch.setenv('SERVICE_CHECK_DELAY', '0.1')
         asyncio.run(trading_bot.check_services())
@@ -212,4 +213,5 @@ def test_check_services_host_only(monkeypatch):
         monkeypatch.setenv('DATA_HANDLER_URL', f'http://localhost:{dh_port}')
         monkeypatch.setenv('MODEL_BUILDER_URL', f'http://localhost:{mb_port}')
         monkeypatch.setenv('TRADE_MANAGER_URL', f'http://localhost:{tm_port}')
+        monkeypatch.delenv('GPT_OSS_API', raising=False)
         asyncio.run(trading_bot.check_services())


### PR DESCRIPTION
## Summary
- adjust integration tests to remove GPT_OSS_API from environment
- allow service checks to pass when GPT OSS API isn't required

## Testing
- `flake8 tests/test_integration_services.py`
- `pytest -m "not integration" -q` *(205 passed, 3 skipped, 17 deselected)*
- `pytest -m integration -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5da04d180832db76bf274708d6c03