### PR TITLE
Добавлен маркер requires_sklearn для pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,4 +4,5 @@ asyncio_mode = auto
 markers =
     integration: marks tests that require external services or slower integration steps
     asyncio: mark test as asyncio-based
+    requires_sklearn: marks tests that require scikit-learn
 


### PR DESCRIPTION
## Summary
- зарегистрирован маркер `requires_sklearn` для устранения предупреждения pytest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5e8918bfc832db5d9a59640d53363