### PR TITLE
Fix dependency submission workflow

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: write
-  id-token: write
 
 jobs:
   dependency-submission:
@@ -17,5 +16,6 @@ jobs:
       - name: Component detection
         uses: advanced-security/component-detection-dependency-submission-action@v0.1.0
         with:
-          detectorArgs: Pip=EnableIfDefaultOff
-          detectorsCategories: Pip
+          token: ${{ secrets.TOKEN }}
+          detectorArgs: 'Pip=EnableIfDefaultOff'
+          detectorsCategories: 'Pip'


### PR DESCRIPTION
## Summary
- tidy dependency submission workflow
- use TOKEN secret for submission token

## Testing
- `./actionlint .github/workflows/dependency-submission.yml`
- `SKIP=pytest pre-commit run --files .github/workflows/dependency-submission.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b5e86f9778832d8e15418e30cbec86