### PR TITLE
fix dependency submission workflow

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   dependency-submission:
@@ -16,6 +17,5 @@ jobs:
       - name: Component detection
         uses: advanced-security/component-detection-dependency-submission-action@v0.1.0
         with:
-          token: ${{ secrets.TOKEN }}
           detectorArgs: 'Pip=EnableIfDefaultOff'
           detectorsCategories: 'Pip'


### PR DESCRIPTION
## Summary
- correct dependency submission workflow permissions
- rely on default GitHub token for component detection

## Testing
- `pre-commit run flake8 --files .github/workflows/dependency-submission.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5fac44634832d82e19aaa33e47af2