### PR TITLE
refactor: fix dependency graph submission workflow

### DIFF
--- a/.github/workflows/dependency-graph/auto-submission.yml
+++ b/.github/workflows/dependency-graph/auto-submission.yml
@@ -1,4 +1,4 @@
-name: Dependency Submission
+name: Dependency Graph Auto Submission
 
 on:
   push:
@@ -10,10 +10,17 @@ permissions:
   id-token: write
 
 jobs:
-  dependency-submission:
+  auto-submission:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
       - name: Component detection
         uses: advanced-security/component-detection-dependency-submission-action@v0.1.0
         with:


### PR DESCRIPTION
## Summary
- set up Python environment for dependency submission
- relocate workflow to dependency-graph/auto-submission

## Testing
- `pre-commit run --files .github/workflows/dependency-graph/auto-submission.yml tests/test_stubs.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68b6b128de48832da18aedb2a66c3275