### PR TITLE
ci: fix docker publish workflow permissions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,6 +4,7 @@ name: Build and Push Docker image
 permissions:
   contents: read
   packages: write
+  actions: write
 
 'on':
   push:


### PR DESCRIPTION
## Summary
- allow cache/artifact steps by granting `actions: write` permission

## Testing
- `yamllint .github/workflows/docker-publish.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b6b138d660832dbd80051a0e2f5f9f