### PR TITLE
Add missing test dependencies

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -23,3 +23,7 @@ mypy==1.17.1
 hypothesis>=6.138.8
 numpy==2.2.6
 pip-audit==2.9.0
+httpx>=0.28.1
+polars>=1.33.0
+pybit>=5.11.0
+torch>=2.8


### PR DESCRIPTION
## Summary
- include httpx, polars, pybit, and torch in CI requirements so tests can import optional modules

## Testing
- `pytest tests/test_state_recovery.py::test_model_builder_save_recovery -q`
- `pre-commit run flake8 --files requirements-ci.txt`


------
https://chatgpt.com/codex/tasks/task_e_68b6b14d9c1c832db08b6c579bf7c062