### PR TITLE
Handle optional pybit import and update CI deps

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -11,11 +11,13 @@ flask>=3.1.2,<4
 # gymnasium and scikit-learn are unavailable on some Python versions
 gymnasium==1.2.0; python_version<'3.12'
 pandas>=2.3.2
+polars>=1.33.0
 pyarrow>=21.0.0
 python-dotenv>=1.1.1
 psutil>=6.0.0
 werkzeug>=3.1.3,<4
 requests>=2.32.5
+httpx>=0.28.1
 scikit-learn>=1.5; python_version<'3.12'
 setuptools>=80.9.0
 types-requests

--- a/utils.py
+++ b/utils.py
@@ -102,16 +102,6 @@ except ImportError as exc:  # pragma: no cover - fallback when executed directly
     logger.warning("Failed to import TelegramLogger relatively: %s", exc)
     from telegram_logger import TelegramLogger  # type: ignore
 
-if os.getenv("TEST_MODE") == "1":
-    import types
-    import sys
-
-    pybit_mod = types.ModuleType("pybit")
-    ut_mod = types.ModuleType("unified_trading")
-    ut_mod.HTTP = object
-    pybit_mod.unified_trading = ut_mod
-    sys.modules.setdefault("pybit", pybit_mod)
-    sys.modules.setdefault("pybit.unified_trading", ut_mod)
 try:
     from telegram.error import RetryAfter, BadRequest, Forbidden
 except ImportError as exc:  # pragma: no cover - allow missing telegram package
@@ -123,7 +113,14 @@ except ImportError as exc:  # pragma: no cover - allow missing telegram package
     RetryAfter = BadRequest = Forbidden = _TelegramError
 
 
-from pybit.unified_trading import HTTP
+try:
+    from pybit.unified_trading import HTTP
+except ImportError:  # pragma: no cover - pybit is optional in CI
+    class HTTP:  # type: ignore
+        """Fallback HTTP stub when pybit is unavailable."""
+
+        def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - simple stub
+            raise ImportError("pybit is required for HTTP operations")
 
 # Mapping from ccxt/ccxtpro style timeframes to Bybit interval strings
 _BYBIT_INTERVALS = {


### PR DESCRIPTION
## Summary
- avoid failing import when `pybit` is missing by providing a fallback HTTP stub
- include `httpx` and `polars` in `requirements-ci.txt`

## Testing
- `pytest tests/test_env_parsing.py tests/test_force_cpu.py tests/test_gpu_disabled.py`
- `SKIP=pytest pre-commit run --files requirements-ci.txt utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6b1439c20832d84bcff5e40ba1a8b