### PR TITLE
ci: install dependencies before dependency scan

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -14,8 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
       - name: Component detection
         uses: advanced-security/component-detection-dependency-submission-action@v0.1.0
         with:
-          detectorArgs: 'Pip=EnableIfDefaultOff'
-          detectorsCategories: 'Pip'
+          detectorArgs: Pip=EnableIfDefaultOff
+          detectorsCategories: Pip


### PR DESCRIPTION
## Summary
- set up Python 3.11 and install requirements before running dependency component detection

## Testing
- `SKIP=pytest pre-commit run --files .github/workflows/dependency-submission.yml`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68b6b15e0c24832d9be04d44466fe5e2