### PR TITLE
Stub torch dependency for tests

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -1,4 +1,10 @@
 from pathlib import Path
+import os
+
+if os.getenv("TEST_MODE") == "1":  # pragma: no cover - simple import guard
+    import test_stubs as _test_stubs
+
+    _test_stubs.apply()
 
 # Allow loading submodules from project root
 __path__ = [

--- a/model_builder.py
+++ b/model_builder.py
@@ -196,9 +196,18 @@ def _get_torch_modules():
     if _torch_modules is not None:
         return _torch_modules
 
-    import torch
-    import torch.nn as nn
-    from torch.utils.data import DataLoader, TensorDataset
+    try:
+        import torch
+    except ModuleNotFoundError:
+        if os.getenv("TEST_MODE") == "1":  # pragma: no cover - test helper
+            import test_stubs
+
+            test_stubs.apply()
+            import torch
+        else:  # pragma: no cover - real missing dependency
+            raise
+    import torch.nn as nn  # type: ignore
+    from torch.utils.data import DataLoader, TensorDataset  # type: ignore
 
 
     class CNNGRU(nn.Module):

--- a/test_stubs.py
+++ b/test_stubs.py
@@ -234,6 +234,46 @@ def apply() -> None:
     )
     sys.modules["uvicorn"] = cast(ModuleType, uvicorn_mod)
 
+    # ------------------------------------------------------------------- torch
+    torch_mod = cast(ModuleType, types.ModuleType("torch"))
+    nn_mod = types.ModuleType("torch.nn")
+
+    class _NNModule:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+    class _TensorDataset:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+    class _DataLoader:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+    class _Device:
+        def __init__(self, type_: str) -> None:
+            self.type = type_
+
+        def __repr__(self) -> str:  # pragma: no cover - trivial repr
+            return self.type
+
+    def _device(type_: str) -> _Device:  # pragma: no cover - simple factory
+        return _Device(type_)
+
+    nn_mod.Module = _NNModule  # type: ignore[attr-defined]
+    utils_mod = types.ModuleType("torch.utils")
+    data_mod = types.ModuleType("torch.utils.data")
+    setattr(data_mod, "DataLoader", _DataLoader)
+    setattr(data_mod, "TensorDataset", _TensorDataset)
+    setattr(utils_mod, "data", data_mod)
+    torch_mod.nn = nn_mod  # type: ignore[attr-defined]
+    torch_mod.device = _device  # type: ignore[attr-defined]
+    torch_mod.utils = utils_mod  # type: ignore[attr-defined]
+    sys.modules["torch"] = cast(ModuleType, torch_mod)
+    sys.modules["torch.nn"] = cast(ModuleType, nn_mod)
+    sys.modules["torch.utils"] = cast(ModuleType, utils_mod)
+    sys.modules["torch.utils.data"] = cast(ModuleType, data_mod)
+
     # ------------------------------------------------------------------- Flask
     try:  # pragma: no cover - best effort
         from flask import Flask as _Flask


### PR DESCRIPTION
## Summary
- auto-apply lightweight stubs when TEST_MODE is enabled
- provide torch stubs so tests can run without heavy deps
- gracefully load torch in model builder during tests

## Testing
- `python -m pre_commit run flake8 --files test_stubs.py bot/__init__.py model_builder.py`
- `pytest --maxfail=1 --disable-warnings -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b17ca4c0832da57c30d4341a516d