### PR TITLE
Fix torch import syntax error

### DIFF
--- a/model_builder.py
+++ b/model_builder.py
@@ -214,7 +214,10 @@ def _get_torch_modules():
 
     try:
         import torch
-
+        from torch import nn
+        from torch.utils.data import DataLoader, TensorDataset
+    except ImportError as e:  # pragma: no cover - torch missing
+        raise ImportError("PyTorch is required to use torch-based models") from e
 
     class CNNGRU(nn.Module):
         """Conv1D + GRU variant."""


### PR DESCRIPTION
## Summary
- guard PyTorch-dependent code with explicit ImportError handling

## Testing
- `pre-commit run --show-diff-on-failure --all-files` *(failed: pytest interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b72af53ac4832d9e43250433ec255a