### PR TITLE
Simplify dependency graph workflow

### DIFF
--- a/.github/workflows/dependency-graph/auto-submission.yml
+++ b/.github/workflows/dependency-graph/auto-submission.yml
@@ -17,10 +17,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
       - name: Component detection
         uses: advanced-security/component-detection-dependency-submission-action@v0.1.0
         with:


### PR DESCRIPTION
## Summary
- remove dependency installation step from dependency graph auto submission workflow

## Testing
- `pre-commit run --files .github/workflows/dependency-graph/auto-submission.yml` *(fails: SyntaxError in model_builder.py during tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b72ad2c330832d99565b2611653134