### PR TITLE
fix: update docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,7 +6,7 @@ permissions:
   packages: write
   actions: write
 
-'on':
+on:
   push:
     branches: ["main"]  # или "master", если у тебя так называется основная ветка
   schedule:
@@ -30,7 +30,7 @@ jobs:
             image: myapp-gptoss
             artifact: trivy-report-gptoss
     env:
-      DOCKERHUB_USERNAME: ${{ secrets.AVERINALEKS }}
+      DOCKERHUB_USERNAME: ${{ secrets.averinaleks }}
       DOCKERHUB_TOKEN: ${{ secrets.BOT }}
 
     steps:


### PR DESCRIPTION
## Summary
- fix docker workflow secrets and `on` syntax
- reference repository-specific Docker Hub secrets

## Testing
- `pip install -r requirements.txt` *(fails: No matching distribution found for backports-asyncio-runner==1.2.0)*
- `pre-commit run --files .github/workflows/docker-publish.yml` *(fails: ModuleNotFoundError: No module named 'psutil')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_68b72afa9058832d8d9992c2c4ecc172