### PR TITLE
fix: ensure Dependabot script checks token

### DIFF
--- a/scripts/run_dependabot.sh
+++ b/scripts/run_dependabot.sh
@@ -7,6 +7,13 @@ if [[ -z "${GITHUB_REPOSITORY:-}" ]]; then
 fi
 repo="${GITHUB_REPOSITORY}"
 
+if [[ -z "${TOKEN:-}" ]]; then
+    echo "TOKEN is not set; export a PAT with repo and security_events scopes" >&2
+    exit 1
+fi
+token="${TOKEN}"
+fail_arg="--fail"
+
 
 for ecosystem in pip github-actions; do
   set +e


### PR DESCRIPTION
## Summary
- ensure run_dependabot.sh validates TOKEN env var and uses curl --fail

## Testing
- `pytest tests/test_run_dependabot_script.py`
- `pytest` *(fails: ModuleNotFoundError/other missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b72cd8f350832db601e685aa3e2183