### PR TITLE
ci: install deps before dependency submission

### DIFF
--- a/.github/workflows/dependency-graph/auto-submission.yml
+++ b/.github/workflows/dependency-graph/auto-submission.yml
@@ -17,6 +17,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
       - name: Component detection
         uses: advanced-security/component-detection-dependency-submission-action@v0.1.0
         with:


### PR DESCRIPTION
## Summary
- install project's Python dependencies before running dependency submission

## Testing
- `pre-commit run --files .github/workflows/dependency-graph/auto-submission.yml` *(fails: python-dotenv is required)*

------
https://chatgpt.com/codex/tasks/task_e_68b73e0a2eec832d9f34ba60afb4f20f