### PR TITLE
Fix torch module import in model builder

### DIFF
--- a/model_builder.py
+++ b/model_builder.py
@@ -232,6 +232,10 @@ def _get_torch_modules():
 
     try:
         import torch
+        from torch import nn
+        from torch.utils.data import DataLoader, TensorDataset
+    except Exception as e:  # pragma: no cover - environment dependency
+        raise RuntimeError("PyTorch is required for model building") from e
 
     class CNNGRU(nn.Module):
         """Conv1D + GRU variant."""


### PR DESCRIPTION
## Summary
- fix lazy torch import in model builder

## Testing
- `flake8 model_builder.py`
- `mypy model_builder.py`
- `pytest` *(fails: KeyboardInterrupt after partial run)*

------
https://chatgpt.com/codex/tasks/task_e_68b73e9ff6ac832d820f006208082b34