### PR TITLE
ci: allow pip audit to fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Audit dependencies
         id: audit
         working-directory: /mnt
+        continue-on-error: true
         run: |
           pip-audit --strict -f json -o pip-audit.json
       - name: Check pip-audit report exists


### PR DESCRIPTION
## Summary
- don't fail CI job when pip-audit finds issues

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68b747e4db08832d88c9fae82d89acbb