### PR TITLE
fix(workflow): убрать установку зависимостей

### DIFF
--- a/.github/workflows/dependency-graph/auto-submission.yml
+++ b/.github/workflows/dependency-graph/auto-submission.yml
@@ -17,9 +17,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: Install dependencies
-        run: |
-          pip install -r requirements.txt
       - name: Component detection
         uses: advanced-security/component-detection-dependency-submission-action@v0.1.0
         with:


### PR DESCRIPTION
## Summary
- убрать установку зависимостей в auto-submission

## Testing
- `pre-commit run --files .github/workflows/dependency-graph/auto-submission.yml` *(ошибка: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_68b747b81f70832d8092c01e6168af19