### PR TITLE
Fix mock server readiness check in CI

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -54,7 +54,7 @@ jobs:
           HTTPServer(('127.0.0.1', 8009), Handler).serve_forever()
           PY
           echo $! > server.pid
-          timeout 30 bash -c 'until curl -sf http://127.0.0.1:8009 >/dev/null; do sleep 0.5; done'
+          timeout 30 bash -c 'until curl -sf -X POST -H "Content-Type: application/json" -d "{}" http://127.0.0.1:8009/v1/completions >/dev/null; do sleep 0.5; done'
       - name: Run flake8
         run: flake8 .
       - name: Run mypy


### PR DESCRIPTION
## Summary
- ensure CI mock server is detected by sending POST to /v1/completions

## Testing
- `flake8 .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b747f0dfa4832da3a2a4e5b4f369bb