### PR TITLE
Rename Docker Hub env vars

### DIFF
--- a/.env
+++ b/.env
@@ -25,6 +25,6 @@ MODEL=Qwen/Qwen2.5-0.5B-Instruct
 # GitHub personal access token used by CI workflows
 TOKEN=
 # Docker Hub username
-AVERINALEKS=
+DOCKERHUB_USERNAME=
 # Docker Hub access token
-BOT=
+DOCKERHUB_TOKEN=

--- a/tests/test_dockerhub_push.py
+++ b/tests/test_dockerhub_push.py
@@ -7,8 +7,8 @@ import pytest
 
 @pytest.fixture
 def docker_env(monkeypatch):
-    monkeypatch.setenv("AVERINALEKS", "fake_user")
-    monkeypatch.setenv("BOT", "fake_password")
+    monkeypatch.setenv("DOCKERHUB_USERNAME", "fake_user")
+    monkeypatch.setenv("DOCKERHUB_TOKEN", "fake_password")
 
 
 @pytest.fixture
@@ -21,12 +21,12 @@ def run_mock(monkeypatch):
 def test_build_and_push(tmp_path, docker_env, run_mock):
     dockerfile = tmp_path / "Dockerfile"
     dockerfile.write_text("FROM alpine:3.18\nRUN echo test > /test.txt\n")
-    image = f"{os.environ['AVERINALEKS']}/bot-test-image:latest"
+    image = f"{os.environ['DOCKERHUB_USERNAME']}/bot-test-image:latest"
 
     subprocess.run(["docker", "build", "-t", image, str(tmp_path)], check=True)
     subprocess.run(
-        ["docker", "login", "-u", os.environ["AVERINALEKS"], "--password-stdin"],
-        input=os.environ["BOT"].encode(),
+        ["docker", "login", "-u", os.environ["DOCKERHUB_USERNAME"], "--password-stdin"],
+        input=os.environ["DOCKERHUB_TOKEN"].encode(),
         check=True,
     )
     subprocess.run(["docker", "push", image], check=True)
@@ -34,8 +34,8 @@ def test_build_and_push(tmp_path, docker_env, run_mock):
     assert run_mock.call_args_list == [
         call(["docker", "build", "-t", image, str(tmp_path)], check=True),
         call(
-            ["docker", "login", "-u", os.environ["AVERINALEKS"], "--password-stdin"],
-            input=os.environ["BOT"].encode(),
+            ["docker", "login", "-u", os.environ["DOCKERHUB_USERNAME"], "--password-stdin"],
+            input=os.environ["DOCKERHUB_TOKEN"].encode(),
             check=True,
         ),
         call(["docker", "push", image], check=True),


### PR DESCRIPTION
## Summary
- rename Docker Hub secrets to DOCKERHUB_USERNAME and DOCKERHUB_TOKEN
- adjust docker hub push test for new env var names

## Testing
- `pre-commit run --files .env tests/test_dockerhub_push.py` *(fails: SyntaxError in model_builder.py)*
- `pytest tests/test_dockerhub_push.py`


------
https://chatgpt.com/codex/tasks/task_e_68b88b229a44832db592578b4c892687