### PR TITLE
Use default GitHub token in workflows

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -38,7 +38,7 @@ jobs:
           # exit with 0, even with results found
           exit_zero: false # fail when issues are found
           # Github token of the repository (automatically created by Github)
-          GITHUB_TOKEN: ${{ secrets.TOKEN }} # Needed to get PR information.
+          GITHUB_TOKEN: ${{ github.token }} # Needed to get PR information.
           # File or directory to run bandit on
           # path: # optional, default is .
           # Report only issues of a given severity level or higher. Can be LOW, MEDIUM or HIGH. Default is UNDEFINED (everything)

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -21,4 +21,4 @@ jobs:
         run: bash scripts/run_dependabot.sh
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
-          TOKEN: ${{ secrets.TOKEN != '' && secrets.TOKEN || github.token }}
+          TOKEN: ${{ github.token }}

--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -51,7 +51,7 @@ jobs:
         id: generate-diff
         if: success()
         env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           base_sha=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
             https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER \

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -22,4 +22,4 @@ jobs:
         with:
           config-name: release-drafter.yml
         env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -30,7 +30,7 @@ jobs:
         uses: gitleaks/gitleaks-action@dcedce43c6f43de0b836d1fe38946645c9c638dc # v2
         env:
           GITLEAKS_ARGS: --no-git --redact --report-format=sarif --report-path=results.sarif
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
       - name: Upload SARIF report
         if: always()
         uses: github/codeql-action/upload-sarif@ad2a4837011b42f6947b78d6417e7c253b1c504b # v3

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Login to GHCR
         env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: echo "$GITHUB_TOKEN" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Cleanup before Trivy scan


### PR DESCRIPTION
## Summary
- replace custom TOKEN secret with default GITHUB token in workflows

## Testing
- `pre-commit run --files .github/workflows/gptoss_review.yml .github/workflows/release-drafter.yml .github/workflows/trivy.yml .github/workflows/bandit.yml .github/workflows/secret-scan.yml .github/workflows/dependabot.yml` *(fails: SyntaxError in model_builder.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b88dcd61fc832d9fc4ddfacc613635