### PR TITLE
Fix incomplete try block in model builder

### DIFF
--- a/model_builder.py
+++ b/model_builder.py
@@ -232,6 +232,10 @@ def _get_torch_modules():
 
     try:
         import torch
+        import torch.nn as nn
+        from torch.utils.data import DataLoader, TensorDataset
+    except Exception as e:
+        raise ImportError("PyTorch is required for neural network features") from e
 
     class CNNGRU(nn.Module):
         """Conv1D + GRU variant."""


### PR DESCRIPTION
## Summary
- ensure `_get_torch_modules` imports torch modules with proper `try/except`

## Testing
- `git ls-files '*.py' -z | xargs -0 python -m py_compile`
- `pytest` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_68b890c614a8832da6a0f03b19faf87e