### PR TITLE
Simplify dependency graph auto submission workflow

### DIFF
--- a/.github/workflows/dependency-graph/auto-submission.yml
+++ b/.github/workflows/dependency-graph/auto-submission.yml
@@ -14,11 +14,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
       - name: Component detection
         uses: advanced-security/component-detection-dependency-submission-action@v0.1.0
-        with:
-          detectorArgs: 'Pip=EnableIfDefaultOff'
-          detectorsCategories: 'Pip'


### PR DESCRIPTION
## Summary
- simplify dependency graph auto submission workflow

## Testing
- `pre-commit run --files .github/workflows/dependency-graph/auto-submission.yml` *(fails: ModuleNotFoundError: No module named 'psutil')*


------
https://chatgpt.com/codex/tasks/task_e_68b8a7375050832d9b96580be68930cf