### PR TITLE
Include master branch in docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,7 +8,7 @@ permissions:
 
 on:
   push:
-    branches: ["main"]  # или "master", если у тебя так называется основная ветка
+    branches: ["main", "master"]
   schedule:
     - cron: '0 0 * * 0'
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- run docker publish workflow when pushing to `main` or `master`

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml` *(fails: ModuleNotFoundError: No module named 'python-dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68b8a7409124832da51f71a29ae550fa