### PR TITLE
chore: gate integration tests on unit success

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,6 @@ jobs:
     name: Integration tests
     runs-on: ubuntu-latest
     needs: unit
-    if: ${{ always() }}
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12']


### PR DESCRIPTION
## Summary
- run integration workflow only when unit tests succeed

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(interrupted: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a7513c7c832d917e1a5f722eba3c