### PR TITLE
Register requires_sklearn pytest marker

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,4 +4,5 @@ asyncio_mode = auto
 markers =
     integration: marks tests that require external services or slower integration steps
     asyncio: mark test as asyncio-based
+    requires_sklearn: marks tests that require scikit-learn
 


### PR DESCRIPTION
## Summary
- register missing `requires_sklearn` mark in pytest configuration to silence warnings

## Testing
- `python -m flake8 .`
- `python -m mypy .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8a75e0bcc832da17438a315c6a178