### PR TITLE
chore: fix dependency graph auto submission action

### DIFF
--- a/.github/workflows/dependency-graph/auto-submission.yml
+++ b/.github/workflows/dependency-graph/auto-submission.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Component detection
-        uses: advanced-security/component-detection-dependency-submission-action@v0.1.0
+        uses: advanced-security/component-detection-dependency-submission-action@6310c0e10248aa08b9a8e6147a2d6cfb33357eb6


### PR DESCRIPTION
## Summary
- pin dependency graph auto-submission action to a Node 20 compatible commit

## Testing
- `pre-commit run --files .github/workflows/dependency-graph/auto-submission.yml` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68b93e7072c4832d8aad6106505c3ed4