### PR TITLE
fix: add joblib dependency for Python 3.12

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -19,6 +19,7 @@ werkzeug>=3.1.3,<4
 requests>=2.32.5
 httpx>=0.28.1
 scikit-learn>=1.5; python_version<'3.12'
+joblib>=1.5
 setuptools>=80.9.0
 types-requests
 mypy==1.17.1


### PR DESCRIPTION
## Summary
- include joblib in CI requirements to cover Python 3.12 builds

## Testing
- `python -m flake8 .`
- `mypy .`
- `pytest`
- `pytest` (Python 3.12)


------
https://chatgpt.com/codex/tasks/task_e_68b93e884d60832da8ca9b373b8ccb18