### PR TITLE
chore: update dependency graph workflow

### DIFF
--- a/.github/workflows/dependency-graph/auto-submission.yml
+++ b/.github/workflows/dependency-graph/auto-submission.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Component detection
-        uses: advanced-security/component-detection-dependency-submission-action@6310c0e10248aa08b9a8e6147a2d6cfb33357eb6
+        uses: advanced-security/component-detection-dependency-submission-action@v0.1.0


### PR DESCRIPTION
## Summary
- use released version of component detection action for dependency graph submission

## Testing
- `pytest` *(fails: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68b94b8e6eb0832dad0b9e67443ce620