### PR TITLE
Исправление проверки Docker образов

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -156,7 +156,7 @@ jobs:
 
   healthcheck:
     needs: build
-    if: always()
+    if: ${{ needs.build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- запуск healthcheck только при успешной сборке образов

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml` *(failed: ModuleNotFoundError: No module named 'psutil', and other missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b94b9938c0832d96e98527a120969f