### PR TITLE
Pin github-script action in GPT-OSS review workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -112,7 +112,7 @@ jobs:
           echo "has_content=true" >> "$GITHUB_OUTPUT"
       - name: Comment PR
         if: always() && steps.llm-review.outputs.has_content == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
## Summary
- pin actions/github-script to a specific commit for security

## Testing
- `pre-commit run --files .github/workflows/gptoss_review.yml` *(fails: ModuleNotFoundError: No module named 'psutil')*


------
https://chatgpt.com/codex/tasks/task_e_68b94bab6a88832db90bc136da665e8b