### PR TITLE
chore: improve dependency graph submission

### DIFF
--- a/.github/workflows/dependency-graph/auto-submission.yml
+++ b/.github/workflows/dependency-graph/auto-submission.yml
@@ -14,5 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Component detection
         uses: advanced-security/component-detection-dependency-submission-action@v0.1.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- set up Python and install dependencies before submitting to dependency graph
- explicitly pass token to component detection action

## Testing
- `pytest` *(fails: RuntimeError: python-dotenv is required)*

------
https://chatgpt.com/codex/tasks/task_e_68b971c08510832d97e135cba1222ac9