### PR TITLE
fix: avoid installing packages in dependency graph workflow

### DIFF
--- a/.github/workflows/dependency-graph/auto-submission.yml
+++ b/.github/workflows/dependency-graph/auto-submission.yml
@@ -18,11 +18,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Component detection
         uses: advanced-security/component-detection-dependency-submission-action@v0.1.0
+        env:
+          PipReportOverrideBehavior: SourceCodeScan
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- skip installing dependencies in dependency graph submission workflow
- use SourceCodeScan to avoid pip report errors

## Testing
- `pre-commit run --hook-stage manual --files .github/workflows/dependency-graph/auto-submission.yml`

------
https://chatgpt.com/codex/tasks/task_e_68b98679bc54832db3d807ae5cf2b35a