### PR TITLE
Fix dependency graph workflow env variable

### DIFF
--- a/.github/workflows/dependency-graph/auto-submission.yml
+++ b/.github/workflows/dependency-graph/auto-submission.yml
@@ -21,6 +21,6 @@ jobs:
       - name: Component detection
         uses: advanced-security/component-detection-dependency-submission-action@v0.1.0
         env:
-          PipReportOverrideBehavior: SourceCodeScan
+          PIP_REPORT_OVERRIDE_BEHAVIOR: SourceCodeScan
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- ensure dependency submission uses the correct pip override env var

## Testing
- `pre-commit run --files .github/workflows/dependency-graph/auto-submission.yml` *(fails: tests error during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b99a761ed4832dbb2983b862d327c5