### PR TITLE
fix: robust diff chunk detection

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -90,7 +90,7 @@ jobs:
         run: |
           model="${{ vars.LLM_MODEL || 'Qwen/Qwen2.5-Coder-1.5B-Instruct' }}"
           review=""
-          if ls diff_part_* 1> /dev/null 2>&1; then
+          if compgen -G "diff_part_*" > /dev/null; then
             for part in diff_part_*; do
               payload=$(jq -n --arg diff "$(cat "$part")" --arg model "$model" \
                 '{model:$model, messages:[{role:"user", content:"Review the following diff and provide feedback:\n" + $diff}]}')


### PR DESCRIPTION
## Summary
- ensure GitHub workflow detects diff chunks without relying on `ls`

## Testing
- `pre-commit run --files .github/workflows/gptoss_review.yml` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_68b9a0f5c188832db3cc16289ad52f47