### PR TITLE
Use CPU-only torch in CI

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,3 +1,4 @@
+--extra-index-url https://download.pytorch.org/whl/cpu
 # Minimal requirements for running tests in CI
 aiohttp>=3.12.15
 bcrypt>=4.3.0
@@ -26,7 +27,5 @@ mypy==1.17.1
 hypothesis>=6.138.8
 numpy==2.2.6
 pip-audit==2.9.0
-httpx>=0.28.1
-polars>=1.33.0
 pybit>=5.11.0
-torch>=2.8
+torch==2.8.0+cpu


### PR DESCRIPTION
## Summary
- use CPU-only torch wheel to avoid installing CUDA runtimes in CI
- deduplicate dependencies in requirements-ci.txt

## Testing
- `pytest tests/test_http_client_cleanup.py`
- `pytest tests/test_env_parsers.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9a0d8345c832d84a4f0404657bd16