### PR TITLE
fix: pin Python 3.11 for dependency graph workflow

### DIFF
--- a/.github/workflows/dependency-graph/auto-submission.yml
+++ b/.github/workflows/dependency-graph/auto-submission.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.11'
       - name: Component detection
         uses: advanced-security/component-detection-dependency-submission-action@v0.1.0
         env:


### PR DESCRIPTION
## Summary
- pin Python 3.11 for dependency graph auto submission

## Testing
- `SKIP=pytest pre-commit run --files .github/workflows/dependency-graph/auto-submission.yml`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_68b9d0c83e7c832db979e5727632efad