### PR TITLE
chore: fix CodeQL workflow runner

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   analyze:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+          fetch-depth: 0
       - uses: github/codeql-action/init@v3
         with:
           languages: python


### PR DESCRIPTION
## Summary
- use supported ubuntu-latest runner for CodeQL
- checkout full history for accurate analysis

## Testing
- `pre-commit run --files .github/workflows/codeql.yml` *(fails: No module named 'flask', 'polars', 'bcrypt', 'pydantic', 'httpx', 'python-dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_68b9d7464584832db2ef0b12814b5ae2