### PR TITLE
Исправить версию backports-asyncio-runner

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ attrs==25.3.0
     #   aiohttp
     #   jsonschema
     #   referencing
-backports-asyncio-runner==1.2.0
+backports-asyncio-runner==1.0.0
     # via pytest-asyncio
 bcrypt==4.3.0
     # via -r requirements-core.in


### PR DESCRIPTION
## Summary
- использовать backports-asyncio-runner 1.0.0 для совместимости с Python 3.11

## Testing
- `python -m pre_commit run --files requirements.txt` *(ошибка: Skip: could not import pandas)*
- `pytest` *(ошибка: could not import pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d768f3a8832dadba69ac2820a2bc