### PR TITLE
fix: use supported runner for secret scan

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   gitleaks:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4 08eba0b27e820071cde6df949e0beb9ba4906955
         with:


### PR DESCRIPTION
## Summary
- use ubuntu-latest runner for secret scan workflow

## Testing
- `pre-commit run --files .github/workflows/secret-scan.yml` *(fails: pytest Interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d78965e8832db8891767ee1c0d98