### PR TITLE
fix: correct release drafter workflow permissions

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Update release draft
         uses: release-drafter/release-drafter@v6
         with:
           config-name: release-drafter.yml
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- ensure release drafter has write access to pull requests
- use `secrets.GITHUB_TOKEN` for authentication

## Testing
- `actionlint -no-color .github/workflows/release-drafter.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b9d7cde3dc832dba649ddf55fd7416