### PR TITLE
fix: install deps before dependency graph submission

### DIFF
--- a/.github/workflows/dependency-graph/auto-submission.yml
+++ b/.github/workflows/dependency-graph/auto-submission.yml
@@ -18,6 +18,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
       - name: Component detection
         uses: advanced-security/component-detection-dependency-submission-action@v0.1.0
         env:


### PR DESCRIPTION
## Summary
- install Python dependencies before running component detection

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9d71b7194832d87ee87d5b621636e