### PR TITLE
Подавление ложного срабатывания Bandit в тестах

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -206,7 +206,7 @@ def test_validate_host_empty_string(monkeypatch, caplog):
     assert 'HOST не установлен' in caplog.text
 
 
-@pytest.mark.parametrize('host', ['0.0.0.0', '256.0.0.1', 'example.com'])
+@pytest.mark.parametrize('host', ['0.0.0.0', '256.0.0.1', 'example.com'])  # nosec B104
 def test_validate_host_rejects_invalid(host, monkeypatch):
     monkeypatch.setenv('HOST', host)
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- помечен тестовый кейс `# nosec B104`, чтобы Bandit не рассматривал адрес `0.0.0.0` как небезопасный

## Testing
- `bandit -r . -ll -ii`
- `pytest tests/test_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9f3b5d6d4832d9eef4d854727deb5