### PR TITLE
Handle Docker service restart without systemd

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -75,10 +75,19 @@ jobs:
 
       - name: Relocate Docker storage to /mnt
         run: |
-          sudo systemctl stop docker
+          set -euo pipefail
+          if command -v systemctl >/dev/null; then
+            sudo systemctl stop docker
+          else
+            sudo service docker stop
+          fi
           sudo mv /var/lib/docker /mnt/docker
           sudo ln -s /mnt/docker /var/lib/docker
-          sudo systemctl start docker
+          if command -v systemctl >/dev/null; then
+            sudo systemctl start docker
+          else
+            sudo service docker start
+          fi
 
       - name: Login to Docker Hub
         run: echo "$DOCKERHUB_TOKEN" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin


### PR DESCRIPTION
## Summary
- handle environments lacking `systemctl` when moving Docker storage

## Testing
- `actionlint .github/workflows/docker-publish.yml`
- `pytest` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68b9f3c8b67c832d85154ccd34d9fc62