### PR TITLE
Simplify dependency graph workflow

### DIFF
--- a/.github/workflows/dependency-graph/auto-submission.yml
+++ b/.github/workflows/dependency-graph/auto-submission.yml
@@ -14,14 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
       - name: Component detection
         uses: advanced-security/component-detection-dependency-submission-action@v0.1.0
         env:


### PR DESCRIPTION
## Summary
- streamline dependency graph submission workflow by removing Python setup and dependency installation

## Testing
- `pre-commit run --files .github/workflows/dependency-graph/auto-submission.yml` *(fails: Skipped: could not import 'pandas': No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68b9f3a7e194832db3467910c5a35232