### PR TITLE
fix: extend LLM startup wait

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -40,7 +40,8 @@ jobs:
             --device cpu
       - name: Wait for LLM container
         run: |
-          for i in {1..60}; do
+          # The model can take a while to load, especially on fresh runners
+          for i in {1..300}; do
             if curl -sf http://127.0.0.1:8000/v1/models; then
               exit 0
             fi


### PR DESCRIPTION
## Summary
- allow more time for LLM container to become ready in GPT-OSS review workflow

## Testing
- `yamllint .github/workflows/gptoss_review.yml`
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68b9f4025650832dbc9770a1c18bc6d5