### PR TITLE
ci: update gitleaks action in secret scan workflow

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@dcedce43c6f43de0b836d1fe38946645c9c638dc # v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
           GITLEAKS_ARGS: --no-git --redact --report-format=sarif --report-path=results.sarif
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- update gitleaks action to latest v2.3.9 commit

## Testing
- `pre-commit run flake8 --files .github/workflows/secret-scan.yml`
- `pytest tests/test_cache.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9f4203db0832db07afc241ff31710