### PR TITLE
chore: refine release drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,11 +1,16 @@
 ---
 name: Release Drafter
 
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   push:
     branches:
       - main
   pull_request:
+    types: [opened, reopened, synchronize]
     branches:
       - main
   workflow_dispatch:
@@ -13,12 +18,9 @@ on:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - name: Update release draft
-        uses: release-drafter/release-drafter@v6
+        uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6
         with:
           config-name: release-drafter.yml
         env:


### PR DESCRIPTION
## Summary
- better configure release drafter workflow with explicit permissions and PR event types
- pin release-drafter action to commit hash

## Testing
- `./bin/actionlint .github/workflows/release-drafter.yml`
- `pytest tests/test_cache.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9f40ced28832d82f2bcfc610715a3