### PR TITLE
fix release drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,9 +18,11 @@ on:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
+      - uses: actions/checkout@v4
       - name: Update release draft
-        uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6
+        uses: release-drafter/release-drafter@7cf306f56b79636bb76931494ccf29fc893763bd # v6.1.0
         with:
           config-name: release-drafter.yml
         env:


### PR DESCRIPTION
## Summary
- skip release drafting for fork pull requests
- upgrade release-drafter action
- check out repository before running release-drafter

## Testing
- `SKIP=pytest pre-commit run --files .github/workflows/release-drafter.yml`
- `pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68bc432ee254832d882ee7948d5b75a9