### PR TITLE
Use PAT for Dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -21,4 +21,4 @@ jobs:
         run: bash scripts/run_dependabot.sh
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
-          TOKEN: ${{ github.token }}
+          TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}


### PR DESCRIPTION
## Summary
- use PAT secret instead of GITHUB_TOKEN in Dependabot workflow

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc441ce49c832d8e58b16e216c26cd