### PR TITLE
Improve Dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -21,4 +21,4 @@ jobs:
         run: bash scripts/run_dependabot.sh
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
-          TOKEN: ${{ github.token }}
+          TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}


### PR DESCRIPTION
## Summary
- handle HTTP errors in Dependabot trigger script
- use dedicated DEPENDABOT_TOKEN secret in workflow

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml scripts/run_dependabot.sh` *(interrupted: KeyboardInterrupt)*
- `GITHUB_REPOSITORY=averinaleks/bot TOKEN=dummy bash scripts/run_dependabot.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bc441b6948832d969d8032efd92f60