### PR TITLE
Use constant-time CSRF token comparison

### DIFF
--- a/fastapi_csrf_protect/__init__.py
+++ b/fastapi_csrf_protect/__init__.py
@@ -27,7 +27,7 @@ class CsrfProtect:
     async def validate_csrf(self, request):
         token = request.headers.get("X-CSRF-Token")
         signed = request.cookies.get("fastapi-csrf-token")
-        if token != signed:
+        if not (token and signed and secrets.compare_digest(token, signed)):
             raise CsrfProtectError("CSRF token mismatch")
 
 


### PR DESCRIPTION
## Summary
- guard against timing attacks by comparing CSRF tokens with `secrets.compare_digest`

## Testing
- `pytest tests/test_server_csrf_unexpected.py tests/test_server_auth.py tests/test_server_request_validation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc491c53fc832da111224d164b07b6