### PR TITLE
fix: ensure dependabot workflow uses builtin token

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -21,4 +21,4 @@ jobs:
         run: bash scripts/run_dependabot.sh
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
-          TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- use built-in `GITHUB_TOKEN` for Dependabot workflow so it runs without extra secrets

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml` *(flake8 skipped; pytest interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bc492b7304832da690e1ae2edc617d