### PR TITLE
fix: avoid proxy usage in requests session

### DIFF
--- a/http_client.py
+++ b/http_client.py
@@ -29,6 +29,11 @@ def get_requests_session(
 ) -> Generator[requests.Session, None, None]:
     """Return a :class:`requests.Session` with a default timeout."""
     session = requests.Session()
+    # Avoid respecting proxy-related environment variables which can cause
+    # local connections (e.g. to the mock GPT server in CI) to be routed through
+    # a non-existent proxy and hang until a network timeout occurs.
+    session.trust_env = False
+    session.proxies = {}
     original = session.request
 
     @wraps(original)


### PR DESCRIPTION
## Summary
- disable proxy env handling in get_requests_session to prevent CI hangs when HTTP proxies are set

## Testing
- `flake8 http_client.py`
- `mypy http_client.py`
- `pytest tests/test_http_client_cleanup.py tests/test_http_client_shared.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc3e7a7144832d98de9b48ee9f0ef2