### PR TITLE
Close shared HTTP client in test session

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@ import sys
 
 import pytest
 
+from bot import http_client as _http_client
+
 pd = pytest.importorskip("pandas")
 
 
@@ -40,3 +42,10 @@ def fast_sleep(monkeypatch):
         return None
 
     monkeypatch.setattr(asyncio, "sleep", _sleep)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _close_shared_http_client():
+    """Ensure the shared async HTTP client is closed after tests."""
+    yield
+    asyncio.run(_http_client.close_async_http_client())


### PR DESCRIPTION
## Summary
- ensure shared async HTTP client is closed after the test session

## Testing
- `pre-commit run --files tests/conftest.py`
- `pytest tests/test_trading_bot.py::test_send_telegram_alert_reuses_client tests/test_trade_manager.py::test_shutdown_handles_missing_is_initialized -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc4998c0a0832d80ae3c2d1400007e