### PR TITLE
Disable env proxy usage in default httpx client

### DIFF
--- a/http_client.py
+++ b/http_client.py
@@ -49,6 +49,11 @@ def get_httpx_client(
 ) -> Generator[httpx.Client, None, None]:
     """Return an :class:`httpx.Client` with a default timeout."""
     kwargs.setdefault("timeout", timeout)
+    # For consistency with the asynchronous helpers, avoid inheriting proxy
+    # settings from the environment unless explicitly requested.  This mirrors
+    # the behaviour of :func:`get_async_http_client` and prevents surprising
+    # proxy usage in environments where variables like ``HTTP_PROXY`` are set.
+    kwargs.setdefault("trust_env", False)
     client = httpx.Client(**kwargs)
     try:
         yield client

--- a/tests/test_httpx_client_defaults.py
+++ b/tests/test_httpx_client_defaults.py
@@ -1,0 +1,6 @@
+from http_client import get_httpx_client
+
+
+def test_get_httpx_client_trust_env_false():
+    with get_httpx_client() as client:
+        assert client.trust_env is False


### PR DESCRIPTION
## Summary
- avoid inheriting proxy settings from environment in `get_httpx_client`
- add regression test for new default

## Testing
- `SKIP=pytest pre-commit run --files http_client.py tests/test_httpx_client_defaults.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc49cd15a0832d84a3cd7dd2422ec9