### PR TITLE
fix: restore dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -19,3 +19,5 @@ jobs:
 
       - name: Run Dependabot
         env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: bash scripts/run_dependabot.sh


### PR DESCRIPTION
## Summary
- restore missing env and run step in dependabot workflow

## Testing
- `pre-commit run flake8 --files .github/workflows/dependabot.yml`
- `pre-commit run --files .github/workflows/dependabot.yml` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68bc51bb9a58832dac733a1b274d14cc