### PR TITLE
chore: use ubuntu-latest for bandit workflow

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   bandit:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:


### PR DESCRIPTION
## Summary
- run bandit workflow on `ubuntu-latest`

## Testing
- `pre-commit run --files .github/workflows/bandit.yml` *(interrupted: pytest hook running entire test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68bc51caba20832d932f9479ac6a5c3d