### PR TITLE
chore: increase wait time for gptoss review

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -41,7 +41,8 @@ jobs:
       - name: Wait for LLM container
         run: |
           # The model can take a while to load, especially on fresh runners
-          for i in {1..300}; do
+          # Allow extra time for the container to become ready
+          for i in {1..600}; do
             if curl -sf http://127.0.0.1:8000/v1/models; then
               exit 0
             fi


### PR DESCRIPTION
## Summary
- increase wait time for local LLM container in gptoss review workflow

## Testing
- `SKIP=pytest pre-commit run --files .github/workflows/gptoss_review.yml`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc51f4d100832d9ec9220fbc0908e3