### PR TITLE
chore: pin dependency graph workflow actions

### DIFF
--- a/.github/workflows/dependency-graph/auto-submission.yml
+++ b/.github/workflows/dependency-graph/auto-submission.yml
@@ -13,8 +13,8 @@ jobs:
   auto-submission:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
           fetch-depth: 0
       - name: Component detection
-        uses: advanced-security/component-detection-dependency-submission-action@v0.1.0
+        uses: advanced-security/component-detection-dependency-submission-action@d433c2f467e149a8009c8fbce92cc708ed15ef7b # v0.1.0


### PR DESCRIPTION
## Summary
- pin actions in dependency graph auto submission workflow to specific commit SHAs

## Testing
- `SKIP=pytest pre-commit run --files .github/workflows/dependency-graph/auto-submission.yml`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc57e7b8d4832d9aaf6f53dc46ac74