### PR TITLE
chore: adjust docker image names

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,13 +21,13 @@ jobs:
       matrix:
         include:
           - file: Dockerfile.cpu
-            image: myapp-cpu
+            image: bot-cpu
             artifact: trivy-report-cpu
           - file: Dockerfile.ci
-            image: myapp-ci
+            image: bot-ci
             artifact: trivy-report-ci
           - file: Dockerfile.gptoss
-            image: myapp-gptoss
+            image: bot-gptoss
             artifact: trivy-report-gptoss
     env:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
## Summary
- align docker publish workflow image names with bot project

## Testing
- `pre-commit run flake8 --files .github/workflows/docker-publish.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc5c5eca48832d8aaf30b9c81bc4c2