### PR TITLE
fix: ensure dependabot workflow uses GH_TOKEN

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -24,4 +24,4 @@ jobs:
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- use `GH_TOKEN` in dependabot auto-merge workflow for proper `gh` authentication

## Testing
- `pytest tests/test_cache.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc5c878580832da195d8a33eab74c9