### PR TITLE
fix: unquote on key in gptoss review workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -2,7 +2,7 @@
 ---
 name: GPT-OSS Code Review
 
-'on':
+on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   issue_comment:


### PR DESCRIPTION
## Summary
- fix YAML by removing quotes around top-level `on` in `gptoss_review` workflow

## Testing
- `SKIP=pytest pre-commit run --files .github/workflows/gptoss_review.yml`
- `pytest test_stubs.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc5c911258832daa97ba8c0eeec17b