### PR TITLE
Disable MLflow telemetry to prevent test hangs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,11 @@ import pytest
 
 from bot import http_client as _http_client
 
+# MLflow spawns a background telemetry thread on import which keeps the
+# process alive after tests finish. Disabling telemetry prevents the thread
+# from starting and avoids hanging the pytest run.
+os.environ.setdefault("MLFLOW_DISABLE_TELEMETRY", "1")
+
 pd = pytest.importorskip("pandas")
 
 


### PR DESCRIPTION
## Summary
- disable MLflow telemetry in test suite to avoid lingering threads and hanging runs

## Testing
- `pytest -m "not integration" -o cache_dir=/mnt/pytest_cache`


------
https://chatgpt.com/codex/tasks/task_e_68bc65e173c0832d8fd19897c9fda137