### PR TITLE
ci: fix Semgrep workflow

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -29,59 +29,17 @@ jobs:
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     name: Scan
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           persist-credentials: false
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+      - uses: returntocorp/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d # v1
         with:
-          tool-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
-      - name: Clean Docker dir
-        run: sudo rm -rf /var/lib/docker/*
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version-file: .python-version
-      - name: Install Semgrep
-        run: |
-          export PIP_CACHE_DIR=/mnt/pip-cache
-          pip install --no-cache-dir semgrep
-      - name: Prepare build volume
-        run: |
-          if [ -e /dev/buildvg/buildlv ]; then
-            sudo wipefs -a /dev/buildvg/buildlv || true
-          else
-            echo "Device /dev/buildvg/buildlv not found, skipping wipefs"
-          fi
-            sudo swapoff /mnt/swapfile || true
-            sudo rm -f /mnt/swapfile || true
-            sudo rm -rf /mnt/* || true
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v10
-        with:
-          root-reserve-mb: 1024
-          temp-reserve-mb: 100
-          swap-size-mb: 4096
-          build-mount-path: /mnt
-          pv-loop-path: /root-pv.img
-          tmp-pv-loop-path: /mnt/tmp-pv.img
-      - name: Run Semgrep
-        run: |
-          semgrep --version
-          semgrep --config=p/ci --sarif --output=semgrep.sarif
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@d6c5e1b140009be28958d3837ed3be3fb637d8c0 # v3
-        with:
-          sarif_file: semgrep.sarif
-      - name: Semgrep CI
+          config: p/ci
+          generateSarif: true
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
-        run: semgrep ci --config p/ci
-      - name: Cleanup buildx
-        run: docker buildx prune -af || true
+      - uses: github/codeql-action/upload-sarif@d6c5e1b140009be28958d3837ed3be3fb637d8c0 # v3
+        with:
+          sarif_file: semgrep.sarif


### PR DESCRIPTION
## Summary
- simplify Semgrep workflow
- use official Semgrep action on ubuntu-latest runner

## Testing
- `pre-commit run --files .github/workflows/semgrep.yml` *(fails: pytest interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5caecf88832d92f8b65026484d26