### PR TITLE
Fix Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,20 +1,19 @@
 name: Dependabot Auto Merge
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
 
 permissions:
   contents: write
   pull-requests: write
-  security-events: write
 
 jobs:
   dependabot:
     if: ${{ github.actor == 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.4.0


### PR DESCRIPTION
## Summary
- run Dependabot auto-merge workflow on `pull_request_target`
- drop unneeded `security-events` permission
- update `actions/checkout` to v4.3.0 commit

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml` *(fails: interrupted during pytest hook)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6ac09364832d8dff3fb38de04abc