### PR TITLE
ci: fix Trivy workflow permissions

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -13,6 +13,7 @@ permissions:
   contents: read
   packages: read
   security-events: write
+  actions: read # required for github/codeql-action/upload-sarif
 
 jobs:
   scan:


### PR DESCRIPTION
## Summary
- allow upload-sarif in Trivy workflow by granting actions:read

## Testing
- `SKIP=pytest pre-commit run --files .github/workflows/trivy.yml`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc5cbf6ba4832d83a386afade1538c