### PR TITLE
chore: install gh cli for dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -14,6 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      - name: Install GitHub CLI
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gh
       - name: Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.4.0


### PR DESCRIPTION
## Summary
- install GitHub CLI so dependabot auto-merge workflow can run gh commands

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml` *(fails: Interrupted (KeyboardInterrupt))*
- `pre-commit run flake8 --files .github/workflows/dependabot.yml`
- `pytest tests/test_config_list_parsing.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc6d384d7c832db9bd525d6a310624