### PR TITLE
chore: remove gh installation from dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -14,10 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-      - name: Install GitHub CLI
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gh
+      - name: Check gh version
+        run: gh --version
       - name: Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.4.0


### PR DESCRIPTION
## Summary
- rely on preinstalled GitHub CLI for dependabot auto-merge workflow
- add version check step

## Testing
- `pre-commit run --hook-stage manual --files .github/workflows/dependabot.yml`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc6fa3d14c832dad240cde3ed51bc2