### PR TITLE
chore: simplify semgrep workflow

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -36,10 +36,8 @@ jobs:
           persist-credentials: false
       - uses: semgrep/ci@v1
         with:
-          config: p/ci
+          config: auto
           generateSarif: true
-        env:
-          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
       - uses: github/codeql-action/upload-sarif@d6c5e1b140009be28958d3837ed3be3fb637d8c0 # v3
         with:
           sarif_file: semgrep.sarif


### PR DESCRIPTION
## Summary
- run Semgrep with built-in rules so workflow doesn't require Semgrep App token

## Testing
- `SKIP=pytest pre-commit run --files .github/workflows/semgrep.yml`


------
https://chatgpt.com/codex/tasks/task_e_68bc703e09a4832d802b7a1bc370ac1d