### PR TITLE
fix(codeql): specify python version and install dependencies

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,12 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:


### PR DESCRIPTION
## Summary
- pin Python 3.11 for CodeQL workflow
- install project dependencies before analysis

## Testing
- `pytest -m "not integration" -q` *(fails: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68bc70bae20c832da1bf7602ba177bc9