### PR TITLE
chore: approve dependabot PRs before auto-merge

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -21,6 +21,11 @@ jobs:
         uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.4.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Approve Dependabot PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Enable auto-merge for Dependabot PRs
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Summary
- approve Dependabot PRs prior to enabling auto-merge

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml` *(fails: Interrupted (KeyboardInterrupt))*

------
https://chatgpt.com/codex/tasks/task_e_68bc7104bea4832dba40488578643c89