### PR TITLE
fix: use public semgrep ruleset

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -36,7 +36,8 @@ jobs:
           persist-credentials: false
       - uses: semgrep/ci@v1
         with:
-          config: auto
+          # Use the community "ci" ruleset which does not require an auth token
+          config: p/ci
           generateSarif: true
       - uses: github/codeql-action/upload-sarif@d6c5e1b140009be28958d3837ed3be3fb637d8c0 # v3
         with:


### PR DESCRIPTION
## Summary
- avoid Semgrep `config: auto` which needs a token
- run CI with public `p/ci` ruleset

## Testing
- `pre-commit run flake8 --files .github/workflows/semgrep.yml`
- `pytest tests/test_safe_html_parser.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc72aae660832d8c5136d75a5c4688