### PR TITLE
fix(trivy): use buildx and update action

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -24,13 +24,17 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
       - name: Build Docker image
         run: |
-          docker build -f Dockerfile.ci \
-            -t ${{ github.repository }}:${{ github.sha }} .
+          docker buildx build -f Dockerfile.ci \
+            -t ${{ github.repository }}:${{ github.sha }} \
+            --load .
 
       - name: Run Trivy scan
-        uses: aquasecurity/trivy-action@f9424c10c36e288d5fa79bd3dfd1aeb2d6eae808 # 0.33.0
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
         with:
           image-ref: ${{ github.repository }}:${{ github.sha }}
           format: sarif


### PR DESCRIPTION
## Summary
- set up Docker Buildx and build with `buildx` to allow scanning
- update Trivy GitHub Action to 0.33.1

## Testing
- `SKIP=pytest pre-commit run --files .github/workflows/trivy.yml`

------
https://chatgpt.com/codex/tasks/task_e_68bc734ab918832d9c32deae120c11f7