### PR TITLE
chore: use lightweight deps for codeql

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements-ci.txt
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:


### PR DESCRIPTION
## Summary
- use `requirements-ci.txt` in CodeQL workflow to avoid heavy dependencies

## Testing
- `pre-commit run flake8 --files .github/workflows/codeql.yml`
- `pytest` *(interrupted: KeyboardInterrupt after 262 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7396a7c0832d885d1dc7c530eee1