### PR TITLE
ci: pin upload-sarif action

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Run Bandit
         run: bandit -r . -ll -ii -x tests,scripts,gptoss_check -f sarif -o bandit.sarif --exit-zero
       - name: Upload Bandit results
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ad2a4837011b42f6947b78d6417e7c253b1c504b # v3
         with:
           sarif_file: bandit.sarif
 


### PR DESCRIPTION
## Summary
- pin github/codeql-action/upload-sarif to a specific commit in Bandit workflow

## Testing
- `pre-commit run --files .github/workflows/bandit.yml` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68bc704ef554832d9bd0845b074deeab