### PR TITLE
chore: pin semgrep action to commit

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           persist-credentials: false
-      - uses: semgrep/ci@v1
+      - uses: returntocorp/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d # v1
         with:
           # Use the community "ci" ruleset which does not require an auth token
           config: p/ci


### PR DESCRIPTION
## Summary
- pin Semgrep GitHub Action to a specific commit for reproducible scans

## Testing
- `SKIP=pytest pre-commit run --files .github/workflows/semgrep.yml`
- `pytest` *(fails: KeyboardInterrupt after tests complete)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7a77c8c4832dbf32a9d7b86dd1a6