### PR TITLE
fix: grant actions read permission to bandit workflow

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -4,6 +4,7 @@
 name: Bandit
 
 permissions:
+  actions: read
   contents: read
   security-events: write
 


### PR DESCRIPTION
## Summary
- grant actions read permission to Bandit workflow so setup job can access GitHub actions

## Testing
- `SKIP=pytest pre-commit run --files .github/workflows/bandit.yml`

------
https://chatgpt.com/codex/tasks/task_e_68bc7e162f30832d9fa781bd2845954e