### PR TITLE
fix: ensure dependabot workflow uses pull_request_target

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,7 +1,7 @@
 name: Dependabot Auto Merge
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
 
 permissions:


### PR DESCRIPTION
## Summary
- run dependabot auto-merge workflow on `pull_request_target` to allow necessary permissions

## Testing
- `pre-commit run flake8 --files .github/workflows/dependabot.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc7de8bae4832dae1493647cca1b3a