### PR TITLE
fix: allow dependabot workflow to run on re-runs

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   dependabot:
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.actor == 'dependabot[bot]' || github.event.pull_request.user.login == 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0


### PR DESCRIPTION
## Summary
- ensure dependabot workflow runs even when actor is not dependabot by checking PR author

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml` *(interrupted)*
- `pytest` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7ff389f8832db5d6563e79d5a198