### PR TITLE
ci: skip SARIF upload when no semgrep results

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -39,6 +39,15 @@ jobs:
           # Use the community "ci" ruleset which does not require an auth token
           config: p/ci
           generateSarif: true
+      - name: Check for SARIF results
+        id: sarif_check
+        run: |
+          if [ -s semgrep.sarif ] && [ "$(jq '.runs[].results | length' semgrep.sarif)" -gt 0 ]; then
+            echo "upload=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "upload=false" >> "$GITHUB_OUTPUT"
+          fi
       - uses: github/codeql-action/upload-sarif@d6c5e1b140009be28958d3837ed3be3fb637d8c0 # v3
+        if: steps.sarif_check.outputs.upload == 'true'
         with:
           sarif_file: semgrep.sarif


### PR DESCRIPTION
## Summary
- avoid failing semgrep workflow by only uploading SARIF when findings exist

## Testing
- `pre-commit run --files .github/workflows/semgrep.yml` *(fails: Interrupted (KeyboardInterrupt))*

------
https://chatgpt.com/codex/tasks/task_e_68bc80ac8e44832db5408291e3305056