### PR TITLE
fix: skip trivy sarif upload on PR

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -44,6 +44,7 @@ jobs:
           exit-code: 0
 
       - name: Upload Trivy scan results to GitHub Security tab
+        if: github.event_name != 'pull_request'
         uses: github/codeql-action/upload-sarif@ad2a4837011b42f6947b78d6417e7c253b1c504b # v3
         with:
           sarif_file: trivy-results.sarif


### PR DESCRIPTION
## Summary
- skip SARIF upload step on pull_request events to avoid permission errors

## Testing
- `pre-commit run --files .github/workflows/trivy.yml` *(failed: Interrupted (KeyboardInterrupt))*

------
https://chatgpt.com/codex/tasks/task_e_68bc7ac144b0832d998d7840291b82d1