### PR TITLE
ci: skip SARIF upload when no bandit results

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -29,8 +29,17 @@ jobs:
         run: pip install bandit bandit-sarif-formatter
       - name: Run Bandit
         run: bandit -r . -ll -ii -x tests,scripts,gptoss_check -f sarif -o bandit.sarif --exit-zero
+      - name: Check for SARIF results
+        id: sarif_check
+        run: |
+          if [ -s bandit.sarif ] && [ "$(jq '.runs[].results | length' bandit.sarif)" -gt 0 ]; then
+            echo "upload=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "upload=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Upload Bandit results
         uses: github/codeql-action/upload-sarif@ad2a4837011b42f6947b78d6417e7c253b1c504b # v3
+        if: steps.sarif_check.outputs.upload == 'true'
         with:
           sarif_file: bandit.sarif
 


### PR DESCRIPTION
## Summary
- avoid uploading empty SARIF reports in Bandit workflow

## Testing
- `pre-commit run flake8 --files .github/workflows/bandit.yml`
- `pre-commit run --files .github/workflows/bandit.yml` *(fails: KeyboardInterrupt, pytest runtime)*
- `pytest test_stubs.py`

------
https://chatgpt.com/codex/tasks/task_e_68bc80bc440c832dbf61622ecc0d45d2