### PR TITLE
ci: add timeout for pytest in cpu workflow

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Run mypy
         run: mypy .
       - name: Run pytest
-        run: pytest
+        run: timeout 15m pytest
       - name: Stop mock server
         if: always()
         run: |


### PR DESCRIPTION
## Summary
- add 15m timeout for pytest to avoid hanging CI

## Testing
- `SKIP=pytest pre-commit run --files .github/workflows/ci_cpu.yml`


------
https://chatgpt.com/codex/tasks/task_e_68bc9638f20c832d857ff94eb615d2f5