### PR TITLE
ci: allow trivy scan to fail without stopping build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -140,6 +140,7 @@ jobs:
         run: mkdir -p /mnt/trivy-tmp
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8  # 0.33.1
+        continue-on-error: true
         env:
           TMPDIR: /mnt/trivy-tmp
           TRIVY_CACHE_DIR: /mnt/trivy-cache


### PR DESCRIPTION
## Summary
- prevent Trivy vulnerabilities from failing docker-publish workflow

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml` *(fails: interrupted by timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68bc960f3758832d8b817e40ce44c777