### PR TITLE
ci: increase gpt-oss container wait time

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           # The model can take a while to load, especially on fresh runners
           # Allow extra time for the container to become ready
-          for i in {1..600}; do
+          for i in {1..1200}; do
             if curl -sf http://127.0.0.1:8000/v1/models; then
               exit 0
             fi


### PR DESCRIPTION
## Summary
- allow up to 20 minutes for the local vLLM container to become ready

## Testing
- `yamllint .github/workflows/gptoss_review.yml`
- `pytest` *(interrupted: KeyboardInterrupt after tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9656e060832db0ca3935c709fb08