### PR TITLE
fix: remove redundant gh installation

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -14,11 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-      - name: Install GitHub CLI
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gh
-          gh --version
+      - name: Check GitHub CLI
+        run: gh --version
       - name: Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.4.0


### PR DESCRIPTION
## Summary
- clean up dependabot auto-merge workflow to use pre-installed gh CLI

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml` *(fails: Interrupted (KeyboardInterrupt))*

------
https://chatgpt.com/codex/tasks/task_e_68bc9acc8f2c832dab6fcb44ca5d26d9