### PR TITLE
fix: handle failed dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -28,7 +28,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Enable auto-merge for Dependabot PRs
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL" || echo "Auto-merge failed"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- avoid failing Dependabot workflow when auto-merge cannot be enabled

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bca13307ac832d8e38488b64d4824d