### PR TITLE
Fix Semgrep GitHub Action workflow

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -39,5 +39,7 @@ jobs:
           # Use the community "ci" ruleset which does not require an auth token
           config: p/ci
           generateSarif: true
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@ad2a4837011b42f6947b78d6417e7c253b1c504b # v3
         with:
           sarif_file: semgrep.sarif


### PR DESCRIPTION
## Summary
- fix Semgrep workflow
- upload SARIF results to code scanning

## Testing
- `pre-commit run --hook-stage manual --files .github/workflows/semgrep.yml`
- `pytest -q` *(fails: KeyboardInterrupt after completion; 125 passed, 4 skipped, 17 deselected)*

------
https://chatgpt.com/codex/tasks/task_e_68bca1239d7c832db017a57b4f626adb