### PR TITLE
ci: install jq for bandit workflow

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -25,6 +25,8 @@ jobs:
         uses: actions/setup-python@0a48b7bf1eabc3ec69474a3854c4f0a36e029be2 # v5
         with:
           python-version: '3.11'
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
       - name: Install Bandit
         run: pip install bandit bandit-sarif-formatter
       - name: Run Bandit


### PR DESCRIPTION
## Summary
- install jq before running Bandit so the SARIF check works on Ubuntu 24.04 runners

## Testing
- `pre-commit run --files .github/workflows/bandit.yml`

------
https://chatgpt.com/codex/tasks/task_e_68bca4f1cf24832daf42bdb20bb391ea