### PR TITLE
Fix Bandit workflow for forked PRs

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -34,14 +34,14 @@ jobs:
       - name: Check for SARIF results
         id: sarif_check
         run: |
-          if [ -s bandit.sarif ] && [ "$(jq '.runs[].results | length' bandit.sarif)" -gt 0 ]; then
+          if [ -s bandit.sarif ] && [ "$(jq '[.runs[].results] | flatten | length' bandit.sarif)" -gt 0 ]; then
             echo "upload=true" >> "$GITHUB_OUTPUT"
           else
             echo "upload=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Upload Bandit results
         uses: github/codeql-action/upload-sarif@ad2a4837011b42f6947b78d6417e7c253b1c504b # v3
-        if: steps.sarif_check.outputs.upload == 'true'
+        if: steps.sarif_check.outputs.upload == 'true' && github.event_name != 'pull_request'
         with:
           sarif_file: bandit.sarif
 


### PR DESCRIPTION
## Summary
- improve SARIF result check with robust jq expression
- skip SARIF upload for pull_request events to avoid permission errors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bca73decc0832d895a8c607f4b857b