### PR TITLE
fix: install gh cli in dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Install GitHub CLI
         run: |
+          sudo apt-get update
+          sudo apt-get install -y gh
           gh --version
       - name: Dependabot metadata
         id: metadata


### PR DESCRIPTION
## Summary
- install GitHub CLI before using it in Dependabot auto-merge workflow

## Testing
- `SKIP=pytest pre-commit run --files .github/workflows/dependabot.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bca72b05b8832d9112866735d0d45b