### PR TITLE
fix: update setup-python reference

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
       - name: Set up Python
-        uses: actions/setup-python@0a48b7bf1eabc3ec69474a3854c4f0a36e029be2 # v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
       - name: Install jq


### PR DESCRIPTION
## Summary
- pin `actions/setup-python` to an existing v5.6.0 commit so Bandit workflow can run

## Testing
- `pre-commit run --files .github/workflows/bandit.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bca9491224832da37bcbd35bcd6715