### PR TITLE
fix: allow artifact upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 permissions:
   contents: read
+  actions: write
 
 # If a job fails with a temporary runner error, rerun the workflow.
 # Self-hosted runners are also supported. When contacting GitHub Support


### PR DESCRIPTION
## Summary
- grant `actions: write` permission so CI can upload artifacts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd601c6dd8832db71fdb3928400bb8