### PR TITLE
chore: allow dependabot code execution

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    insecure-external-code-execution: allow
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary
- allow Dependabot to run pip-compile

## Testing
- `pre-commit run --files .github/dependabot.yml`

------
https://chatgpt.com/codex/tasks/task_e_68bd60419608832d94304be5cd125d0e