### PR TITLE
ci: fail on bandit issues

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -30,7 +30,9 @@ jobs:
       - name: Install Bandit
         run: pip install bandit bandit-sarif-formatter
       - name: Run Bandit
-        run: bandit -r . -ll -ii -x tests,scripts,gptoss_check -f sarif -o bandit.sarif --exit-zero
+        id: run_bandit
+        continue-on-error: true
+        run: bandit -r . -ll -ii -x tests,scripts,gptoss_check -f sarif -o bandit.sarif
       - name: Check for SARIF results
         id: sarif_check
         run: |
@@ -44,4 +46,7 @@ jobs:
         if: steps.sarif_check.outputs.upload == 'true' && github.event_name != 'pull_request'
         with:
           sarif_file: bandit.sarif
+      - name: Fail if Bandit failed
+        if: steps.run_bandit.outcome == 'failure'
+        run: exit 1
 


### PR DESCRIPTION
## Summary
- fail workflow when Bandit finds issues
- ensure SARIF is uploaded before exiting

## Testing
- `pre-commit run --files .github/workflows/bandit.yml`


------
https://chatgpt.com/codex/tasks/task_e_68bd60082528832d8b09738a290045b4