### PR TITLE
fix: add token to dependency graph submission

### DIFF
--- a/.github/workflows/dependency-graph/auto-submission.yml
+++ b/.github/workflows/dependency-graph/auto-submission.yml
@@ -18,3 +18,5 @@ jobs:
           fetch-depth: 0
       - name: Component detection
         uses: advanced-security/component-detection-dependency-submission-action@d433c2f467e149a8009c8fbce92cc708ed15ef7b # v0.1.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- provide GITHUB_TOKEN to component detection action

## Testing
- `pre-commit run --files .github/workflows/dependency-graph/auto-submission.yml` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68bd5ff4b72c832d93df8830b6eff01c