### PR TITLE
ci: skip docker publish without credentials

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   build:
+    if: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- skip Docker image publishing when Docker Hub credentials are not provided

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml`


------
https://chatgpt.com/codex/tasks/task_e_68bd5fee54d8832da581c32699f42c96