### PR TITLE
fix: update release drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize]
     branches:
       - main
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update release draft
-        # release-drafter v6.1.0
-        uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5  # yamllint disable-line rule:line-length
+        # release-drafter v6
+        uses: release-drafter/release-drafter@v6
         with:
           config-name: release-drafter.yml
         env:


### PR DESCRIPTION
## Summary
- use pull_request trigger instead of pull_request_target
- update Release Drafter action to `v6`

## Testing
- `pre-commit run --files .github/workflows/release-drafter.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd6053d780832dae7f4c6177f61e77