### PR TITLE
Fix SARIF results check in Semgrep workflow

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Check for SARIF results
         id: sarif_check
         run: |
-          if [ -s semgrep.sarif ] && [ "$(jq '.runs[].results | length' semgrep.sarif)" -gt 0 ]; then
+          if [ -s semgrep.sarif ] && [ "$(jq '[.runs[].results | length] | add' semgrep.sarif)" -gt 0 ]; then
             echo "upload=true" >> "$GITHUB_OUTPUT"
           else
             echo "upload=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- ensure SARIF upload step sums results across runs

## Testing
- `pre-commit run --files .github/workflows/semgrep.yml`
- `pytest`
- `yamllint .github/workflows/semgrep.yml` *(fails: missing document start, bracket spacing, line length)*

------
https://chatgpt.com/codex/tasks/task_e_68bd605f0108832db4c773c6b6f1d432