### PR TITLE
ci: run flake8 in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,5 +31,9 @@ jobs:
         run: python -m pip install --upgrade pip
       - name: Install dependencies
         run: python -m pip install -r requirements-ci.txt
+      - name: Install project
+        run: pip install -e .
+      - name: Run flake8
+        run: flake8 .
       - name: Run tests
         run: pytest --maxfail=1 --disable-warnings -q


### PR DESCRIPTION
## Summary
- install project in tests workflow
- add flake8 step before tests

## Testing
- `pre-commit run --files .github/workflows/tests.yml`
- `flake8 .`
- `pytest --maxfail=1 --disable-warnings -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd6067f718832da6aa96ba6bccf842