### PR TITLE
fix: fail build on Trivy vulnerabilities

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -41,7 +41,8 @@ jobs:
           output: trivy-results.sarif
           severity: CRITICAL,HIGH
           scan-type: image
-          exit-code: 0
+          # Fail the workflow when vulnerabilities of the specified severity are found
+          exit-code: 1
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
## Summary
- enforce non-zero exit when Trivy finds high/critical vulnerabilities

## Testing
- `pre-commit run --files .github/workflows/trivy.yml`

------
https://chatgpt.com/codex/tasks/task_e_68bd60721570832db6179c57acff55dc