### PR TITLE
ci: drop python 3.12 from cpu workflow

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11']
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5


### PR DESCRIPTION
## Summary
- drop unsupported Python 3.12 from CI CPU workflow matrix

## Testing
- `flake8 .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd6026f76c832d8eeddef8fa50ea04