### PR TITLE
ci: use GITHUB_TOKEN for gh cli

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -25,10 +25,10 @@ jobs:
         run: gh pr review --approve "$PR_URL" || echo "PR already approved"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Enable auto-merge for Dependabot PRs
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: gh pr merge --auto --squash "$PR_URL" || echo "Auto-merge failed"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- ensure gh commands use GITHUB_TOKEN in dependabot workflow

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml`

------
https://chatgpt.com/codex/tasks/task_e_68bd66c5d498832d8f404b96f98f26d7