### PR TITLE
feat: add concurrency for docker publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,6 +13,10 @@ on:
     - cron: '0 0 * * 0'
   workflow_dispatch:
 
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     env:


### PR DESCRIPTION
## Summary
- add workflow concurrency to avoid overlapping docker publish runs

## Testing
- `python -m flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd67482880832d860c2c36545371e5