### PR TITLE
fix: sanitize docker publish concurrency

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: docker-publish-${{ github.ref }}
+  group: docker-publish-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- use `github.ref_name` for docker-publish concurrency group

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml`


------
https://chatgpt.com/codex/tasks/task_e_68bd6864e760832d8c64fb3e4eb20076