### PR TITLE
fix: sanitize docker publish concurrency

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: docker-publish-${{ github.ref_name }}
+  group: docker-publish-${{ github.ref_name && github.ref_name != '' && replace(github.ref_name, '[^a-zA-Z0-9_-]', '-') || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- sanitize concurrency group for docker publish workflow to remove invalid characters

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd69e886e0832dbf1e3e82996592e6