### PR TITLE
fix docker publish concurrency

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: docker-publish-${{ github.ref_name && github.ref_name != '' && replace(github.ref_name, '[^a-zA-Z0-9_-]', '-') || github.run_id }}
+  group: "docker-publish-${{ github.ref_name && github.ref_name != '' && replace(github.ref_name, '[^a-zA-Z0-9_-]', '-') || github.run_id }}"
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- fix concurrency group name in docker publish workflow

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml`

------
https://chatgpt.com/codex/tasks/task_e_68bd6b409598832daa3a40488092b34e