### PR TITLE
Fix concurrency group in docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: "docker-publish-${{ github.ref_name && github.ref_name != '' && replace(github.ref_name, '[^a-zA-Z0-9_-]', '-') || github.run_id }}"
+  group: docker-publish-${{ github.ref_name && github.ref_name != '' && replace(github.ref_name, '[^a-zA-Z0-9_-]', '-') || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- fix concurrency group so branch name falls back to run ID without quotes

## Testing
- `SKIP=pytest pre-commit run --files .github/workflows/docker-publish.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd6cb42894832dbd0d22e743e39ea5