### PR TITLE
fix: setup GitHub CLI for dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - name: Check GitHub CLI
-        run: gh --version
+      - name: Set up GitHub CLI
+        uses: cli/cli@89512590addc159fff0f13acca811d803d592ff9 # v2.78.0
       - name: Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.4.0


### PR DESCRIPTION
## Summary
- ensure Dependabot workflow installs GitHub CLI instead of checking presence

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd6cb9f960832d8a418b7152bb5001