### PR TITLE
Simplify docker publish concurrency group

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,9 +13,9 @@ on:
     - cron: '0 0 * * 0'
   workflow_dispatch:
 
-concurrency:
-  group: docker-publish-${{ github.ref_name && github.ref_name != '' && replace(github.ref_name, '[^a-zA-Z0-9_-]', '-') || github.run_id }}
-  cancel-in-progress: true
+  concurrency:
+    group: docker-publish-${{ github.ref_name || github.run_id }}
+    cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- streamline concurrency group expression in docker publish workflow

## Testing
- `pytest -q` (193 passed, 4 skipped, 17 deselected)


------
https://chatgpt.com/codex/tasks/task_e_68bd6e19127c832d87fc3d70a9b6f4db