### PR TITLE
fix: correct concurrency placement in docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,9 +13,9 @@ on:
     - cron: '0 0 * * 0'
   workflow_dispatch:
 
-  concurrency:
-    group: docker-publish-${{ github.ref_name || github.run_id }}
-    cancel-in-progress: true
+concurrency:
+  group: docker-publish-${{ github.ref_name || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- fix docker-publish workflow concurrency placement

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml` *(fails: Interrupted (^C))*
- `pytest` *(fails: Interrupted (^C))*

------
https://chatgpt.com/codex/tasks/task_e_68bd6f438750832daf05dcc393747c20