### PR TITLE
fix: use GH_TOKEN in dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -23,10 +23,10 @@ jobs:
         run: gh pr review --approve "$PR_URL" || echo "PR already approved"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Enable auto-merge for Dependabot PRs
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: gh pr merge --auto --squash "$PR_URL" || echo "Auto-merge failed"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- use GH_TOKEN so gh CLI can authorize in Dependabot auto-merge workflow

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml`


------
https://chatgpt.com/codex/tasks/task_e_68bd6f4ff5c4832d81387e96b29f485a