### PR TITLE
fix: simplify docker publish concurrency

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: docker-publish-${{ github.ref_name || github.run_id }}
+  group: docker-publish-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- use a simpler concurrency group for docker publish workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd702a7508832d9cb67e907677024a