### PR TITLE
fix: update Dependabot script token error message

### DIFF
--- a/scripts/run_dependabot.sh
+++ b/scripts/run_dependabot.sh
@@ -9,7 +9,7 @@ repo="${GITHUB_REPOSITORY}"
 
 token="${TOKEN:-${GITHUB_TOKEN:-}}"
 if [[ -z "${token}" ]]; then
-    echo "TOKEN or GITHUB_TOKEN is not set; export a PAT with repo and security_events scopes" >&2
+    echo "TOKEN is not set; export a PAT with repo and security_events scopes" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- align Dependabot trigger script error message with test expectations

## Testing
- `pytest tests/test_run_dependabot_script.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd7234840c832dbb7497cb378d4852