### PR TITLE
chore: simplify dependabot token check

### DIFF
--- a/scripts/run_dependabot.sh
+++ b/scripts/run_dependabot.sh
@@ -7,7 +7,7 @@ if [[ -z "${GITHUB_REPOSITORY:-}" ]]; then
 fi
 repo="${GITHUB_REPOSITORY}"
 
-token="${TOKEN:-${GITHUB_TOKEN:-}}"
+token="${TOKEN:-}"
 if [[ -z "${token}" ]]; then
     echo "TOKEN is not set; export a PAT with repo and security_events scopes" >&2
     exit 1


### PR DESCRIPTION
## Summary
- use PAT-only token check in Dependabot runner
- keep error message expected by tests

## Testing
- `pytest tests/test_run_dependabot_script.py::test_run_dependabot_requires_token -q`
- `GITHUB_REPOSITORY=foo/bar bash scripts/run_dependabot.sh 2>&1 || true`


------
https://chatgpt.com/codex/tasks/task_e_68bd7361b8bc832dbcebadae9b41c90b