### PR TITLE
fix: sanitize docker publish concurrency group

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: docker-publish-${{ github.ref }}
+  group: docker-publish-${{ github.ref_name || github.sha }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- sanitize docker publish concurrency group

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml`

------
https://chatgpt.com/codex/tasks/task_e_68bd7688adb0832d96f374504fae0907