### PR TITLE
fix: correct Trivy failure condition

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -60,7 +60,7 @@ jobs:
           path: trivy-results.sarif
 
       - name: Fail if vulnerabilities found
-        if: steps.trivy.outcome == 'failure'
+        if: ${{ steps.trivy.conclusion == 'failure' }}
         run: exit 1
 
       - name: Cleanup buildx


### PR DESCRIPTION
## Summary
- ensure Trivy workflow fails when scan detects vulnerabilities

## Testing
- `SKIP=pytest pre-commit run --files .github/workflows/trivy.yml`
- `pytest` *(прошло 99 тестов)*

------
https://chatgpt.com/codex/tasks/task_e_68bd79d9371c832d97c2ecb9aa6d438a