### PR TITLE
fix: correct conditional in Bandit workflow

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -47,6 +47,6 @@ jobs:
         with:
           sarif_file: bandit.sarif
       - name: Fail if Bandit failed
-        if: steps.run_bandit.outcome == 'failure'
+        if: ${{ steps.run_bandit.outcome == 'failure' }}
         run: exit 1
 


### PR DESCRIPTION
## Summary
- ensure Bandit workflow fails only on actual Bandit errors

## Testing
- `pre-commit run --files .github/workflows/bandit.yml`


------
https://chatgpt.com/codex/tasks/task_e_68bd79dddfd8832dbcc1abf181ac644b