### PR TITLE
Пропустить шаги отчёта pip-audit при сбое аудита

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,10 @@ jobs:
         run: |
           pip-audit --strict -f json -o pip-audit.json
       - name: Check pip-audit report exists
-        if: always()
+        if: steps.audit.conclusion == 'success'
         run: test -f /mnt/pip-audit.json
       - name: Upload pip-audit report
-        if: always()
+        if: steps.audit.conclusion == 'success'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pip-audit-report


### PR DESCRIPTION
## Summary
- пропуск проверки и загрузки отчёта pip-audit, если шаг аудита завершился с ошибкой

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -q` *(прервано)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7a885a10832d89135dc68c5dd1f0