### PR TITLE
ci: pin vllm image in gptoss review workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Start vLLM container
         run: |
           docker run -d --rm --name gptoss -p 127.0.0.1:8000:8000 \
-            vllm/vllm-openai:latest \
+            vllm/vllm-openai:v0.5.1 \
             --model "${{ vars.LLM_MODEL || 'Qwen/Qwen2.5-Coder-1.5B-Instruct' }}" \
             --trust-remote-code \
             --device cpu


### PR DESCRIPTION
## Summary
- pin `vllm/vllm-openai` image to v0.5.1 for stable GPT-OSS review workflow

## Testing
- `pre-commit run --files .github/workflows/gptoss_review.yml`

------
https://chatgpt.com/codex/tasks/task_e_68bd91425ce8832d8344a337025be4c6