### PR TITLE
Исправить Bandit конфигурацию и тестовую аннотацию

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,4 +1,4 @@
 [bandit]
-exclude = */tests/*,*/scripts/*,*/gptoss_check/*
+exclude = tests/*,scripts/*,gptoss_check/*
 targets = .
 recursive = True

--- a/tests/test_trade_manager_routes.py
+++ b/tests/test_trade_manager_routes.py
@@ -155,7 +155,13 @@ def test_resolve_host_handles_empty_and_localhost(monkeypatch):
     assert tm._resolve_host() == "127.0.0.1"
 
 
-@pytest.mark.parametrize("value", ["0.0.0.0", "127.0.0.2", "8.8.8.8"])
+# Bandit: B104 is triggered by the "0.0.0.0" value in this test, but it's safe here
+# because we're verifying that the TradeManager rejects binding to public interfaces.
+# Adding "nosec" ensures Bandit ignores this intentional usage.
+@pytest.mark.parametrize(
+    "value",
+    ["0.0.0.0", "127.0.0.2", "8.8.8.8"],  # nosec B104
+)
 def test_resolve_host_rejects_public_addresses(monkeypatch, value):
     tm, _, _ = _setup_module(monkeypatch)
     monkeypatch.setenv("HOST", value)


### PR DESCRIPTION
## Summary
- скорректированы исключения в `.bandit`
- добавлен `# nosec B104` в параметризацию теста `test_trade_manager_routes`

## Testing
- `pre-commit run --files .bandit tests/test_trade_manager_routes.py`
- `bandit -r . -ll -ii -x tests,scripts,gptoss_check`


------
https://chatgpt.com/codex/tasks/task_e_68bd9120913c832dacf47302f77ea7aa