### PR TITLE
Исправление CI: пропуск отчёта pip-audit при сбое

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,10 @@ jobs:
         run: |
           pip-audit --strict -f json -o pip-audit.json
       - name: Check pip-audit report exists
-        if: steps.audit.conclusion == 'success'
+        if: steps.audit.outcome == 'success'
         run: test -f /mnt/pip-audit.json
       - name: Upload pip-audit report
-        if: steps.audit.conclusion == 'success'
+        if: steps.audit.outcome == 'success'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pip-audit-report


### PR DESCRIPTION
## Summary
- ограничил шаги проверки и загрузки отчёта pip-audit условием успешного выполнения аудита

## Testing
- `pre-commit run --files trading_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd9131153c832da990f9ee72ef476e