### PR TITLE
ci: add csrf secret to cpu workflow

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -10,6 +10,7 @@ env:
   GPT_OSS_API: http://127.0.0.1:8009
   GPT_OSS_TIMEOUT: 5
   TEST_MODE: "1"
+  CSRF_SECRET: testsecret
 
 jobs:
   lint-type-test:


### PR DESCRIPTION
## Summary
- set CSRF_SECRET in CI CPU workflow

## Testing
- `flake8 .`
- `pytest`
- `mypy .` *(fails: Interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bd917819b4832d837bb7c357e2b682