### PR TITLE
chore: ignore unfixed vulnerabilities in Trivy scan

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -43,6 +43,7 @@ jobs:
           output: trivy-results.sarif
           severity: CRITICAL,HIGH
           scan-type: image
+          ignore-unfixed: true
           # Fail the workflow when vulnerabilities of the specified severity are found
           exit-code: 1
 


### PR DESCRIPTION
## Summary
- игнорирование не исправленных уязвимостей при сканировании Trivy

## Testing
- `pre-commit run flake8 --files .github/workflows/trivy.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd92272e58832daea6ebd712bdcf17