### PR TITLE
fix: setup python for docker publish healthcheck

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -181,6 +181,10 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5
         with:
           persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: '3.11'
       - name: Install dependencies
         run: python -m pip install -r requirements-healthcheck.txt
       - name: Start data handler service


### PR DESCRIPTION
## Summary
- set up Python 3.11 for healthcheck job in Docker publish workflow

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68bd949c6458832d9980b5d236fe3cb9