### PR TITLE
fix: sanitize docker publish concurrency group

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,7 +14,13 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: docker-publish-${{ github.ref_name || github.sha }}
+  group: >-
+    docker-publish-${{
+      github.ref_name &&
+      github.ref_name != '' &&
+      replace(github.ref_name, '[^a-zA-Z0-9_-]', '-') ||
+      github.run_id
+    }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- sanitize docker publish concurrency group to remove unsupported characters and fall back to run id

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml`


------
https://chatgpt.com/codex/tasks/task_e_68bd966e0118832db487458072370fbc