### PR TITLE
Declare colorama version to satisfy numba checks

### DIFF
--- a/colorama/__init__.py
+++ b/colorama/__init__.py
@@ -1,13 +1,22 @@
 """Minimal colorama stub for tests."""
 
+# Provide a version attribute so libraries that perform version checks (e.g.
+# `numba`) treat this stub as sufficiently recent.  The value matches a widely
+# used colorama release.
+__version__ = "0.4.6"
+
+
 class _Ansi:
     def __getattr__(self, name):  # pragma: no cover - trivial
         return ""
 
+
 Fore = _Ansi()
 Style = _Ansi()
+
 
 def init(*args, **kwargs):  # pragma: no cover - trivial
     return None
 
-__all__ = ["Fore", "Style", "init"]
+
+__all__ = ["Fore", "Style", "init", "__version__"]


### PR DESCRIPTION
## Summary
- add `__version__` to colorama stub so libraries treat it as recent

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd9a9e61d0832d8b37ed7d2fb7b22b