### PR TITLE
Fix semgrep workflow by installing jq

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -39,6 +39,8 @@ jobs:
           # Use the community "ci" ruleset which does not require an auth token
           config: p/ci
           generateSarif: true
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
       - name: Check for SARIF results
         id: sarif_check
         run: |


### PR DESCRIPTION
## Summary
- install jq before checking SARIF file in semgrep workflow

## Testing
- `pre-commit run --files .github/workflows/semgrep.yml`

------
https://chatgpt.com/codex/tasks/task_e_68bd9ad2ab84832d9dac4c851a6bb0bf