### PR TITLE
fix: remove jq installation from Bandit workflow

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -25,8 +25,6 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
-      - name: Install jq
-        run: sudo apt-get update && sudo apt-get install -y jq
       - name: Install Bandit
         run: pip install bandit bandit-sarif-formatter
       - name: Run Bandit


### PR DESCRIPTION
## Summary
- remove redundant jq installation step from Bandit workflow

## Testing
- `./scripts/install-test-deps.sh`
- `pre-commit run --files .github/workflows/bandit.yml`


------
https://chatgpt.com/codex/tasks/task_e_68bd99ff5d24832dafd8ac8bcf56e687