### PR TITLE
Fix mypy step in CPU CI workflow

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Run flake8
         run: flake8 .
       - name: Run mypy
-        run: mypy .
+        run: mypy --no-site-packages .
       - name: Run pytest
         run: timeout 15m pytest
       - name: Stop mock server


### PR DESCRIPTION
## Summary
- ignore site-packages during mypy run in CPU CI workflow

## Testing
- `flake8 .`
- `mypy --no-site-packages .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd9a12220c832d9ce244c5cea5a007