### PR TITLE
chore: fix release drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
     branches:
       - main


### PR DESCRIPTION
## Summary
- fix release drafter workflow to use pull_request_target

## Testing
- `pre-commit run --files .github/workflows/release-drafter.yml`


------
https://chatgpt.com/codex/tasks/task_e_68bd9aaa4b6c832db62c1aa4833f26ea