### PR TITLE
chore: lighten CI requirements

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -27,4 +27,3 @@ hypothesis>=6.90.0
 numpy==1.26.4
 pip-audit==2.9.0
 pybit>=5.7.0
-torch>=2.2.0; python_version<'3.12'


### PR DESCRIPTION
## Summary
- remove heavy torch dep from CI requirements to avoid install failures

## Testing
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd9ac69df4832daf7785162f8b0b6e