### PR TITLE
fix: pin checkout action in dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -30,7 +30,7 @@ jobs:
       # the head of the pull request.  The head ref is safe to use here
       # because the job is scoped to Dependabot-created pull requests.
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 


### PR DESCRIPTION
## Summary
- pin actions/checkout to a specific commit in dependabot workflow

## Testing
- `yamllint .github/workflows/dependabot.yml` *(fails: line-length issues and other style warnings)*
- `pytest -m "not integration" -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd9b92d8f0832da7b0ad0ab9348988