### PR TITLE
fix: adjust docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,13 +14,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: >-
-    docker-publish-${{
-      github.ref_name &&
-      github.ref_name != '' &&
-      replace(github.ref_name, '[^a-zA-Z0-9_-]', '-') ||
-      github.run_id
-    }}
+  group: docker-publish-${{ github.ref_name != '' && github.ref_name || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -28,7 +22,6 @@ jobs:
     env:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-    if: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- remove unsupported replace function and simplify concurrency group
- drop job-level secret check to satisfy actionlint

## Testing
- `/root/.local/share/mise/installs/go/1.24.3/bin/actionlint .github/workflows/docker-publish.yml`


------
https://chatgpt.com/codex/tasks/task_e_68bd9bf14f64832da039fcde06594ee1