### PR TITLE
Упростить тест запуска Dependabot

### DIFF
--- a/tests/test_run_dependabot_script.py
+++ b/tests/test_run_dependabot_script.py
@@ -1,7 +1,6 @@
 import os
 import subprocess
 from pathlib import Path
-from unittest.mock import Mock, patch
 
 
 def test_run_dependabot_requires_token():
@@ -10,16 +9,9 @@ def test_run_dependabot_requires_token():
     env["GITHUB_REPOSITORY"] = "owner/repo"
     env.pop("TOKEN", None)
 
-    mock_proc = Mock(
-        returncode=1,
-        stderr="TOKEN is not set; export a PAT with repo and security_events scopes\n",
-    )
-    with patch("subprocess.run", return_value=mock_proc) as mock_run:
-        proc = subprocess.run(
-            ["bash", str(script)], capture_output=True, text=True, env=env
-        )
-
-    mock_run.assert_called_once_with(
+    proc = subprocess.run(
         ["bash", str(script)], capture_output=True, text=True, env=env
     )
+
+    assert proc.returncode == 1
     assert "TOKEN is not set" in proc.stderr


### PR DESCRIPTION
## Summary
- запустить run_dependabot.sh напрямую в тесте

## Testing
- `pytest tests/test_run_dependabot_script.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bd9ee90ff8832d84846c6ed85728ca