### PR TITLE
fix: repair CI CPU workflow

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -19,6 +19,9 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11']
     steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
+      - name: Set up Python
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Get pip cache dir


### PR DESCRIPTION
## Summary
- restore setup steps for CI CPU workflow

## Testing
- `pre-commit run flake8 --files .github/workflows/ci_cpu.yml`
- `pytest tests/test_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68bda327f944832d946bdcb0f1246496