### PR TITLE
fix: update tests workflow for CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,9 @@ jobs:
     env:
       TEST_MODE: "1"
     steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Get pip cache dir


### PR DESCRIPTION
## Summary
- add checkout and Python setup steps to tests CI workflow
- ensure dependencies and tests run in CI

## Testing
- `flake8 .`
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_68bda3313db8832db0e25423618f0c77