### PR TITLE
fix: dependency graph auto-submission workflow

### DIFF
--- a/.github/workflows/dependency-graph/auto-submission.yml
+++ b/.github/workflows/dependency-graph/auto-submission.yml
@@ -17,6 +17,4 @@ jobs:
         with:
           fetch-depth: 0
       - name: Component detection
-        uses: advanced-security/component-detection-dependency-submission-action@v0.1.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        uses: advanced-security/component-detection-dependency-submission-action@d433c2f467e149a8009c8fbce92cc708ed15ef7b # v0.1.0


### PR DESCRIPTION
## Summary
- fix GitHub Actions dependency graph auto submission workflow by removing unsupported token input and pinning action version

## Testing
- `pre-commit run --files .github/workflows/dependency-graph/auto-submission.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bda51d1ba0832db02a8cc6f366bf76