### PR TITLE
fix: allow dependabot workflow to automerge

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,7 +1,7 @@
 name: Dependabot Auto Merge
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
 
 permissions:


### PR DESCRIPTION
## Summary
- trigger dependabot automerge job with pull_request_target to provide write permissions

## Testing
- `pytest -m "not integration" -q`

------
https://chatgpt.com/codex/tasks/task_e_68bda7615edc832dab3546180ed83132