### PR TITLE
fix: include data_handler package in build config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,10 @@ classifiers = ["Programming Language :: Python :: 3"]
 dependencies = ["flask>=3.0.2"]
 
 [tool.setuptools]
-packages = ["bot", "services"]
+packages = ["bot", "services", "data_handler"]
 py-modules = [
   "cache",
   "config",
-  "data_handler",
   "gpt_client",
   "http_client",
   "model_builder",


### PR DESCRIPTION
## Summary
- include `data_handler` package for setuptools and drop invalid module entry

## Testing
- `pre-commit run --files pyproject.toml`

------
https://chatgpt.com/codex/tasks/task_e_68bda73540dc832da3f9b578b5502cf2