### PR TITLE
chore(ci): reuse setup-env in cpu workflow

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -1,16 +1,21 @@
 name: CI CPU
 
+permissions:
+  contents: read
+
 on:
   push:
     paths-ignore:
       - 'docs/**'
   pull_request:
+  workflow_dispatch:
 
 env:
   GPT_OSS_API: http://127.0.0.1:8009
   GPT_OSS_TIMEOUT: 5
   TEST_MODE: "1"
   CSRF_SECRET: testsecret
+  PYTHONPYCACHEPREFIX: /mnt/pycache
 
 jobs:
   lint-type-test:
@@ -18,24 +23,13 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11']
+        device: [cpu]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
-      - name: Set up Python
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+      - uses: ./.github/actions/setup-env
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Get pip cache dir
-        id: pip-cache
-        run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
-      - name: Cache pip wheels
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements-ci.txt') }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-ci.txt
+          device: ${{ matrix.device }}
       - name: Start mock server
         run: |
           python - <<'PY' &
@@ -70,6 +64,9 @@ jobs:
           path: flake8.log
       - name: Run mypy
         run: mypy --no-site-packages .
+      - name: Remove test caches
+        if: always()
+        uses: ./.github/actions/clear-test-caches
       - name: Run pytest
         run: |
           set -o pipefail
@@ -91,3 +88,6 @@ jobs:
             rm server.pid
             test ! -f server.pid
           fi
+      - name: Cleanup buildx
+        if: always()
+        run: docker buildx prune -af || true


### PR DESCRIPTION
## Summary
- reuse shared setup-env composite action in CI CPU workflow
- clear caches and cleanup buildx

## Testing
- `pre-commit run --files .github/workflows/ci_cpu.yml` (fails: ModuleNotFoundError: No module named 'httpx')
- `SKIP=pytest pre-commit run --files .github/workflows/ci_cpu.yml`

------
https://chatgpt.com/codex/tasks/task_e_68bdaa4f40e0832d9a912467f88d35ef