### PR TITLE
Ensure Dependabot workflow tests PR code

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -24,6 +24,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout code
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       # Set up a Python environment that matches the main CI.  This
       # installs the appropriate Python version and device specific


### PR DESCRIPTION
## Summary
- checkout Dependabot PR head commit so tests run on the correct code

## Testing
- `pytest -m "not integration" -q` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68bdab2cacb4832d9c803269f988ec14