### PR TITLE
fix: корректный checkout кода в Dependabot

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -25,7 +25,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
 
       # Set up a Python environment that matches the main CI.  This
       # installs the appropriate Python version and device specific


### PR DESCRIPTION
## Summary
- корректный checkout кода в Dependabot workflow

## Testing
- `pytest -m "not integration" -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68bdacaf3704832da7c5d458e9932dac