### PR TITLE
feat: enable pip detector for dependency graph

### DIFF
--- a/.github/workflows/dependency-graph/auto-submission.yml
+++ b/.github/workflows/dependency-graph/auto-submission.yml
@@ -18,4 +18,6 @@ jobs:
           fetch-depth: 0
       - name: Component detection
         uses: advanced-security/component-detection-dependency-submission-action@c7cb2bbc9360d8a011e4fac7dc542c689415d62f # c7cb2b
+        with:
+          detectorArgs: Pip=EnableIfDefaultOff
 


### PR DESCRIPTION
## Summary
- enable pip detector in dependency graph auto submission workflow

## Testing
- `pre-commit run --files .github/workflows/dependency-graph/auto-submission.yml` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68bdad155af0832db469a3c360c3bc9a