### PR TITLE
fix dependency graph workflow

### DIFF
--- a/.github/workflows/dependency-graph/auto-submission.yml
+++ b/.github/workflows/dependency-graph/auto-submission.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Component detection
-        uses: advanced-security/component-detection-dependency-submission-action@c7cb2bbc9360d8a011e4fac7dc542c689415d62f # c7cb2b
+        uses: advanced-security/component-detection-dependency-submission-action@c7cb2bbc9360d8a011e4fac7dc542c689415d62f
         with:
           detectorArgs: Pip=EnableIfDefaultOff
 


### PR DESCRIPTION
## Summary
- fix workflow file for dependency graph submission

## Testing
- `pre-commit run --files .github/workflows/dependency-graph/auto-submission.yml` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68bdbd3d6930832dac93881666fa4194