### PR TITLE
fix: correct setup-python version comment

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -181,7 +181,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v5
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6
         with:
           python-version: '3.11'
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- fix setup-python step comment to reflect v6 in Docker publish workflow

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml`

------
https://chatgpt.com/codex/tasks/task_e_68bdbd4ce640832d8175937b35a7eeef