### PR TITLE
fix: suppress requests typing

### DIFF
--- a/http_client.py
+++ b/http_client.py
@@ -10,7 +10,7 @@ from functools import wraps
 from typing import AsyncGenerator, Generator
 
 import httpx
-import requests
+import requests  # type: ignore[import-untyped]
 
 DEFAULT_TIMEOUT_STR = os.getenv("MODEL_DOWNLOAD_TIMEOUT", "30")
 try:

--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -4,7 +4,7 @@ import sys
 from typing import Iterable
 
 import logging
-import requests
+import requests  # type: ignore[import-untyped]
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- silence requests imports for mypy

## Testing
- `flake8 scripts/health_check.py http_client.py`
- `mypy --no-site-packages .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bdbd360f60832db410126a5fb60148