### PR TITLE
fix(ci): allow cache writes

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -2,6 +2,7 @@ name: CI CPU
 
 permissions:
   contents: read
+  actions: write
 
 on:
   push:


### PR DESCRIPTION
## Summary
- allow GitHub Actions cache to write in CI CPU workflow

## Testing
- `pre-commit run --files .github/workflows/ci_cpu.yml`


------
https://chatgpt.com/codex/tasks/task_e_68bdbd6960b4832d8662263894eacd40