### PR TITLE
fix: run Dependabot workflow only for Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   dependabot:
-    if: ${{ github.actor == 'dependabot[bot]' || github.event.pull_request.user.login == 'dependabot[bot]' }}
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - name: Dependabot metadata


### PR DESCRIPTION
## Summary
- ensure Dependabot job runs based on PR author

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68bdbd8218e8832d908a60714a806c3b