### PR TITLE
refactor: simplify dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -29,33 +29,25 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
 
-      # Set up a Python environment that matches the main CI.  This
-      # installs the appropriate Python version and device specific
-      # dependencies (CPU by default) so that tests run in a
-      # reproducible manner.  The setup-env action is defined in this
-      # repository under .github/actions/setup-env.
-      - name: Setup Python environment
-        uses: ./.github/actions/setup-env
+      # Set up a lightweight Python environment and install only the
+      # dependencies required to run the unit tests.  This avoids the
+      # heavier setup used in the main CI workflow which was causing
+      # Dependabot update checks to fail.
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
-          device: 'cpu'
-
-      # Remove any stale pytest caches prior to running the test suite.
-      # Old cache data can cause test runs to use outdated compiled
-      # artifacts which in turn mask failures or lead to false
-      # positives.  This action is defined locally under
-      # .github/actions/clear-test-caches.
-      - name: Remove test caches
-        uses: ./.github/actions/clear-test-caches
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-ci.txt -r requirements-cpu.txt
 
       # Run the unit tests against the Dependabot update.  Integration
       # tests are excluded here to keep the workflow fast; they run in
       # the main CI.  If any test fails this step will surface the
       # error and prevent automatic merging of the pull request.
       - name: Run unit tests
-        run: |
-          set -o pipefail
-          pytest -m "not integration" -o cache_dir=/mnt/pytest_cache -q
+        run: pytest -m "not integration" -q
 
       - name: Enable auto-merge for Dependabot PRs
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'


### PR DESCRIPTION
## Summary
- streamline Dependabot auto-merge workflow with a lightweight Python setup

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml` *(fails: No module named 'pandas')*
- `pytest -m "not integration" -q` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68bdbd8e7d90832d91728d8736cb58f2