### PR TITLE
fix: корректная проверка актера в dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -10,7 +10,9 @@ permissions:
 
 jobs:
   dependabot:
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    # Run this job only for Dependabot PRs. Using `github.actor` keeps the check
+    # reliable even if the pull_request payload is missing in the event.
+    if: ${{ github.actor == 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - name: Dependabot metadata


### PR DESCRIPTION
## Summary
- run dependabot auto-merge job only when actor is dependabot

## Testing
- `pytest -m "not integration" -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdc2f6115c832d897ad2b6e5fd705c