### PR TITLE
Add Python setup to dependency graph workflow

### DIFF
--- a/.github/workflows/dependency-graph/auto-submission.yml
+++ b/.github/workflows/dependency-graph/auto-submission.yml
@@ -16,6 +16,10 @@ jobs:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
           fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6
+        with:
+          python-version: '3.10'
       - name: Component detection
         uses: advanced-security/component-detection-dependency-submission-action@c7cb2bbc9360d8a011e4fac7dc542c689415d62f
         with:


### PR DESCRIPTION
## Summary
- ensure workflow uses Python 3.10 before dependency submission

## Testing
- `pre-commit run --files .github/workflows/dependency-graph/auto-submission.yml` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68bdd00f5148832daba3ebfd7bfea920