### PR TITLE
chore: simplify docker publish concurrency

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: docker-publish-${{ github.ref_name != '' && github.ref_name || github.run_id }}
+  group: docker-publish-${{ github.head_ref || github.ref_name || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- simplify concurrency group expression in Docker publish workflow

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml` *(fails: No module named 'flask', 'fastapi', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd01cdb2c832d84595d5729bc67ea