### PR TITLE
ci: ignore missing test logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
         with:
           name: unit-test-log
           path: pytest.log
+          if-no-files-found: ignore
       - name: Cleanup buildx
         if: always()
         run: docker buildx prune -af || true
@@ -103,6 +104,7 @@ jobs:
         with:
           name: integration-test-log
           path: pytest.log
+          if-no-files-found: ignore
       - name: Cleanup buildx
         if: always()
         run: docker buildx prune -af || true


### PR DESCRIPTION
## Summary
- avoid failing when test log files are missing in CI

## Testing
- `pytest -q`
- `SKIP=pytest pre-commit run --files .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_68bdd02aea58832d867fccdc47fcbdc1