### PR TITLE
ci: correct checkout action version

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -26,7 +26,7 @@ jobs:
         python-version: ['3.10', '3.11']
         device: [cpu]
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - uses: ./.github/actions/setup-env
         with:
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
## Summary
- fix checkout action comment to v5

## Testing
- `pre-commit run --files .github/workflows/ci_cpu.yml` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68bdd0393440832d9f09de12bc22807e