### PR TITLE
fix: корректная проверка автора в dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -10,9 +10,9 @@ permissions:
 
 jobs:
   dependabot:
-    # Run this job only for Dependabot PRs. Using `github.actor` keeps the check
-    # reliable even if the pull_request payload is missing in the event.
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    # Run this job only for Dependabot PRs. Checking the PR author allows
+    # maintainers to re-run the workflow while still filtering to Dependabot.
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - name: Dependabot metadata


### PR DESCRIPTION
## Summary
- ensure dependabot auto-merge job checks PR author instead of triggering actor

## Testing
- `pytest tests/test_run_dependabot_script.py::test_run_dependabot_requires_token -q` *(fails: could not import 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68bdd04758e4832db51b3e760eb0b372