### PR TITLE
fix: install jq in gptoss review workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -61,6 +61,8 @@ jobs:
           echo "LLM container failed to start" >&2
           docker logs gptoss || true
           exit 1
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
       - name: Generate diff
         id: generate-diff
         if: success()


### PR DESCRIPTION
## Summary
- ensure jq is available in gptoss review workflow

## Testing
- `pytest` *(fails: could not import 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68bdd05573a4832db30372393a457cc6