### PR TITLE
Skip tests for non-Python Dependabot updates

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -36,10 +36,12 @@ jobs:
       # heavier setup used in the main CI workflow which was causing
       # Dependabot update checks to fail.
       - name: Setup Python
+        if: steps.metadata.outputs.package-ecosystem == 'pip'
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
       - name: Install dependencies
+        if: steps.metadata.outputs.package-ecosystem == 'pip'
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-ci.txt -r requirements-cpu.txt
@@ -49,6 +51,7 @@ jobs:
       # the main CI.  If any test fails this step will surface the
       # error and prevent automatic merging of the pull request.
       - name: Run unit tests
+        if: steps.metadata.outputs.package-ecosystem == 'pip'
         run: pytest -m "not integration" -q
 
       - name: Enable auto-merge for Dependabot PRs


### PR DESCRIPTION
## Summary
- Skip Python setup and tests when Dependabot updates are not for `pip`

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml`


------
https://chatgpt.com/codex/tasks/task_e_68bdd43ff4ec832d894cef48645a4086