### PR TITLE
fix: use PEP 621 license field

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "trading-bot-x"
 version = "0.1.1"
 description = "Пример торгового бота на Python."
 readme = "README.md"
-license = "MIT"
+license = { file = "LICENSE" }
 license-files = ["LICENSE"]
 authors = [{ name = "Project Authors" }]
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- fix pyproject metadata so dependency submission workflow validates

## Testing
- `pre-commit run --files pyproject.toml`
- `pytest tests/test_config_logging.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bddf48493c832db9f391adf3e2683e