### PR TITLE
Уточнить образ для Trivy в docker-publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -153,7 +153,7 @@ jobs:
           TRIVY_CACHE_DIR: /mnt/trivy-cache
         with:
           version: v0.65.0
-          image-ref: ${{ env.DOCKERHUB_USERNAME }}/${{ matrix.image }}:latest
+          image-ref: docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ matrix.image }}:latest
           format: table
           output: ${{ matrix.artifact }}.txt
           scanners: vuln


### PR DESCRIPTION
## Summary
- указать явный docker.io в ссылке на образ при сканировании Trivy

## Testing
- `pytest` (ошибки: 16 during collection)

------
https://chatgpt.com/codex/tasks/task_e_68bddf630c80832d85b714cf3b1edb66