### PR TITLE
Clear old logging handlers before configuring new ones

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -79,11 +79,11 @@ def test_logging_not_duplicated_on_reimport(monkeypatch, tmp_path, capsys):
 
     utils_mod = importlib.import_module("bot.utils")
     captured = capsys.readouterr()
-    assert "Logging initialized" not in captured.err
+    assert "Logging configured" not in captured.err
 
     utils_mod.configure_logging()
     captured = capsys.readouterr()
-    assert captured.err.count("Logging initialized") == 1
+    assert captured.err.count("Logging configured") == 1
 
     utils_mod.logger.info("first")
     captured = capsys.readouterr()
@@ -91,7 +91,7 @@ def test_logging_not_duplicated_on_reimport(monkeypatch, tmp_path, capsys):
 
     utils_mod = importlib.reload(utils_mod)
     captured = capsys.readouterr()
-    assert "Logging initialized" not in captured.err
+    assert "Logging configured" not in captured.err
 
     utils_mod.logger.info("second")
     captured = capsys.readouterr()
@@ -109,12 +109,12 @@ def test_configure_logging_level_update(monkeypatch, tmp_path):
     monkeypatch.setenv("LOG_LEVEL", "WARNING")
     utils.configure_logging()
     assert logger.level == logging.WARNING
-    handlers = list(logger.handlers)
+    handler_count = len(logger.handlers)
 
     monkeypatch.setenv("LOG_LEVEL", "DEBUG")
     utils.configure_logging()
     assert logger.level == logging.DEBUG
-    assert logger.handlers == handlers
+    assert len(logger.handlers) == handler_count
 
     for h in logger.handlers[:]:
         logger.removeHandler(h)

--- a/utils.py
+++ b/utils.py
@@ -41,15 +41,16 @@ def configure_logging() -> None:
         os.makedirs(log_dir, exist_ok=True)
 
     if logger.handlers:
-        return
+        for handler in logger.handlers[:]:
+            logger.removeHandler(handler)
+            handler.close()
 
     formatter = logging.Formatter(
         "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     )
 
-    file_handler = logging.FileHandler(
-        os.path.join(log_dir, "trading_bot.log"), encoding="utf-8"
-    )
+    log_file_path = os.path.join(log_dir, "trading_bot.log")
+    file_handler = logging.FileHandler(log_file_path, encoding="utf-8")
     file_handler.setFormatter(formatter)
     logger.addHandler(file_handler)
 
@@ -58,9 +59,9 @@ def configure_logging() -> None:
     logger.addHandler(console_handler)
 
     logger.info(
-        "Logging initialized at %s; writing logs to %s",
+        "Logging configured. File: %s, level: %s",
+        log_file_path,
         logging.getLevelName(logger.level),
-        log_dir,
     )
 
 


### PR DESCRIPTION
## Summary
- clear existing logging handlers before adding new ones
- log the log file path and final log level during configuration
- update tests for new logging behavior

## Testing
- `pytest tests/test_utils.py::test_logging_not_duplicated_on_reimport tests/test_utils.py::test_configure_logging_level_update -q`
- `pytest` *(fails: async def functions are not natively supported, 132 failed, 182 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bddf71b1e8832d8dd64c2a7f426c77