### PR TITLE
feat: add retry parameters for safe_api_call

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -36,11 +36,10 @@ async def test_safe_api_call_retries(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_safe_api_call_test_mode(monkeypatch):
-    monkeypatch.setenv("TEST_MODE", "1")
+async def test_safe_api_call_test_mode():
     exch = DummyExchange()
 
-    result = await utils.safe_api_call(exch, 'fail')
+    result = await utils.safe_api_call(exch, 'fail', test_mode=True)
 
     assert result == {'retCode': 1}
     assert exch.calls == 1


### PR DESCRIPTION
## Summary
- add configurable max_attempts, backoff_factor and test_mode to safe_api_call
- add exponential backoff for retries
- update tests to use test_mode flag

## Testing
- `pytest tests/test_utils.py::test_safe_api_call_retries tests/test_utils.py::test_safe_api_call_test_mode tests/test_utils.py::test_safe_api_call_unhandled -q`


------
https://chatgpt.com/codex/tasks/task_e_68bddf7a8e30832da59572f456c9121c