### PR TITLE
fix: prevent curl wait command from splitting URL

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -51,7 +51,11 @@ jobs:
           HTTPServer(('127.0.0.1', 8009), Handler).serve_forever()
           PY
           echo $! > server.pid
-          timeout 30 bash -c 'until curl --max-time 5 -sf -X POST -H "Content-Type: application/json" -d "{}" http://127.0.0.1:8009/v1/completions >/dev/null; do sleep 0.5; done'
+          timeout 30 bash <<'BASH'
+          until curl --max-time 5 -sf -X POST -H "Content-Type: application/json" -d '{}' http://127.0.0.1:8009/v1/completions >/dev/null; do
+            sleep 0.5
+          done
+          BASH
       - name: Run flake8
         run: |
           set -o pipefail


### PR DESCRIPTION
## Summary
- avoid accidental URL splitting in CI mock server wait loop

## Testing
- `pre-commit run --files .github/workflows/ci_cpu.yml`


------
https://chatgpt.com/codex/tasks/task_e_68bddfacf0a8832d8f879e12d9724b7f