### PR TITLE
chore: update dependabot workflow actions

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout code
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
@@ -37,7 +37,7 @@ jobs:
       # Dependabot update checks to fail.
       - name: Setup Python
         if: steps.metadata.outputs.package-ecosystem == 'pip'
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: '3.11'
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- update checkout action to v5 and setup-python to v6 in dependabot workflow

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml`

------
https://chatgpt.com/codex/tasks/task_e_68bddfb9573c832daeb905a4e89f65e6