### PR TITLE
feat: skip review when llm container fails

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -43,6 +43,8 @@ jobs:
             --trust-remote-code \
             --device cpu
       - name: Wait for LLM container
+        id: wait-llm
+        continue-on-error: true
         run: |
           # The model can take a while to load, especially on fresh runners
           # Allow extra time for the container to become ready
@@ -62,10 +64,11 @@ jobs:
           docker logs gptoss || true
           exit 1
       - name: Install jq
+        if: steps.wait-llm.outcome == 'success'
         run: sudo apt-get update && sudo apt-get install -y jq
       - name: Generate diff
         id: generate-diff
-        if: success()
+        if: steps.wait-llm.outcome == 'success'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
@@ -102,7 +105,7 @@ jobs:
             echo "has_diff=false" >> "$GITHUB_OUTPUT"
           fi
       - name: LLM review
-        if: steps.generate-diff.outputs.has_diff == 'true'
+        if: steps.wait-llm.outcome == 'success' && steps.generate-diff.outputs.has_diff == 'true'
         id: llm-review
         run: |
           model="${{ vars.LLM_MODEL || 'Qwen/Qwen2.5-Coder-1.5B-Instruct' }}"
@@ -128,7 +131,7 @@ jobs:
           printf "%s" "$review" > review.md
           echo "has_content=true" >> "$GITHUB_OUTPUT"
       - name: Comment PR
-        if: always() && steps.llm-review.outputs.has_content == 'true'
+        if: steps.wait-llm.outcome == 'success' && steps.llm-review.outputs.has_content == 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
         with:
           script: |


### PR DESCRIPTION
## Summary
- avoid failing workflow when LLM container can't start

## Testing
- `pre-commit run --files .github/workflows/gptoss_review.yml` *(fails: missing dependencies during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bddfc38890832daee5fd73704d932b