### PR TITLE
Annotate DataHandler init to satisfy mypy

### DIFF
--- a/data_handler/core.py
+++ b/data_handler/core.py
@@ -19,7 +19,13 @@ from .utils import expected_ws_rate
 class DataHandler:
     """Simplified DataHandler focused on functionality used in tests."""
 
-    def __init__(self, cfg, http_client, optimizer, exchange=None):
+    def __init__(
+        self,
+        cfg: Any,
+        http_client: Any,
+        optimizer: Any,
+        exchange: Any = None,
+    ) -> None:
         self.cfg = cfg
         self.exchange = exchange
         self.ws_queue: asyncio.PriorityQueue[Tuple[int, Any]] = asyncio.PriorityQueue()


### PR DESCRIPTION
## Summary
- add explicit type hints to `DataHandler.__init__` so mypy checks this module cleanly

## Testing
- `flake8 && echo flake8-pass`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bddfe5bf38832d89ec6e728e51ba86