### PR TITLE
fix: skip docker publish without credentials

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   build:
+    if: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
     env:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- skip docker publish when Docker Hub secrets are missing

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml` *(fails: Interrupted 16 errors during collection)*
- `pytest` *(fails: Interrupted 16 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf001bb44832d853d47c21c4a8f83