### PR TITLE
ci: make review comment trigger case-insensitive

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -20,7 +20,7 @@ jobs:
        github.event.pull_request.draft == false) ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request != null &&
-       contains(github.event.comment.body, '/llm-review'))
+       contains(toLower(github.event.comment.body), '/llm-review'))
     runs-on: ubuntu-latest
     env:
       PR_NUMBER: >-


### PR DESCRIPTION
## Summary
- ensure `/llm-review` comment trigger is case-insensitive

## Testing
- `pre-commit run --files .github/workflows/gptoss_review.yml` *(fails: No module named 'flask', 'polars', 'pydantic', 'joblib', 'fastapi', 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_68bdf02b2050832d8b55590207c00dce