### PR TITLE
fix: include httpx dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,10 @@ license-files = ["LICENSE"]
 authors = [{ name = "Project Authors" }]
 requires-python = ">=3.10"
 classifiers = ["Programming Language :: Python :: 3"]
-dependencies = ["flask>=3.0.2"]
+dependencies = [
+    "flask>=3.0.2",
+    "httpx>=0.27.0",
+]
 
 [tool.setuptools]
 packages = ["bot", "services", "data_handler"]


### PR DESCRIPTION
## Summary
- add httpx as core dependency in pyproject

## Testing
- `pytest`
- `flake8`
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_68bdf0a88720832d9a5cec0d510c5362