### PR TITLE
fix: allow manual dependabot runs

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -3,6 +3,7 @@ name: Dependabot Auto Merge
 on:
   pull_request_target:
     types: [opened, reopened, synchronize]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- allow triggering dependabot workflow manually via `workflow_dispatch`

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml`
- `pytest -m "not integration" -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdf020756c832d881af444a24907b2