### PR TITLE
fix: handle missing comment body in LLM review workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -20,7 +20,7 @@ jobs:
        github.event.pull_request.draft == false) ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request != null &&
-       contains(toLower(github.event.comment.body), '/llm-review'))
+       contains(toLower(github.event.comment.body || ''), '/llm-review'))
     runs-on: ubuntu-latest
     env:
       PR_NUMBER: >-


### PR DESCRIPTION
## Summary
- prevent gptoss_review.yml from failing when comment body is missing

## Testing
- `pre-commit run --files .github/workflows/gptoss_review.yml` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68bdf46a9968832db263f41bd56eaf1a