### PR TITLE
fix: allow manual dependabot runs

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -13,7 +13,7 @@ jobs:
   dependabot:
     # Run this job only for Dependabot PRs. Checking the PR author allows
     # maintainers to re-run the workflow while still filtering to Dependabot.
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       - name: Dependabot metadata


### PR DESCRIPTION
## Summary
- allow Dependabot workflow to run when triggered manually

## Testing
- `pytest -m "not integration" -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdf4a4e89c832db86f4ee6d56ac5c7