### PR TITLE
fix: allow docker workflow without secrets

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,7 +19,6 @@ concurrency:
 
 jobs:
   build:
-    if: ${{ secrets.DOCKERHUB_USERNAME && secrets.DOCKERHUB_TOKEN }}
     env:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -95,6 +94,7 @@ jobs:
           fi
 
       - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1  # v3.5.0
         with:
           username: ${{ env.DOCKERHUB_USERNAME }}
@@ -128,8 +128,8 @@ jobs:
         with:
           context: .
           file: ${{ matrix.file }}
-          push: true
-          tags: docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ matrix.image }}:latest
+          push: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
+          tags: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' && format('docker.io/{0}/{1}:latest', env.DOCKERHUB_USERNAME, matrix.image) || format('{0}:latest', matrix.image) }}
           cache-from: type=local,src=${{ github.workspace }}/.buildx-cache
           cache-to: type=local,dest=${{ github.workspace }}/.buildx-cache-new,mode=max
 
@@ -139,14 +139,17 @@ jobs:
           mv "$GITHUB_WORKSPACE/.buildx-cache-new" "$GITHUB_WORKSPACE/.buildx-cache"
 
       - name: Cleanup before Trivy scan
+        if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
         run: |
           sudo find /tmp -maxdepth 1 -name 'trivy-*' -exec rm -rf {} + || true
           sudo rm -rf /mnt/trivy-cache /mnt/trivy-tmp || true
           rm -rf ~/.cache/trivy || true
           mkdir -p /mnt/trivy-cache
       - name: Prepare Trivy temp
+        if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
         run: mkdir -p /mnt/trivy-tmp
       - name: Run Trivy vulnerability scanner
+        if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
         uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8  # 0.33.1
         continue-on-error: true
         env:
@@ -160,9 +163,11 @@ jobs:
           scanners: vuln
 
       - name: Show Trivy scan results
+        if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
         run: cat ${{ matrix.artifact }}.txt
 
       - name: Upload Trivy report artifact
+        if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: ${{ matrix.artifact }}


### PR DESCRIPTION
## Summary
- allow build job to run without Docker Hub secrets
- only login/push and trivy scan when secrets are present

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml`

------
https://chatgpt.com/codex/tasks/task_e_68bdf6c978f0832dae5d83debcc4bd08