### PR TITLE
chore: update gptoss review container tag

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -38,7 +38,7 @@ jobs:
           docker run -d --rm --name gptoss \
             -e HUGGING_FACE_HUB_TOKEN="$HF_TOKEN" \
             -p 127.0.0.1:8000:8000 \
-            vllm/vllm-openai:v0.5.1 \
+            vllm/vllm-openai:v0.10.1 \
             --model "${{ vars.LLM_MODEL || 'Qwen/Qwen2.5-Coder-1.5B-Instruct' }}" \
             --trust-remote-code \
             --device cpu


### PR DESCRIPTION
## Summary
- use existing v0.10.1 tag for vllm/vllm-openai image in GPT-OSS review workflow

## Testing
- `pytest` *(fails: Skipped: could not import 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68bdf6d11904832dbd453e0430f4de33