### PR TITLE
fix(github): guard issue fields in gptoss review workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -19,7 +19,9 @@ jobs:
       (github.event_name == 'pull_request_target' &&
        github.event.pull_request.draft == false) ||
       (github.event_name == 'issue_comment' &&
+       github.event.issue != null &&
        github.event.issue.pull_request != null &&
+       github.event.comment != null &&
        contains(toLower(github.event.comment.body || ''), '/llm-review'))
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
## Summary
- guard issue_comment fields in gptoss_review workflow to avoid failures when triggered by unrelated events

## Testing
- `pre-commit run --files .github/workflows/gptoss_review.yml` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68bdf8a2495c832da64fb5c2d0645b63