### PR TITLE
fix: guard pull_request fields in gptoss review workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -17,6 +17,7 @@ jobs:
   review:
     if: >-
       (github.event_name == 'pull_request_target' &&
+       github.event.pull_request != null &&
        github.event.pull_request.draft == false) ||
       (github.event_name == 'issue_comment' &&
        github.event.issue != null &&


### PR DESCRIPTION
## Summary
- add null guard when accessing pull_request fields in gptoss review workflow to avoid evaluation errors on issue_comment events

## Testing
- `pre-commit run --files .github/workflows/gptoss_review.yml` *(fails: missing pandas and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf9b7b0d0832d8a5991a951b1961c