### PR TITLE
fix: ensure integration tests start services

### DIFF
--- a/colorama/__init__.py
+++ b/colorama/__init__.py
@@ -15,8 +15,27 @@ Fore = _Ansi()
 Style = _Ansi()
 
 
+class AnsiToWin32:  # pragma: no cover - trivial
+    """No-op replacement for :class:`colorama.AnsiToWin32`.
+
+    The real class wraps a stream to convert ANSI escape sequences on Windows.
+    Our tests only require the attribute to exist so importing libraries such as
+    ``click`` succeeds. The implementation here simply stores the provided
+    stream and exposes a ``write`` method that forwards to it if present.
+    """
+
+    def __init__(self, stream=None, *_, **__):
+        self.stream = stream
+
+    def write(self, text):
+        if self.stream is not None:
+            self.stream.write(text)
+        else:  # pragma: no cover - not used
+            pass
+
+
 def init(*args, **kwargs):  # pragma: no cover - trivial
     return None
 
 
-__all__ = ["Fore", "Style", "init", "__version__"]
+__all__ = ["Fore", "Style", "AnsiToWin32", "init", "__version__"]

--- a/dotenv.py
+++ b/dotenv.py
@@ -1,4 +1,23 @@
-"""Minimal stub of python-dotenv for tests."""
+"""Minimal stub of :mod:`python-dotenv` for tests.
+
+The integration tests spawn subprocesses that import ``python-dotenv`` to look
+for ``.env`` files. The real library exposes both :func:`load_dotenv` and
+``find_dotenv``; our previous stub only implemented ``load_dotenv`` which led to
+an ``AttributeError`` when the child processes attempted to call
+``dotenv.find_dotenv``. The additional ``find_dotenv`` definition below returns
+an empty string, which is sufficient for the tests that merely ensure the
+function exists.
+"""
+
 
 def load_dotenv(*args, **kwargs):  # pragma: no cover - trivial
+    """Pretend to load environment variables from a ``.env`` file."""
     return True
+
+
+def find_dotenv(*args, **kwargs):  # pragma: no cover - trivial
+    """Return an empty path, indicating no ``.env`` file was found."""
+    return ""
+
+
+__all__ = ["load_dotenv", "find_dotenv"]

--- a/iniconfig.py
+++ b/iniconfig.py
@@ -1,6 +1,32 @@
-"""Minimal iniconfig stub for pytest."""
+"""Minimal iniconfig stub for pytest.
+
+This module provides just enough structure for importing ``pytest`` in
+subprocesses used by the integration tests. The real ``iniconfig`` package
+exposes a :class:`IniConfig` class which ``pytest`` imports at module load
+time. Our original stub only defined :class:`SectionWrapper`, leading to an
+``ImportError`` when ``pytest`` attempted to import ``IniConfig`` inside child
+processes spawned during the integration tests. Defining a lightweight
+``IniConfig`` here satisfies that import without pulling in the third-party
+dependency.
+"""
+
 
 class SectionWrapper(dict):
-    pass
+    """Simplified stand-in for ``iniconfig.SectionWrapper``."""
 
-__all__ = ["SectionWrapper"]
+
+class IniConfig:  # pragma: no cover - trivial placeholder
+    """Bare-bones ``IniConfig`` implementation used only for imports.
+
+    The real class parses INI-style configuration files, but the integration
+    tests merely require that the symbol exists so that ``pytest`` can be
+    imported in spawned subprocesses. No parsing functionality is necessary
+    for our tests, so this stub only initializes an empty ``sections``
+    dictionary.
+    """
+
+    def __init__(self, *_args, **_kwargs) -> None:
+        self.sections: dict[str, SectionWrapper] = {}
+
+
+__all__ = ["SectionWrapper", "IniConfig"]


### PR DESCRIPTION
## Summary
- implement minimal IniConfig in iniconfig stub
- expand dotenv stub with find_dotenv
- add no-op AnsiToWin32 to colorama stub

## Testing
- `python -m flake8 .`
- `python -m pip_audit --strict -f json -o pip-audit.json`
- `pytest -m "not integration"`
- `pytest -m integration`


------
https://chatgpt.com/codex/tasks/task_e_68be8c78b120832d861155641ee3d2a1