### PR TITLE
fix: update dependency runner version

### DIFF
--- a/requirements-core.in
+++ b/requirements-core.in
@@ -37,4 +37,5 @@ bcrypt>=4.2.0
 openai==1.106.1
 jsonschema==4.25.1
 pytest-asyncio>=1.1
+backports-asyncio-runner==1.0.0; python_version < "3.12"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ attrs==25.3.0
     #   aiohttp
     #   jsonschema
     #   referencing
-backports-asyncio-runner==1.2.0
+backports-asyncio-runner==1.0.0
     # via pytest-asyncio
 bcrypt==4.3.0
     # via -r requirements-core.in


### PR DESCRIPTION
## Summary
- pin backports-asyncio-runner to a valid release to restore dependency-graph auto submission

## Testing
- `pre-commit run --files requirements.txt .github/workflows/dependency-graph/auto-submission.yml` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68be88f6a3fc832da1fa7e3563349ba8