### PR TITLE
Fix httpx stub to expose trust_env and close

### DIFF
--- a/test_stubs.py
+++ b/test_stubs.py
@@ -164,7 +164,10 @@ def apply() -> None:
 
         class _HTTPXClient:  # pragma: no cover - minimal placeholder
             def __init__(self, *args: Any, **kwargs: Any) -> None:
-                pass
+                self.trust_env = kwargs.get("trust_env", False)
+
+            def close(self) -> None:  # pragma: no cover - simple no-op
+                return None
 
         class _HTTPXBaseTransport:  # pragma: no cover - minimal placeholder
             ...


### PR DESCRIPTION
## Summary
- ensure httpx test stub exposes trust_env attribute and close() method

## Testing
- `TEST_MODE=1 pytest tests/test_httpx_client_defaults.py -q`
- `SKIP=pytest pre-commit run --files test_stubs.py`


------
https://chatgpt.com/codex/tasks/task_e_68be88ebb140832db0062022c7150680