### PR TITLE
chore: fix dependabot workflow syntax

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,7 +1,7 @@
 ---
 name: Dependabot Auto Merge
 
-'on':
+on:
   pull_request_target:
     types: [opened, reopened, synchronize]
 


### PR DESCRIPTION
## Summary
- fix `on` key in Dependabot workflow

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml`
- `pytest -m "not integration" -q`


------
https://chatgpt.com/codex/tasks/task_e_68be8ca0e304832d9a296c4d2a90f3ac