### PR TITLE
Handle optional dependencies for tests

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -1,7 +1,12 @@
 from pathlib import Path
 import os
+import sys
 
-if os.getenv("TEST_MODE") == "1":  # pragma: no cover - simple import guard
+# ``pytest`` imports this package before tests set ``TEST_MODE``.  Detect a
+# pytest run by checking for the module and enable lightweight stubs so tests
+# don't require heavy optional dependencies like ``httpx``.
+if os.getenv("TEST_MODE") == "1" or "pytest" in sys.modules:
+    os.environ.setdefault("TEST_MODE", "1")
     import test_stubs as _test_stubs
 
     _test_stubs.apply()

--- a/data_handler/__init__.py
+++ b/data_handler/__init__.py
@@ -7,7 +7,10 @@ import numpy as np
 from typing import Iterable
 
 from .core import DataHandler
-from .api import api_app
+try:  # pragma: no cover - optional dependency
+    from .api import api_app
+except Exception:  # pragma: no cover - Flask not installed
+    api_app = None  # type: ignore[assignment]
 from .storage import DEFAULT_PRICE
 from bot import http_client as _http_client
 

--- a/http_client.py
+++ b/http_client.py
@@ -7,10 +7,11 @@ import os
 import asyncio
 from contextlib import asynccontextmanager, contextmanager
 from functools import wraps
-from typing import AsyncGenerator, Generator
+from typing import AsyncGenerator, Generator, TYPE_CHECKING
 
 import httpx
-import requests  # type: ignore[import-untyped]
+if TYPE_CHECKING:  # pragma: no cover - imported for type hints only
+    import requests
 
 DEFAULT_TIMEOUT_STR = os.getenv("MODEL_DOWNLOAD_TIMEOUT", "30")
 try:
@@ -26,8 +27,14 @@ except ValueError:
 @contextmanager
 def get_requests_session(
     timeout: float = DEFAULT_TIMEOUT,
-) -> Generator[requests.Session, None, None]:
-    """Return a :class:`requests.Session` with a default timeout."""
+) -> Generator["requests.Session", None, None]:
+    """Return a :class:`requests.Session` with a default timeout.
+
+    The import is deferred so the module can be used without the optional
+    ``requests`` dependency installed.
+    """
+    import requests  # type: ignore[import-untyped]
+
     session = requests.Session()
     # Avoid respecting proxy-related environment variables which can cause
     # local connections (e.g. to the mock GPT server in CI) to be routed through

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -14,7 +14,10 @@ import json
 import logging
 import ipaddress
 import re
-import aiohttp
+try:  # pragma: no cover - optional dependency
+    import aiohttp  # type: ignore
+except Exception:  # pragma: no cover - minimal stub
+    aiohttp = types.SimpleNamespace(ClientError=Exception)
 
 try:  # pragma: no cover - fallback for tests
     from dotenv import load_dotenv
@@ -76,7 +79,38 @@ except ImportError as exc:  # noqa: W0703 - optional dependency may not be insta
 import time
 from typing import Dict, Optional, Tuple
 import shutil
-from flask import Flask, request, jsonify
+try:  # pragma: no cover - optional dependency
+    from flask import Flask, request, jsonify  # type: ignore
+except Exception:  # pragma: no cover - minimal stubs
+    Flask = object  # type: ignore
+
+    def request(*args, **kwargs):  # type: ignore
+        return None
+
+    def jsonify(*args, **kwargs):  # type: ignore
+        return {}
+
+    class _StubApp:  # minimal API used in tests
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def before_request(self, func):
+            return func
+
+        def route(self, *args, **kwargs):  # pragma: no cover - simple passthrough
+            def decorator(func):
+                return func
+
+            return decorator
+
+        def run(self, *args, **kwargs):  # pragma: no cover - no-op
+            return None
+
+        @property
+        def asgi_app(self):  # pragma: no cover - simple property
+            return None
+
+    Flask = _StubApp  # type: ignore[assignment]
 import threading
 import multiprocessing as mp
 


### PR DESCRIPTION
## Summary
- Ensure test stubs activate automatically when running under pytest
- Lazily import optional HTTP client dependencies
- Guard against missing Flask/aiohttp so modules import without heavy deps

## Testing
- `pytest tests/test_http_client_shared.py::test_shared_http_client_cleanup tests/test_run_async.py::test_run_async_logs_exception -q`

------
https://chatgpt.com/codex/tasks/task_e_68be8cb72f04832d802e6883cef0f9f7