### PR TITLE
fix: allow cache module to be imported standalone

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -12,9 +12,18 @@ logger = logging.getLogger("TradingBot")
 def _sanitize_symbol(symbol: str) -> str:
     """Sanitize symbol string using utility helper.
 
-    Import is done lazily to avoid circular dependencies with ``bot.utils``.
+    The import is performed lazily to avoid circular dependencies with
+    ``bot.utils``.  Some callers import this module as ``bot.cache`` while
+    others may import it as the top level ``cache`` module.  A purely
+    relative import fails in the latter case (``ImportError: attempted
+    relative import with no known parent package``).  To support both usage
+    styles we try the relative import first and fall back to an absolute
+    import if necessary.
     """
-    from .utils import sanitize_symbol  # noqa: WPS433 (import inside function)
+    try:  # pragma: no cover - import style depends on caller
+        from .utils import sanitize_symbol  # type: ignore  # noqa: WPS433
+    except ImportError:  # pragma: no cover
+        from utils import sanitize_symbol  # type: ignore  # noqa: WPS433
 
     return sanitize_symbol(symbol)
 


### PR DESCRIPTION
## Summary
- handle cache imports both as `bot.cache` and top-level `cache`
- fall back to absolute import of `utils.sanitize_symbol`

## Testing
- `flake8 --exclude venv .`
- `mypy --no-site-packages --exclude venv .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be9af92ca4832dbe72c10b9ac10375