### PR TITLE
chore: update dependabot metadata action

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@46cfd663b8c18cab02928a3fa963cf0e73994bb1
+        uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.4.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Auto approve


### PR DESCRIPTION
## Summary
- update dependabot metadata action to latest release

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml`
- `pytest -m "not integration" -q` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68be9b0ac1ac832dba6d6a2bba7ce0ab