### PR TITLE
Enable async tests without pytest-asyncio

### DIFF
--- a/pytest_asyncio.py
+++ b/pytest_asyncio.py
@@ -3,9 +3,13 @@
 import asyncio
 import types
 
+
 def pytest_pyfunc_call(pyfuncitem):
+    """Run coroutine test functions with their fixture arguments."""
     testfunction = pyfuncitem.obj
     if isinstance(testfunction, types.FunctionType) and asyncio.iscoroutinefunction(testfunction):
-        asyncio.run(testfunction(**pyfuncitem.funcargs))
+        # Only pass arguments the test function expects to avoid autouse fixtures.
+        kwargs = {name: pyfuncitem.funcargs[name] for name in pyfuncitem._fixtureinfo.argnames}
+        asyncio.run(testfunction(**kwargs))
         return True
     return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,11 @@
-import asyncio
 import os
 import sys
-
+import asyncio
 import pytest
 
 from bot import http_client as _http_client
+
+pytest_plugins = ("pytest_asyncio",)
 
 # MLflow spawns a background telemetry thread on import which keeps the
 # process alive after tests finish. Disabling telemetry prevents the thread
@@ -50,7 +51,7 @@ def fast_sleep(monkeypatch):
 
 
 @pytest.fixture(scope="session", autouse=True)
-async def _close_shared_http_client():
+def _close_shared_http_client():
     """Ensure the shared async HTTP client is closed after tests."""
     yield
-    await _http_client.close_async_http_client()
+    asyncio.run(_http_client.close_async_http_client())


### PR DESCRIPTION
## Summary
- load lightweight async test plugin
- close shared HTTP client in a synchronous fixture
- avoid autouse fixture args when running coroutine tests

## Testing
- `pytest tests/test_gpt_client.py -q`
- `pytest tests/test_http_client_cleanup.py tests/test_http_client_shared.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be9b17073c832d9eb17f6e0dd47fb9