### PR TITLE
fix: resolve yamllint warnings in docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,12 +1,12 @@
 ---
-# yamllint disable rule:line-length
+# yamllint disable rule:line-length rule:truthy
 name: Build and Push Docker image
 permissions:
   contents: read
   packages: write
   actions: write
 
-'on':
+on:
   push:
     branches: ["main", "master"]
   schedule:


### PR DESCRIPTION
## Summary
- silence yamllint truthy warning by disabling rule
- use `on:` key in docker publish workflow

## Testing
- `yamllint .github/workflows/docker-publish.yml`
- `/tmp/actionlint .github/workflows/docker-publish.yml`


------
https://chatgpt.com/codex/tasks/task_e_68bee36bb134832db94aa90937f6be70