### PR TITLE
fix(ci): update checkout action pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         python-version: ['3.10', '3.11']
         device: [cpu]
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - uses: ./.github/actions/setup-env
         with:
           python-version: ${{ matrix.python-version }}
@@ -85,7 +85,7 @@ jobs:
         python-version: ['3.10', '3.11']
         device: [cpu]
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - uses: ./.github/actions/setup-env
         with:
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
## Summary
- pin actions/checkout to latest v4.2.1 commit in CI workflow

## Testing
- `flake8 . --exclude venv`
- `pytest -m "not integration"`
- `pytest -m integration`


------
https://chatgpt.com/codex/tasks/task_e_68bee377db98832dba88a08586d0e1dd