### PR TITLE
ci: ignore missing logs in CPU workflow

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           name: flake8-log
           path: flake8.log
+          if-no-files-found: ignore
       - name: Run mypy
         run: mypy --no-site-packages --exclude venv .
       - name: Remove test caches
@@ -83,6 +84,7 @@ jobs:
         with:
           name: pytest-log
           path: pytest.log
+          if-no-files-found: ignore
       - name: Stop mock server
         if: always()
         run: |


### PR DESCRIPTION
## Summary
- avoid failing when log files absent in CPU CI workflow

## Testing
- `pre-commit run --files .github/workflows/ci_cpu.yml`
- `flake8 --exclude venv .`
- `pytest`
- `mypy --no-site-packages --exclude venv .` *(fails: Library stubs not installed for "requests")*


------
https://chatgpt.com/codex/tasks/task_e_68bee381b92c832d801d5f2856493c7d