### PR TITLE
fix: update dependency graph workflow

### DIFF
--- a/.github/workflows/dependency-graph/auto-submission.yml
+++ b/.github/workflows/dependency-graph/auto-submission.yml
@@ -1,7 +1,7 @@
 ---
 name: Dependency Graph Auto Submission
 
-'on':
+on:
   push:
     branches: [main]
   workflow_dispatch:
@@ -14,14 +14,15 @@ jobs:
   auto-submission:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Component detection
-        uses: advanced-security/component-detection-dependency-submission-action@c7cb2bbc9360d8a011e4fac7dc542c689415d62f  # yamllint disable-line rule:line-length
+        uses: advanced-security/component-detection-dependency-submission-action@v0.1.0  # yamllint disable-line rule:line-length
         with:
           detectorArgs: Pip=EnableIfDefaultOff
+


### PR DESCRIPTION
## Summary
- update dependency graph auto submission action to released versions
- align with repo defaults for checkout and python setup

## Testing
- `pre-commit run --files .github/workflows/dependency-graph/auto-submission.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bee763c650832db6d069fe22a37225