### PR TITLE
fix: trigger Dependabot workflow on pull_request

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -2,7 +2,7 @@
 name: Dependabot Auto Merge
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize]
 
 permissions:


### PR DESCRIPTION
## Summary
- switch Dependabot workflow to `pull_request` trigger

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml`

------
https://chatgpt.com/codex/tasks/task_e_68bee7a4c5bc832daa20715ebd1c1db3