### PR TITLE
chore: fix test workflow actions versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,9 +13,9 @@ jobs:
     env:
       TEST_MODE: "1"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'


### PR DESCRIPTION
## Summary
- fix tests workflow by using existing versions of GitHub actions

## Testing
- `flake8 .`
- `pytest --maxfail=1 --disable-warnings -q`


------
https://chatgpt.com/codex/tasks/task_e_68bee7b60ef0832dbdcdfe3f5d4ca506