### PR TITLE
chore: fix dependabot workflow trigger

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -2,7 +2,7 @@
 name: Dependabot Auto Merge
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
 
 permissions:


### PR DESCRIPTION
## Summary
- use `pull_request_target` event for dependabot auto-merge workflow

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml`


------
https://chatgpt.com/codex/tasks/task_e_68beead2619c832da1d1c3a7a050fa06