### PR TITLE
ci: use env URL in CPU workflow

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -52,7 +52,9 @@ jobs:
           PY
           echo $! > server.pid
           timeout 30 bash <<'BASH'
-          until curl --max-time 5 -sf -X POST -H "Content-Type: application/json" -d '{}' http://127.0.0.1:8009/v1/completions >/dev/null; do
+          until curl --max-time 5 -sf \
+            -X POST -H "Content-Type: application/json" -d '{}' \
+            "$GPT_OSS_API/v1/completions" >/dev/null; do
             sleep 0.5
           done
           BASH


### PR DESCRIPTION
## Summary
- reuse `GPT_OSS_API` env var in CPU workflow when waiting for mock server
- break curl command into multiple lines for readability

## Testing
- `pre-commit run --files .github/workflows/ci_cpu.yml` *(fails: could not import 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68bf149907ec832d9874c5ee96ecd9f3