### PR TITLE
Fix dependency graph workflow path and pin action versions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -14,15 +14,16 @@ jobs:
   auto-submission:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: '3.10'
       - name: Component detection
-        uses: advanced-security/component-detection-dependency-submission-action@v0.1.0  # yamllint disable-line rule:line-length
+        # yamllint disable-line rule:line-length
+        uses: advanced-security/component-detection-dependency-submission-action@v0.1.0
         with:
           detectorArgs: Pip=EnableIfDefaultOff
 


### PR DESCRIPTION
## Summary
- move dependency graph submission workflow to top-level workflows directory
- pin checkout and setup-python actions to specific versions

## Testing
- `pre-commit run --files .github/workflows/dependency-graph.yml`


------
https://chatgpt.com/codex/tasks/task_e_68bf14717b18832d8e7bcbfdc471d897