### PR TITLE
chore: pin stable versions in dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
@@ -37,7 +37,7 @@ jobs:
       # Dependabot update checks to fail.
       - name: Setup Python
         if: steps.metadata.outputs.package-ecosystem == 'pip'
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- use `actions/checkout` v4 commit and `setup-python` v5 commit to avoid requiring Node 24

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf1469643c832d8490e624a1e692bf