### PR TITLE
chore: pin actions in CI workflow

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -39,7 +39,7 @@ runs:
         sudo rm -f /mnt/swapfile
         sudo rm -rf /mnt/*
     - name: Maximize build space
-      uses: easimon/maximize-build-space@v10
+      uses: easimon/maximize-build-space@fc881a613ad2a34aca9c9624518214ebc21dfc0c # v10
       with:
         root-reserve-mb: 1024
         temp-reserve-mb: 100

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         python-version: ['3.10', '3.11']
         device: [cpu]
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - uses: ./.github/actions/setup-env
         with:
           python-version: ${{ matrix.python-version }}
@@ -85,7 +85,7 @@ jobs:
         python-version: ['3.10', '3.11']
         device: [cpu]
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - uses: ./.github/actions/setup-env
         with:
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
## Summary
- use checkout v5 in CI
- pin build space action to commit

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/actions/setup-env/action.yml`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf148ed524832dad032cc492e85d48