### PR TITLE
chore: fix ci tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,8 +24,6 @@ jobs:
         run: python -m pip install --upgrade pip
       - name: Install dependencies
         run: python -m pip install -r requirements-ci.txt
-      - name: Install project
-        run: pip install -e .
       - name: Run flake8
         run: flake8 .
       - name: Run tests


### PR DESCRIPTION
## Summary
- remove broken install step from tests workflow so CI runs

## Testing
- `pre-commit run --files .github/workflows/tests.yml`
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_68bf14ab743c832db48f80fa168de277