### PR TITLE
chore: pin release-drafter action

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -20,8 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update release draft
-        # release-drafter v6
-        uses: release-drafter/release-drafter@v6
+        uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6
         with:
           config-name: release-drafter.yml
         env:


### PR DESCRIPTION
## Summary
- pin release-drafter action to commit SHA

## Testing
- `pre-commit run --files .github/workflows/release-drafter.yml` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68bf150c8cc4832d854ce7571259d7d0