### PR TITLE
fix: pin component detection action

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: '3.10'
       - name: Component detection
         # yamllint disable-line rule:line-length
-        uses: advanced-security/component-detection-dependency-submission-action@v0.1.0
+        uses: advanced-security/component-detection-dependency-submission-action@d433c2f467e149a8009c8fbce92cc708ed15ef7b # v0.1.0
         with:
           detectorArgs: Pip=EnableIfDefaultOff
 


### PR DESCRIPTION
## Summary
- pin component detection action to commit

## Testing
- `pytest` *(fails: Skipped: could not import 'pandas': No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68bf1909b2a8832d9ba93305f85b4d4f