### PR TITLE
chore: document action versions in dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Auto approve
-        uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363
+        uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout code
@@ -56,8 +56,7 @@ jobs:
 
       - name: Enable auto-merge for Dependabot PRs
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
-        uses: >-
-          peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d
+        uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d # v3.0.0
         with:
           pull-request-number: ${{ github.event.pull_request.number }}
           merge-method: squash


### PR DESCRIPTION
## Summary
- note pinned versions for auto-approve and auto-merge actions in dependabot workflow

## Testing
- `actionlint .github/workflows/dependabot.yml`
- `pytest -m "not integration" -q` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68bf1938d1bc832dad174cdd221caa5c