### PR TITLE
chore(ci): pin dependency graph action

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: '3.10'
       - name: Component detection
         # yamllint disable-line rule:line-length
-        uses: advanced-security/component-detection-dependency-submission-action@v0.1.0
+        uses: advanced-security/component-detection-dependency-submission-action@d433c2f467e149a8009c8fbce92cc708ed15ef7b # v0.1.0
         with:
           detectorArgs: Pip=EnableIfDefaultOff
 


### PR DESCRIPTION
## Summary
- pin component detection action to a specific commit in dependency graph workflow

## Testing
- `pre-commit run --files .github/workflows/dependency-graph.yml` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68bf195bcdcc832db2c6ec7ccf7b51f3