### PR TITLE
Fix mypy missing stub by ignoring requests import

### DIFF
--- a/http_client.py
+++ b/http_client.py
@@ -11,7 +11,7 @@ from typing import AsyncGenerator, Generator, TYPE_CHECKING
 
 import httpx
 if TYPE_CHECKING:  # pragma: no cover - imported for type hints only
-    import requests
+    import requests  # type: ignore[import-untyped]
 
 DEFAULT_TIMEOUT_STR = os.getenv("MODEL_DOWNLOAD_TIMEOUT", "30")
 try:


### PR DESCRIPTION
## Summary
- add type ignore for requests import under TYPE_CHECKING in http_client

## Testing
- `flake8 --exclude venv .`
- `mypy --no-site-packages --exclude venv .`
- `pytest` *(fails: could not import 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68bf19820eec832da81dd4c682bdf568