### PR TITLE
Исправление ссылок на выводы в dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -36,12 +36,12 @@ jobs:
       # heavier setup used in the main CI workflow which was causing
       # Dependabot update checks to fail.
       - name: Setup Python
-        if: steps.metadata.outputs.package-ecosystem == 'pip'
+        if: ${{ steps.metadata.outputs['package-ecosystem'] == 'pip' }}
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
       - name: Install dependencies
-        if: steps.metadata.outputs.package-ecosystem == 'pip'
+        if: ${{ steps.metadata.outputs['package-ecosystem'] == 'pip' }}
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-ci.txt
@@ -51,11 +51,11 @@ jobs:
       # the main CI.  If any test fails this step will surface the
       # error and prevent automatic merging of the pull request.
       - name: Run unit tests
-        if: steps.metadata.outputs.package-ecosystem == 'pip'
+        if: ${{ steps.metadata.outputs['package-ecosystem'] == 'pip' }}
         run: pytest -m "not integration" -q
 
       - name: Enable auto-merge for Dependabot PRs
-        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        if: ${{ steps.metadata.outputs['update-type'] != 'version-update:semver-major' }}
         uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d # v3.0.0
         with:
           pull-request-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
- корректно обращаемся к выводам шага dependabot metadata

## Testing
- `pytest tests/test_run_dependabot_script.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf208212f8832da1588d45998b3810