### PR TITLE
chore: fix release drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
     branches:
       - main
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update release draft
-        uses: release-drafter/release-drafter@v6.1.0
+        uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         with:
           config-name: release-drafter.yml
         env:


### PR DESCRIPTION
## Summary
- ensure release-drafter uses pull_request_target for write permissions
- pin release-drafter action to commit for reproducibility

## Testing
- `pre-commit run --files .github/workflows/release-drafter.yml` *(fails: tests couldn't import dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bf21c20900832d8025bf84afabc974