### PR TITLE
fix: refine dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,7 +1,7 @@
 ---
 name: Dependabot Auto Merge
 
-'on':
+on:
   pull_request_target:
     types: [opened, reopened, synchronize]
 
@@ -22,6 +22,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Auto approve
+        if: ${{ steps.metadata.outputs['update-type'] != 'version-update:semver-major' }}
         # v4.0.0
         uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ __pycache__/
 *.log
 pytest_cache/
 .pytest_cache/
+.hypothesis/
 venv/
 .venv/


### PR DESCRIPTION
## Summary
- skip auto approval for major dependabot updates
- clean up workflow formatting and ignore hypothesis cache

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml .gitignore`
- `pytest -m "not integration" -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf23b579d8832d95ccbf7e093ed0e3