### PR TITLE
chore: refine test workflow and configs

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,6 @@
 [flake8]
-max-line-length = 180
-select = E9, F63, F7, F82
-extend-ignore = E203, W503
+max-line-length = 100
+select = E9,F63,F7,F82
+exclude = .git,__pycache__,.venv,venv,build,dist
+ignore = E203,W503
+# совместимость с black

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,30 +1,42 @@
 name: Tests
-
 on:
   push:
   pull_request:
-
+permissions:
+  contents: read
 jobs:
   run-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.10', '3.11']
     env:
       TEST_MODE: "1"
+      PYTHONHASHSEED: "0"
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: requirements-ci.txt
-      - name: Upgrade pip
-        run: python -m pip install --upgrade pip
-      - name: Install dependencies
-        run: python -m pip install -r requirements-ci.txt
-      - name: Run flake8
+          cache: pip
+          cache-dependency-path: |
+            requirements*.txt
+            pyproject.toml
+            setup.cfg
+            setup.py
+      - name: Upgrade pip/setuptools/wheel
+        run: python -m pip install --upgrade pip setuptools wheel
+      - name: Install deps (core + ci + extras if exist)
+        run: |
+          set -eux
+          test -f requirements.txt && python -m pip install -r requirements.txt || true
+          test -f requirements-ci.txt && python -m pip install -r requirements-ci.txt || true
+          test -f requirements-extras.txt && python -m pip install -r requirements-extras.txt || true
+      - name: Lint (flake8)
         run: flake8 .
-      - name: Run tests
-        run: pytest --maxfail=1 --disable-warnings -q
+      - name: Run tests (pytest)
+        run: pytest -q --maxfail=1 --disable-warnings

--- a/gptoss_check/check_code.py
+++ b/gptoss_check/check_code.py
@@ -55,6 +55,8 @@ def query(prompt: str) -> str:
 
 def send_telegram(msg: str) -> None:
     """Отправить сообщение в Telegram, если заданы токен и chat_id."""
+    if os.getenv("TEST_MODE") == "1":
+        return
     token = os.getenv("TELEGRAM_BOT_TOKEN")
     chat_id = os.getenv("TELEGRAM_CHAT_ID")
     if token and chat_id:

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,7 @@ markers =
     asyncio: mark test as asyncio-based
     requires_sklearn: marks tests that require scikit-learn
 
+filterwarnings =
+    ignore::DeprecationWarning
+    ignore::PendingDeprecationWarning
+


### PR DESCRIPTION
## Summary
- streamline tests workflow to install required deps, cache installs, and run lint & pytest
- simplify flake8 configuration and add warning filters for pytest
- skip Telegram notifications when running in TEST_MODE

## Testing
- `flake8 .`
- `pytest -q --maxfail=1 --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68bf242db3dc832d99be75c4c5e6924f