### PR TITLE
Fix dependency graph submission workflow

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -25,4 +25,5 @@ jobs:
         # yamllint disable-line rule:line-length
         uses: advanced-security/component-detection-dependency-submission-action@d433c2f467e149a8009c8fbce92cc708ed15ef7b # v0.1.0
         with:
-          detectorArgs: Pip=EnableIfDefaultOff
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          detectorArgs: 'Pip=EnableIfDefaultOff'


### PR DESCRIPTION
## Summary
- configure component-detection action with explicit GitHub token and quoted args

## Testing
- `pre-commit run --files .github/workflows/dependency-graph.yml` *(fails: Interrupted (^C): KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68c027c99290832d9198000cface26f0