### PR TITLE
fix: pin docker workflow to ubuntu 22.04

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,7 +22,7 @@ jobs:
     env:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -181,7 +181,7 @@ jobs:
   healthcheck:
     needs: build
     if: ${{ needs.build.result == 'success' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5


### PR DESCRIPTION
## Summary
- pin docker-publish workflow to ubuntu-22.04 for stable environment

## Testing
- `actionlint .github/workflows/docker-publish.yml`
- `yamllint .github/workflows/docker-publish.yml`
- `pre-commit run --files .github/workflows/docker-publish.yml` *(fails: Unknown config option: asyncio_mode; Interrupted: 11 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c027dbb1d0832d9fc66f88f6711660