### PR TITLE
fix release drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,15 +4,10 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
-    types: [opened, reopened, synchronize]
-    branches:
-      - main
   workflow_dispatch:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
## Summary
- simplify release-drafter workflow triggers

## Testing
- `pre-commit run --files .github/workflows/release-drafter.yml` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68c028350ee8832da5aa757119bc1ec5