### PR TITLE
Fix dependency graph workflow token and stub indentation

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -25,5 +25,5 @@ jobs:
         # yamllint disable-line rule:line-length
         uses: advanced-security/component-detection-dependency-submission-action@d433c2f467e149a8009c8fbce92cc708ed15ef7b # v0.1.0
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           detectorArgs: 'Pip=EnableIfDefaultOff'

--- a/test_stubs.py
+++ b/test_stubs.py
@@ -181,6 +181,10 @@ def apply() -> None:
                 return None
 
             async def aclose(self) -> None:  # pragma: no cover - simple no-op
+                return None
+
+        class _CookieJar:  # pragma: no cover - minimal placeholder
+            ...
 
         class _HTTPXClient:  # pragma: no cover - minimal placeholder
             def __init__(self, *args: Any, **kwargs: Any) -> None:


### PR DESCRIPTION
## Summary
- use correct input name for dependency-graph auto submission
- fix indentation in test stub and add cookie jar placeholder

## Testing
- `pre-commit run --files .github/workflows/dependency-graph.yml test_stubs.py` *(fails: ModuleNotFoundError: No module named 'pydantic', fastapi, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c05259d9b8832da4ee2a0d4774ada6