### PR TITLE
fix: ensure release drafter can read pull requests

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: read
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
## Summary
- allow release-drafter workflow to read pull requests

## Testing
- `pre-commit run --files .github/workflows/release-drafter.yml` *(fails: ImportError in tests/conftest.py -> IndentationError in test_stubs.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c052e661c4832db69dacf274ff7675