### PR TITLE
fix: handle missing LLM container in GPT-OSS review

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -69,24 +69,26 @@ jobs:
           for i in {1..1200}; do
             if docker ps --filter "name=gptoss" --filter "status=running" | grep -q gptoss && \
                curl -sf http://127.0.0.1:8000/v1/models; then
+              echo "llm_running=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
             if ! docker ps --filter "name=gptoss" | grep -q gptoss; then
               echo "LLM container exited" >&2
               docker logs gptoss || true
-              exit 1
+              echo "llm_running=false" >> "$GITHUB_OUTPUT"
+              exit 0
             fi
             sleep 1
           done
           echo "LLM container failed to start" >&2
           docker logs gptoss || true
-          exit 1
+          echo "llm_running=false" >> "$GITHUB_OUTPUT"
       - name: Install jq
-        if: steps.wait_llm.outcome == 'success'
+        if: steps.wait_llm.outputs.llm_running == 'true'
         run: sudo apt-get update && sudo apt-get install -y jq
       - name: Generate diff
         id: generate_diff
-        if: steps.wait_llm.outcome == 'success'
+        if: steps.wait_llm.outputs.llm_running == 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
@@ -123,7 +125,7 @@ jobs:
             echo "has_diff=false" >> "$GITHUB_OUTPUT"
           fi
       - name: LLM review
-        if: steps.wait_llm.outcome == 'success' && steps.generate_diff.outputs.has_diff == 'true'
+        if: steps.wait_llm.outputs.llm_running == 'true' && steps.generate_diff.outputs.has_diff == 'true'
         id: llm_review
         run: |
           model="${{ vars.LLM_MODEL || 'Qwen/Qwen2.5-Coder-1.5B-Instruct' }}"
@@ -149,7 +151,7 @@ jobs:
           printf "%s" "$review" > review.md
           echo "has_content=true" >> "$GITHUB_OUTPUT"
       - name: Comment PR
-        if: steps.wait_llm.outcome == 'success' && steps.llm_review.outputs.has_content == 'true'
+        if: steps.wait_llm.outputs.llm_running == 'true' && steps.llm_review.outputs.has_content == 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
         with:
           script: |


### PR DESCRIPTION
## Summary
- prevent GPT-OSS review workflow from failing when LLM container cannot start

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68c05e49fa7c832d9644b30abd3a3b2b