### PR TITLE
fix: install deps with python -m pip in dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -49,7 +49,7 @@ jobs:
         if: ${{ steps.metadata.outputs['package-ecosystem'] == 'pip' }}
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-ci.txt
+          python -m pip install -r requirements-ci.txt
 
       # Run the unit tests against the Dependabot update.  Integration
       # tests are excluded here to keep the workflow fast; they run in


### PR DESCRIPTION
## Summary
- run pip installs via `python -m pip` in dependabot workflow

## Testing
- `pytest -m "not integration" -q`


------
https://chatgpt.com/codex/tasks/task_e_68c05e3ad544832d8366718795fc1bab