### PR TITLE
Fix stub utilities for linting

### DIFF
--- a/flask.py
+++ b/flask.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import json as _json
+import logging
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from typing import Any, Callable, Dict, Iterable, Optional, Tuple
+from typing import Any, Callable, Dict, Iterable, Optional, Tuple, Type
 from urllib.parse import unquote
-import json as _json
 
 _current_request: _Request | None = None
 
@@ -91,11 +91,11 @@ class Flask:
         self.name = name
         self.config: Dict[str, Any] = {}
         self._routes: list[Tuple[str, Callable[..., Any]]] = []
-        self._error_handlers: Dict[int, Callable[..., Any]] = {}
         self._before_request: list[Callable[[], None]] = []
         self._before_first: list[Callable[[], None]] = []
         self._teardown: list[Callable[[BaseException | None], None]] = []
-        self._error_handlers: Dict[int, Callable[..., Any]] = {}
+        self._error_handlers: Dict[int | Type[Exception], Callable[..., Any]] = {}
+        self.logger = logging.getLogger(name)
         self._first_done = False
 
     def route(self, rule: str, methods: Iterable[str] | None = None) -> Callable:
@@ -104,6 +104,9 @@ class Flask:
             return func
         return decorator
 
+    def errorhandler(
+        self, code: int | Type[Exception]
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
         def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
             self._error_handlers[code] = func
             return func

--- a/test_stubs.py
+++ b/test_stubs.py
@@ -189,6 +189,9 @@ def apply() -> None:
 
             post = get
 
+            async def aclose(self) -> None:  # pragma: no cover - simple no-op
+                self.is_closed = True
+
             def close(self) -> None:  # pragma: no cover - simple no-op
                 self.is_closed = True
         class _HTTPXClient:  # pragma: no cover - minimal placeholder


### PR DESCRIPTION
## Summary
- add logger and errorhandler support to minimal Flask stub
- add async close method to HTTPX AsyncClient stub

## Testing
- `flake8`
- `mypy --no-site-packages --exclude venv .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c06122bdd8832d82c356b554963617