### PR TITLE
Potential fix for code scanning alert no. 2174: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/bcrypt.py
+++ b/bcrypt.py
@@ -20,8 +20,19 @@ def hashpw(password: bytes, salt: bytes) -> bytes:
     if isinstance(salt, str):
         salt = salt.encode()
     prefix = _salt_from_hash(salt)
-    digest = hashlib.sha256(password + prefix).hexdigest().encode()
-    return prefix + digest
+    # Use PBKDF2-HMAC-SHA256 for computational expense instead of SHA256 directly
+    # Use the 'rounds' parameter encoded in the salt to determine iterations
+    try:
+        rounds = int(prefix[4:6])
+    except Exception:
+        rounds = 12
+    # NIST recommends at least 10,000 iterations, bcrypt default work factor is 12 (2**12 = 4096), so scale as 2**rounds
+    iterations = 2 ** rounds
+    # Use prefix as salt, lengthen digest for demonstration only (bcrypt's output is 31 bytes; pbkdf2 defaults to 32)
+    digest = hashlib.pbkdf2_hmac('sha256', password, prefix, iterations, dklen=32)
+    # Base64 encode digest to get ASCII (bcrypt uses a custom alphabet in reality, but for a stub, std base64 is okay)
+    digest_b64 = base64.b64encode(digest)[:43]  # bcrypt hashes are 31 chars base64 for the hash part, but use 43 here for compatibility
+    return prefix + digest_b64
 
 def checkpw(password: bytes, hashed: bytes) -> bool:
     if isinstance(hashed, str):


### PR DESCRIPTION
Potential fix for [https://github.com/averinaleks/bot/security/code-scanning/2174](https://github.com/averinaleks/bot/security/code-scanning/2174)

To fix this problem, replace the usage of `hashlib.sha256` with a dedicated, slow, and secure password hashing algorithm such as `bcrypt`, `scrypt`, `argon2`, or PBKDF2. Since the code is meant as a "minimal bcrypt stub", the natural choice is to use Python's standard library's `hashlib.pbkdf2_hmac` (available and does not require external dependencies) to approximate slow hash-based password storage for tests. This does not produce real bcrypt hashes, but as a stub, it is a much safer stand-in than SHA-256. The fix will:
- Import `hashlib.pbkdf2_hmac`.
- In `hashpw`, replace the usage of `hashlib.sha256(...).hexdigest()` with `hashlib.pbkdf2_hmac` (for example, using 'sha256', password+prefix, some salt, and a high number of iterations).
- Ideally, tie the number of iterations to the `rounds` parameter in `gensalt` to mimic the common bcrypt interface.

Because no external dependencies are to be introduced and only shown code may be edited, the fix will use `pbkdf2_hmac` as a suitable drop-in replacement for this stub.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
