### PR TITLE
chore: use python 3.11 for dependency graph

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Component detection
         # yamllint disable-line rule:line-length
         uses: advanced-security/component-detection-dependency-submission-action@d433c2f467e149a8009c8fbce92cc708ed15ef7b # v0.1.0


### PR DESCRIPTION
## Summary
- use python 3.11 in dependency graph workflow

## Testing
- `pre-commit run --files .github/workflows/dependency-graph.yml` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68c064e2b140832d81a7f4b2911ce7a5