### PR TITLE
chore: run dependabot workflow with base repo token

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -2,7 +2,7 @@
 name: Dependabot Auto Merge
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
 
 permissions:


### PR DESCRIPTION
## Summary
- use pull_request_target so Dependabot workflow has write access

## Testing
- `pytest -m "not integration" -q`
- `actionlint .github/workflows/dependabot.yml` *(fails: Not: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0651e4624832da2976b17202be7b2