### PR TITLE
Mitigate tar CVE-2025-45582 in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y --no-install
     && curl --netrc-file /dev/null -L https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz \
     && echo "${ZLIB_SHA256}  zlib.tar.gz" | sha256sum -c - \
     && (find /usr -type l -lname "*..*" -print 2>/dev/null || true) \
-    && tar --no-overwrite-dir -xf zlib.tar.gz \
+    # Используем --keep-directory-symlink для предотвращения CVE-2025-45582
+    && tar --keep-directory-symlink --no-overwrite-dir -xf zlib.tar.gz \
     && cd zlib-${ZLIB_VERSION} && ./configure --prefix=/usr && make -j"$(nproc)" && make install && cd .. \
     && rm -rf zlib.tar.gz zlib-${ZLIB_VERSION} \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -43,7 +43,8 @@ RUN apt-get install -y --no-install-recommends \
     python3.12-minimal \
     curl \
     python3 \
-    coreutils libgcrypt20 login passwd tar \
+    # Исключаем tar, чтобы избежать CVE-2025-45582
+    coreutils libgcrypt20 login passwd \
     && apt-get install -y --only-upgrade libpam0g \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && python3 --version


### PR DESCRIPTION
## Summary
- Guard tar extraction with `--keep-directory-symlink` to block CVE-2025-45582
- Drop `tar` package from CPU runtime image to avoid vulnerable dependency

## Testing
- `pre-commit run --files Dockerfile Dockerfile.cpu` *(fails: Interrupted: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c06642f600832db2459c7ec34fadab