### PR TITLE
chore: upgrade libpam modules to address CVE-2024-10963

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y --no-install
     libssl-dev \
     libffi-dev \
     libpam0g \
+    libpam-modules \
     libblas-dev \
     liblapack-dev \
     tar \
@@ -86,6 +87,7 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y --no-install
     coreutils \
     zlib1g \
     libpam0g \
+    libpam-modules \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && ldconfig \
     && /app/venv/bin/python --version \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -10,7 +10,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install --no-install-recommends -y \
     python3 python3-venv build-essential linux-libc-dev libgcrypt20 git=1:2.43.0-1ubuntu7.3 \
     && apt-get install -y --no-install-recommends gnupg dirmngr \
-    && apt-get install -y --only-upgrade libpam0g \
+    && apt-get install -y --only-upgrade libpam0g libpam-modules \
     && python3 -m venv /venv \
     && apt-get purge -y --auto-remove build-essential \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
@@ -37,7 +37,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install --no-install-recommends -y \
     libssl3t64=3.0.13-0ubuntu3.5 \
     python3.12-minimal=3.12.3-1ubuntu0.8 \
-    && apt-get install -y --only-upgrade openssl libssl3t64 libpam0g \
+    && apt-get install -y --only-upgrade openssl libssl3t64 libpam0g libpam-modules \
     && apt-get purge -y git \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -13,7 +13,7 @@ RUN apt-get install -y --no-install-recommends \
     curl \
     python3 python3-venv python3-dev \
     zlib1g-dev \
-    && apt-get install -y --only-upgrade libpam0g \
+    && apt-get install -y --only-upgrade libpam0g libpam-modules \
 
 WORKDIR /app
 
@@ -45,7 +45,7 @@ RUN apt-get install -y --no-install-recommends \
     python3 \
     # Исключаем tar, чтобы избежать CVE-2025-45582
     coreutils libgcrypt20 login passwd \
-    && apt-get install -y --only-upgrade libpam0g \
+    && apt-get install -y --only-upgrade libpam0g libpam-modules \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && python3 --version
 

--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -3,13 +3,13 @@ FROM python:3.11-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libtbbmalloc2 libnuma1 curl git \
     && apt-get install -y --no-install-recommends gnupg dirmngr \
-    && apt-get install -y --only-upgrade libpam0g \
+    && apt-get install -y --only-upgrade libpam0g libpam-modules \
     && rm -rf /var/lib/apt/lists/* \
     && gpg --version \
     && dirmngr --version
 
 # Ensure curl is up to date
-RUN apt-get update && apt-get install -y --only-upgrade curl libpam0g \
+RUN apt-get update && apt-get install -y --only-upgrade curl libpam0g libpam-modules \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONUNBUFFERED=1 HF_HOME=/workspace/hf-cache


### PR DESCRIPTION
## Summary
- install and upgrade libpam-modules alongside libpam0g
- apply the update across all Dockerfiles to mitigate CVE-2024-10963

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68c0677fd0dc832db2ff0c971d37281d