### PR TITLE
Fix stub cookie jar for tests

### DIFF
--- a/test_stubs.py
+++ b/test_stubs.py
@@ -163,7 +163,16 @@ def apply() -> None:
             return _HTTPXResponse()
 
         class _CookieJar(dict):  # pragma: no cover - minimal cookie jar
-            ...
+            """Simplified cookie jar supporting assignment via ``set``.
+
+            The real :mod:`httpx` cookie jar exposes a ``set`` method which is
+            used by tests to store CSRF tokens.  Implementing the method here
+            allows the stub client to mimic that behaviour when the actual
+            dependency is not installed.
+            """
+
+            def set(self, key: str, value: str, **_kwargs: Any) -> None:
+                self[key] = value
 
         class _AsyncClient:
             """Lightweight stand in for :class:`httpx.AsyncClient`."""


### PR DESCRIPTION
## Summary
- add `set` method to CookieJar stub so CSRF tests can store tokens without real httpx dependency

## Testing
- `pre-commit run --files test_stubs.py`
- `pytest tests/test_server_auth.py tests/test_server_csrf_unexpected.py tests/test_server_request_validation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c068ed70c4832dbeb7541e1dec5091