### PR TITLE
fix: add explicit GET for price endpoints

### DIFF
--- a/data_handler/api.py
+++ b/data_handler/api.py
@@ -5,7 +5,7 @@ from .storage import price_storage, DEFAULT_PRICE
 api_app = Flask(__name__)
 
 
-@api_app.route('/price/<symbol>')
+@api_app.route('/price/<symbol>', methods=['GET'])
 def price(symbol: str):
     price = price_storage.get(symbol)
     if price is None:

--- a/services/data_handler_service.py
+++ b/services/data_handler_service.py
@@ -71,7 +71,7 @@ CCXT_BASE_ERROR = getattr(ccxt, 'BaseError', Exception)
 CCXT_NETWORK_ERROR = getattr(ccxt, 'NetworkError', CCXT_BASE_ERROR)
 
 # Correct price endpoint without trailing whitespace
-@app.route('/price/<symbol>')
+@app.route('/price/<symbol>', methods=['GET'])
 def price(symbol: str) -> ResponseReturnValue:
     if exchange is None:
         return jsonify({'error': 'exchange not initialized'}), 503


### PR DESCRIPTION
## Summary
- explicitly mark price routes as GET handlers to ensure proper API semantics

## Testing
- `flake8` *(fails: command not found)*
- `mypy .` *(fails: Name "decorator" already defined on line 102; Name "code" is not defined)*
- `pytest tests/test_data_handler.py::test_price_endpoint_returns_default -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68c070e806ec832d952b9255e5bd5de6