### PR TITLE
ci: extend pytest timeout and report summary

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Run pytest
         run: |
           set -o pipefail
-          timeout 15m pytest | tee pytest.log || code=$?
+          timeout 25m pytest -ra | tee pytest.log || code=$?
           exit $code
       - name: Upload pytest log
         if: always()


### PR DESCRIPTION
## Summary
- increase pytest timeout to 25m and report skipped tests with -ra

## Testing
- `pre-commit run --files .github/workflows/ci_cpu.yml` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68c073e87488832d9c3ed7e0ae6b0f27