### PR TITLE
pin test tools and cache deps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,8 +26,6 @@ jobs:
           cache-dependency-path: |
             requirements*.txt
             pyproject.toml
-            setup.cfg
-            setup.py
       - name: Upgrade pip/setuptools/wheel
         run: python -m pip install --upgrade pip setuptools wheel
       - name: Install deps (core + ci + extras if exist)

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -3,7 +3,7 @@ aiohttp>=3.9.4
 bcrypt>=4.1.2
 flake8==7.3.0
 pytest==8.4.2
-pytest-asyncio>=0.23
+pytest-asyncio==1.1.0
 tenacity>=8.5,<10
 fastapi==0.116.1
 fastapi-csrf-protect==1.0.6


### PR DESCRIPTION
## Summary
- pin pytest-asyncio for consistent CI runs
- streamline Python setup cache paths in test workflow

## Testing
- `python -m flake8 . >/tmp/flake8.log && tail -n 20 /tmp/flake8.log` *(fails: F821 undefined name 'code')*
- `pytest -q >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68c073e4a824832d92e3eb3db614eb15