### PR TITLE
chore: ensure mock server cleanup in ci_cpu workflow

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -33,6 +33,7 @@ jobs:
           device: ${{ matrix.device }}
       - name: Start mock server
         run: |
+          trap 'if [ -f server.pid ]; then kill $(cat server.pid) || true; fi' EXIT
           python - <<'PY' &
           from http.server import BaseHTTPRequestHandler, HTTPServer
           import json


### PR DESCRIPTION
## Summary
- ensure mock server is killed on CI exit

## Testing
- `pre-commit run --files .github/workflows/ci_cpu.yml` *(command not found: pre-commit)*
- `pytest` *(29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c073ea3994832d91f0915e451c8ade