### PR TITLE
ci: add concurrency group for cpu workflow

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -4,6 +4,10 @@ permissions:
   contents: read
   actions: write
 
+concurrency:
+  group: ci-cpu-${{ github.ref }}
+  cancel-in-progress: false
+
 on:
   push:
     paths-ignore:
@@ -22,6 +26,7 @@ jobs:
   lint-type-test:
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         python-version: ['3.10', '3.11']
         device: [cpu]


### PR DESCRIPTION
## Summary
- ensure exclusive concurrency group for CPU CI runs
- run CPU workflow matrices sequentially

## Testing
- `pre-commit run --files .github/workflows/ci_cpu.yml` *(failed: ModuleNotFoundError: No module named 'pandas')*
- `pytest -q` *(failed: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68c073ef6ce4832da662f3067e9779b5