### PR TITLE
fix: dependency graph action

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -25,5 +25,4 @@ jobs:
         # yamllint disable-line rule:line-length
         uses: advanced-security/component-detection-dependency-submission-action@d433c2f467e149a8009c8fbce92cc708ed15ef7b # v0.1.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           detectorArgs: 'Pip=EnableIfDefaultOff'


### PR DESCRIPTION
## Summary
- remove unsupported token input from dependency graph auto submission

## Testing
- `pre-commit run --files .github/workflows/dependency-graph.yml` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68c0742ebf98832dbbf175ac041705af