### PR TITLE
fix: streamline dependabot merge condition

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -54,9 +54,7 @@ jobs:
         run: pytest -m "not integration" -q
 
       - name: Enable auto-merge for Dependabot PRs
-        if: >-
-          ${{ steps.metadata.outputs['update-type'] !=
-              'version-update:semver-major' }}
+        if: ${{ steps.metadata.outputs['update-type'] != 'version-update:semver-major' }}
         # yamllint disable-line rule:line-length
         uses: peter-evans/enable-pull-request-automerge@v3
         with:


### PR DESCRIPTION
## Summary
- simplify Dependabot auto-merge condition

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml`
- `pytest -m "not integration" -q`
- `/root/.local/share/mise/installs/go/1.24.3/bin/actionlint .github/workflows/dependabot.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c07448f04c832d8c74d578f69c3923