### PR TITLE
chore: fix release drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -14,8 +14,9 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Update release draft
-        uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
+        uses: release-drafter/release-drafter@v6
         with:
           config-name: release-drafter.yml
         env:


### PR DESCRIPTION
## Summary
- ensure repository checkout
- update release-drafter action to v6

## Testing
- `actionlint .github/workflows/release-drafter.yml`
- `pre-commit run --files .github/workflows/release-drafter.yml .github/release-drafter.yml` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68c12c956830832db5d6ae2a09a61ff7