### PR TITLE
chore: fix dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -2,7 +2,7 @@
 name: Dependabot Auto Merge
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
 
 permissions:

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -8,6 +8,7 @@ tenacity>=8.5,<10
 fastapi==0.116.1
 fastapi-csrf-protect==1.0.6
 flask>=3.0.3,<4
+pydantic==2.11.7
 # gymnasium and scikit-learn are unavailable on some Python versions
 gymnasium==1.2.0; python_version<'3.12'
 pandas>=2.2.0
@@ -27,3 +28,4 @@ hypothesis>=6.90.0
 numpy==1.26.4
 pip-audit==2.9.0
 pybit>=5.7.0
+


### PR DESCRIPTION
## Summary
- ensure auto-merge workflow runs on `pull_request_target` for proper permissions
- add missing `pydantic` dependency to CI requirements

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml requirements-ci.txt`
- `pytest -m "not integration" -q`


------
https://chatgpt.com/codex/tasks/task_e_68c12c709258832d91471986df3263f1