### PR TITLE
fix: guard docker hub login

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -95,6 +95,7 @@ jobs:
           fi
 
       - name: Login to Docker Hub
+        if: env.TRIVY_ENABLED == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
## Summary
- avoid failing when Docker Hub creds absent by conditionally logging in

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml`
- `SKIP=pytest pre-commit run --files .github/workflows/docker-publish.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c12c4d23b0832dba26a0a741d19466