### PR TITLE
Fix dependency graph workflow

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -14,7 +14,7 @@ jobs:
   auto-submission:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
       - name: Set up Python
@@ -23,6 +23,6 @@ jobs:
           python-version: '3.11'
       - name: Component detection
         # yamllint disable-line rule:line-length
-        uses: advanced-security/component-detection-dependency-submission-action@d433c2f467e149a8009c8fbce92cc708ed15ef7b # v0.1.0
+        uses: advanced-security/component-detection-dependency-submission-action@c7cb2bbc9360d8a011e4fac7dc542c689415d62f # v0.1.0
         with:
           detectorArgs: 'Pip=EnableIfDefaultOff'


### PR DESCRIPTION
## Summary
- update dependency graph workflow to latest component-detection action commit

## Testing
- `pre-commit run flake8 --files .github/workflows/dependency-graph.yml`
- `pre-commit run --files .github/workflows/dependency-graph.yml` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68c12c3f6a70832da9c24a4ea0a1bbea