### PR TITLE
fix: ensure release drafter workflow fetches full history

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Update release draft
         uses: release-drafter/release-drafter@v6
         with:


### PR DESCRIPTION
## Summary
- ensure release drafter fetches full git history for tag detection

## Testing
- `pre-commit run --files .github/workflows/release-drafter.yml` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68c160893734832da146a1bcb2b475cd