### PR TITLE
Test Dependabot updates against PR head

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       # Set up a lightweight Python environment and install only the


### PR DESCRIPTION
## Summary
- ensure Dependabot workflow checks out the PR commit before testing

## Testing
- `pytest -m "not integration" -q`
- `/root/.local/share/mise/installs/go/1.24.3/bin/actionlint .github/workflows/dependabot.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c1606d8b40832da87cf2b8210b2238