### PR TITLE
fix: restore Flask error handler registration

### DIFF
--- a/flask.py
+++ b/flask.py
@@ -108,6 +108,11 @@ class Flask:
 
         return decorator
 
+    def errorhandler(
+        self, code: int | Type[Exception]
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        """Register a function to handle an HTTP status code or exception."""
+
         def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
             self._error_handlers[code] = func
             return func


### PR DESCRIPTION
## Summary
- implement proper `errorhandler` method in Flask stub

## Testing
- `flake8 --exclude venv .`
- `mypy --no-site-packages --exclude venv .`
- `pytest -ra`


------
https://chatgpt.com/codex/tasks/task_e_68c160627504832d97992fff0ede897e