### PR TITLE
fix: correct Docker image tags expression

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -136,7 +136,8 @@ jobs:
           context: .
           file: ${{ matrix.file }}
           push: ${{ env.TRIVY_ENABLED == 'true' }}
-          tags: ${{ env.TRIVY_ENABLED == 'true' && format('docker.io/{0}/{1}:latest', env.DOCKERHUB_USERNAME, matrix.image) || format('{0}:latest', matrix.image) }}
+          tags: >-
+            ${{ env.TRIVY_ENABLED == 'true' && format('docker.io/{0}/{1}:latest', env.DOCKERHUB_USERNAME, matrix.image) || format('{0}:latest', matrix.image) }}
           cache-from: type=local,src=${{ github.workspace }}/.buildx-cache
           cache-to: type=local,dest=${{ github.workspace }}/.buildx-cache-new,mode=max
 


### PR DESCRIPTION
## Summary
- avoid YAML misparsing by folding long tags expression in Docker publish workflow

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml` *(fails: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c1604c202c832da176b3024c371262