### PR TITLE
fix dependency graph workflow

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -23,6 +23,6 @@ jobs:
           python-version: '3.11'
       - name: Component detection
         # yamllint disable-line rule:line-length
-        uses: advanced-security/component-detection-dependency-submission-action@c7cb2bbc9360d8a011e4fac7dc542c689415d62f # v0.1.0
+        uses: advanced-security/component-detection-dependency-submission-action@v0.1.0
         with:
           detectorArgs: 'Pip=EnableIfDefaultOff'


### PR DESCRIPTION
## Summary
- use tag-based reference for component detection action in dependency graph workflow

## Testing
- `pre-commit run --files .github/workflows/dependency-graph.yml` *(fails: Interrupted: 29 errors during collection)*
- `pytest` *(fails: Interrupted: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c1602b2a30832d9bc416a62fb365eb