### PR TITLE
chore: declare runtime deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,11 @@ classifiers = ["Programming Language :: Python :: 3"]
 dependencies = [
     "flask>=3.0.2",
     "httpx>=0.27.0",
+    "fastapi>=0.116.1",
+    "aiohttp>=3.12.15",
+    "pandas>=2.3.2",
+    "numpy>=2.3.3",
+    "pydantic>=2.11.7",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary
- declare FastAPI, aiohttp, pandas, numpy and pydantic as project dependencies

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c170391940832dbfa2d9c2705689da