### PR TITLE
Исправлен запуск линтеров в CI

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Run flake8
         run: |
           set -o pipefail
-          flake8 --exclude venv . | tee flake8.log || code=$?
+          python -m flake8 --exclude venv . | tee flake8.log || code=$?
           exit $code
       - name: Upload flake8 log
         if: always()
@@ -77,7 +77,7 @@ jobs:
           path: flake8.log
           if-no-files-found: ignore
       - name: Run mypy
-        run: mypy --no-site-packages --exclude venv .
+        run: python -m mypy --no-site-packages --exclude venv .
       - name: Remove test caches
         if: always()
         uses: ./.github/actions/clear-test-caches


### PR DESCRIPTION
## Summary
- запуск flake8 и mypy через `python -m` для надежности

## Testing
- `python -m flake8 --exclude venv .`
- `python -m mypy --no-site-packages --exclude venv .`
- `pytest -ra`


------
https://chatgpt.com/codex/tasks/task_e_68c1705310fc832db430c8391d1e9794