### PR TITLE
test: require httpx for server tests

### DIFF
--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -3,8 +3,8 @@ import os
 import pytest
 
 pytest.importorskip("transformers")
+pytest.importorskip("httpx")
 
-import pytest
 import server
 from contextlib import contextmanager
 from fastapi.testclient import TestClient

--- a/tests/test_server_csrf_unexpected.py
+++ b/tests/test_server_csrf_unexpected.py
@@ -2,6 +2,7 @@ import os
 import pytest
 
 pytest.importorskip("transformers")
+pytest.importorskip("httpx")
 
 os.environ.setdefault("CSRF_SECRET", "testsecret")
 import server

--- a/tests/test_server_missing_api_keys.py
+++ b/tests/test_server_missing_api_keys.py
@@ -1,6 +1,8 @@
 import importlib
 import sys
 import pytest
+
+pytest.importorskip("httpx")
 from fastapi.testclient import TestClient
 
 

--- a/tests/test_server_request_validation.py
+++ b/tests/test_server_request_validation.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 pytest.importorskip("transformers")
+pytest.importorskip("httpx")
 pytest.importorskip("fastapi_csrf_protect")
 
 os.environ.setdefault("CSRF_SECRET", "testsecret")


### PR DESCRIPTION
## Summary
- skip server tests when `httpx` is not installed to avoid misleading results

## Testing
- `pytest tests/test_server_auth.py tests/test_server_csrf_unexpected.py tests/test_server_missing_api_keys.py tests/test_server_request_validation.py -q`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1706dac4c832d8e081ca599839eea