### PR TITLE
fix: push images to ghcr

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -135,9 +135,8 @@ jobs:
         with:
           context: .
           file: ${{ matrix.file }}
-          push: ${{ env.TRIVY_ENABLED == 'true' }}
-          tags: >-
-            ${{ env.TRIVY_ENABLED == 'true' && format('docker.io/{0}/{1}:latest', env.DOCKERHUB_USERNAME, matrix.image) || format('{0}:latest', matrix.image) }}
+          push: true
+          tags: ${{ env.TRIVY_ENABLED == 'true' && format('ghcr.io/{0}/{1}:latest,docker.io/{2}/{1}:latest', github.repository_owner, matrix.image, env.DOCKERHUB_USERNAME) || format('ghcr.io/{0}/{1}:latest', github.repository_owner, matrix.image) }}
           cache-from: type=local,src=${{ github.workspace }}/.buildx-cache
           cache-to: type=local,dest=${{ github.workspace }}/.buildx-cache-new,mode=max
 


### PR DESCRIPTION
## Summary
- ensure docker images are always pushed to GitHub Container Registry
- keep optional Docker Hub push when credentials are present

## Testing
- `yamllint .github/workflows/docker-publish.yml`
- `/tmp/actionlint -no-color .github/workflows/docker-publish.yml`
- `pre-commit run --files .github/workflows/docker-publish.yml` *(fails: ModuleNotFoundError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b7082350832d9c986d01a466ee80