### PR TITLE
fix: enable network for LLM review workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -44,7 +44,6 @@ jobs:
         run: |
           set -euo pipefail
           docker run -d --rm --name gptoss \
-            --network none \
             -e HUGGING_FACE_HUB_TOKEN="$HF_TOKEN" \
             -p 127.0.0.1:8000:8000 \
             vllm/vllm-openai:v0.10.1 \


### PR DESCRIPTION
## Summary
- allow vLLM container network access to download models

## Testing
- `./actionlint .github/workflows/gptoss_review.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c1b7496ce8832d87c5a64e9fed8ac6