### PR TITLE
chore: drop python 3.12 from ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11']
         device: [cpu]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
@@ -84,7 +84,7 @@ jobs:
     needs: unit
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11']
         device: [cpu]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5


### PR DESCRIPTION
## Summary
- remove unsupported Python 3.12 from CI matrix

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -m "not integration"`
- `pytest -m integration`


------
https://chatgpt.com/codex/tasks/task_e_68c1b716f900832db6c1bff7855753ba