### PR TITLE
chore: fix release drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -14,7 +14,7 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
           fetch-depth: 0
       - name: Update release draft


### PR DESCRIPTION
## Summary
- use stable actions/checkout v4 commit in release drafter workflow

## Testing
- `pre-commit run --files .github/workflows/release-drafter.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1b7627180832d91b0f38b6e872d5f