### PR TITLE
Configure gptoss review workflow concurrency

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -13,6 +13,10 @@ permissions:
   pull-requests: write
   issues: write
 
+concurrency:
+  group: gptoss-review-${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   review:
     # Защита: не запускаем на fork без метки "safe-to-test"
@@ -28,7 +32,10 @@ jobs:
           github.event.comment != null &&
           contains(github.event.comment.body || '', '/llm-review'))
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
     env:
       PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
       MODEL_NAME: ${{ vars.LLM_MODEL || 'Qwen/Qwen2.5-Coder-1.5B-Instruct' }}


### PR DESCRIPTION
## Summary
- add concurrency block to gptoss review workflow
- set job timeout to 30 min and default shell to bash

## Testing
- `pre-commit run --files .github/workflows/gptoss_review.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1b985caec832d86477ab2fcd9f8a2