### PR TITLE
chore: add review job permissions

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -27,6 +27,10 @@ jobs:
           github.event.issue.pull_request != null &&
           github.event.comment != null &&
           contains(github.event.comment.body || '', '/llm-review'))
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:


### PR DESCRIPTION
## Summary
- explicitly set permissions for review job in `gptoss_review.yml`

## Testing
- `pre-commit run --files .github/workflows/gptoss_review.yml` *(interrupted)*


------
https://chatgpt.com/codex/tasks/task_e_68c1b9881400832dac84452f29a01a78