### PR TITLE
fix tomli stub for python 3.10

### DIFF
--- a/tomli.py
+++ b/tomli.py
@@ -1,6 +1,21 @@
-"""Minimal tomli stub using built-in tomllib."""
+"""Minimal TOML loader using the stdlib when available."""
 
-import tomllib as _tomllib
+try:  # Python 3.11+
+    import tomllib as _tomllib  # type: ignore
+except ModuleNotFoundError:  # Python <3.11
+    import importlib
+    import os
+    import sys
+
+    _path = sys.path.copy()
+    _module = sys.modules.pop(__name__, None)
+    try:
+        sys.path = [p for p in sys.path if p not in ("", ".", os.path.dirname(__file__))]
+        _tomllib = importlib.import_module("tomli")  # type: ignore
+    finally:
+        if _module is not None:
+            sys.modules[__name__] = _module
+        sys.path = _path
 
 loads = _tomllib.loads
 


### PR DESCRIPTION
## Summary
- fix tomli shim to fall back to tomli package on Python 3.10

## Testing
- `python -m flake8 --exclude venv .`
- `python -m mypy --no-site-packages --exclude venv .`
- `pytest -ra`


------
https://chatgpt.com/codex/tasks/task_e_68c1b725eab4832dae76adc0920489e9