### PR TITLE
fix: add diff generation step in gptoss workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -80,7 +80,9 @@ jobs:
           docker logs gptoss || true
           exit 1
 
+      - name: Generate diff
         if: steps.wait_llm.outcome == 'success'
+        id: generate_diff
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
## Summary
- add missing generate diff step to gptoss_review workflow

## Testing
- `yamllint .github/workflows/gptoss_review.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1bc7e2fd0832d825615f7a52e1a9b