### PR TITLE
fix gptoss review diff truncation

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -98,7 +98,7 @@ jobs:
             echo "has_diff=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          head -c 200000 diff.patch > diff.patch
+          head -c 200000 diff.patch > diff.patch.trunc && mv diff.patch.trunc diff.patch
           echo "has_diff=true" >> "$GITHUB_OUTPUT"
 
       - name: LLM review


### PR DESCRIPTION
## Summary
- prevent diff.patch from being truncated to empty file when limiting size in gptoss_review workflow

## Testing
- `pre-commit run --files .github/workflows/gptoss_review.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1bdd24a64832d9cd1fbe10d86e482