### PR TITLE
Fix setup-python action version in dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -41,7 +41,7 @@ jobs:
       # Dependabot update checks to fail.
       - name: Setup Python
         if: ${{ steps.metadata.outputs['package-ecosystem'] == 'pip' }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- use `actions/setup-python@v5` in dependabot workflow

## Testing
- `pytest -m "not integration" -q`
- `pre-commit run --files .github/workflows/dependabot.yml`

------
https://chatgpt.com/codex/tasks/task_e_68c1c448ea4c832d82f4f438b22a7811