### PR TITLE
Refine docker tags expression in publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -136,7 +136,10 @@ jobs:
           context: .
           file: ${{ matrix.file }}
           push: true
-          tags: ${{ env.TRIVY_ENABLED == 'true' && format('ghcr.io/{0}/{1}:latest,docker.io/{2}/{1}:latest', github.repository_owner, matrix.image, env.DOCKERHUB_USERNAME) || format('ghcr.io/{0}/{1}:latest', github.repository_owner, matrix.image) }}
+          tags: >-
+            ${{ env.TRIVY_ENABLED == 'true' &&
+                format('ghcr.io/{0}/{1}:latest,docker.io/{2}/{1}:latest', github.repository_owner, matrix.image, env.DOCKERHUB_USERNAME) ||
+                format('ghcr.io/{0}/{1}:latest', github.repository_owner, matrix.image) }}
           cache-from: type=local,src=${{ github.workspace }}/.buildx-cache
           cache-to: type=local,dest=${{ github.workspace }}/.buildx-cache-new,mode=max
 


### PR DESCRIPTION
## Summary
- ensure docker tags expression uses repository owner correctly with multiline format

## Testing
- `yamllint .github/workflows/docker-publish.yml`
- `pre-commit run --files .github/workflows/docker-publish.yml`

------
https://chatgpt.com/codex/tasks/task_e_68c1c6f75064832db7973289f75a9cd7