### PR TITLE
feat: allow flake8 failures in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,5 +36,6 @@ jobs:
           test -f requirements-extras.txt && python -m pip install -r requirements-extras.txt || true
       - name: Lint (flake8)
         run: flake8 .
+        continue-on-error: true
       - name: Run tests (pytest)
         run: pytest -q --maxfail=1 --disable-warnings


### PR DESCRIPTION
## Summary
- let flake8 failures pass in Tests workflow

## Testing
- `pre-commit run --files .github/workflows/tests.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c1caa7a348832dbe8386d6a84c93c7