### PR TITLE
feat: login to registries before pushing images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -94,19 +94,6 @@ jobs:
             sudo service docker start
           fi
 
-      - name: Login to Docker Hub
-        if: env.TRIVY_ENABLED == 'true'
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Prepare buildx cache directory
         run: |
           mkdir -p "$GITHUB_WORKSPACE/.buildx-cache"
@@ -129,6 +116,20 @@ jobs:
         run: |
           mount | grep '/mnt' || true
           df -h /mnt
+
+      - name: Login to Docker Hub
+        if: env.TRIVY_ENABLED == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83  # v6.18.0


### PR DESCRIPTION
## Summary
- login to Docker Hub and GHCR before publishing images

## Testing
- `pre-commit run flake8 --files .github/workflows/docker-publish.yml`
- `pytest tests/test_http_client_cleanup.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1cabda704832d8a7967932e0be89f