### PR TITLE
fix: корректный запуск workflow dependabot

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,7 +1,7 @@
 ---
 name: Dependabot Auto Merge
 
-'on':
+on:  # yamllint disable-line rule:truthy
   pull_request_target:
     types: [opened, reopened, synchronize]
 


### PR DESCRIPTION
## Summary
- гарантирован запуск workflow через `on` без ложных предупреждений `yamllint`

## Testing
- `yamllint .github/workflows/dependabot.yml`
- `pytest -m "not integration" -q`

------
https://chatgpt.com/codex/tasks/task_e_68c1da06ab90832d83a9316e7ae8b8c6