### PR TITLE
chore: synchronize dependency pins for dependabot

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -44,7 +44,7 @@ cachetools==5.5.2
     #   mlflow-tracing
 catalyst==21.5
     # via -r requirements-core.in
-ccxt==4.5.1
+ccxt==4.5.3
     # via -r requirements-core.in
 ccxtpro==1.0.1
     # via -r requirements-core.in
@@ -214,11 +214,11 @@ matplotlib==3.10.5
     # via
     #   mlflow
     #   stable-baselines3
-mlflow==3.3.1
+mlflow==3.3.2
     # via -r requirements-core.in
-mlflow-skinny==3.3.1
+mlflow-skinny==3.3.2
     # via mlflow
-mlflow-tracing==3.3.1
+mlflow-tracing==3.3.2
     # via mlflow
 mpmath==1.3.0
     # via sympy
@@ -366,7 +366,7 @@ python-dotenv==1.1.1
     #   pydantic-settings
 python-telegram-bot==22.3
     # via -r requirements-core.in
-pytorch-lightning==2.5.3
+pytorch-lightning==2.5.5
     # via -r requirements-core.in
 pytz==2025.2
     # via pandas

--- a/requirements.out
+++ b/requirements.out
@@ -60,7 +60,7 @@ cachetools==5.5.2
     #   mlflow-tracing
 catalyst==21.5
     # via -r requirements.txt
-ccxt==4.5.2
+ccxt==4.5.3
     # via -r requirements.txt
 ccxtpro==1.0.1
     # via -r requirements.txt
@@ -296,13 +296,13 @@ matplotlib==3.10.5
     #   -r requirements.txt
     #   mlflow
     #   stable-baselines3
-mlflow==3.3.1
+mlflow==3.3.2
     # via -r requirements.txt
-mlflow-skinny==3.3.1
+mlflow-skinny==3.3.2
     # via
     #   -r requirements.txt
     #   mlflow
-mlflow-tracing==3.3.1
+mlflow-tracing==3.3.2
     # via
     #   -r requirements.txt
     #   mlflow
@@ -496,7 +496,7 @@ python-dotenv==1.1.1
     #   pydantic-settings
 python-telegram-bot==22.3
     # via -r requirements.txt
-pytorch-lightning==2.5.3
+pytorch-lightning==2.5.5
     # via -r requirements.txt
 pytz==2025.2
     # via


### PR DESCRIPTION
## Summary
- align ccxt, mlflow, and pytorch-lightning versions across requirement files to stabilize dependabot updates

## Testing
- `pytest -m "not integration" -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1da18c038832d904ec3dbc2d78b03