### PR TITLE
Fix Trivy workflow failure detection

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -50,6 +50,6 @@ jobs:
           path: trivy-results.sarif
 
       - name: Fail if vulnerabilities found
-        if: ${{ steps.trivy.outcome == 'failure' }}
+        if: ${{ steps.trivy.conclusion == 'failure' }}
         run: exit 1
 


### PR DESCRIPTION
## Summary
- ensure Trivy step failure detected via `conclusion`

## Testing
- `pre-commit run flake8 --files .github/workflows/trivy.yml`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1da3d1438832dae51d44746e09f6c