### PR TITLE
fix: install deps for dependency graph

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -21,6 +21,10 @@ jobs:
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
       - name: Component detection
         # yamllint disable-line rule:line-length
         uses: advanced-security/component-detection-dependency-submission-action@v0.1.0


### PR DESCRIPTION
## Summary
- ensure workflow installs Python dependencies before submitting dependency graph

## Testing
- `pre-commit run --files .github/workflows/dependency-graph.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c1db3de608832d97b8293a202d0656