### PR TITLE
fix: update release-drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,13 +4,13 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
   workflow_dispatch:
 
 permissions:
   contents: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
## Summary
- ensure release draft workflow has write permissions and runs on `pull_request_target`

## Testing
- `./actionlint .github/workflows/release-drafter.yml`
- `pre-commit run --files .github/workflows/release-drafter.yml .github/release-drafter.yml --hook-stage manual`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1db941a18832daf7f0bf35b24a6ee