### PR TITLE
fix: adjust docker publish tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -139,7 +139,8 @@ jobs:
           push: true
           tags: >-
             ${{ env.TRIVY_ENABLED == 'true' &&
-                format('ghcr.io/{0}/{1}:latest,docker.io/{2}/{1}:latest', github.repository_owner, matrix.image, env.DOCKERHUB_USERNAME) ||
+                format('ghcr.io/{0}/{1}:latest,docker.io/{2}/{1}:latest',
+                       github.repository_owner, matrix.image, env.DOCKERHUB_USERNAME) ||
                 format('ghcr.io/{0}/{1}:latest', github.repository_owner, matrix.image) }}
           cache-from: type=local,src=${{ github.workspace }}/.buildx-cache
           cache-to: type=local,dest=${{ github.workspace }}/.buildx-cache-new,mode=max


### PR DESCRIPTION
## Summary
- prevent variable names from breaking in docker tag expression

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml`

------
https://chatgpt.com/codex/tasks/task_e_68c26ecde3e0832d98bf4fc1bf18893e