### PR TITLE
fix: pin actions in dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -28,7 +28,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-number: ${{ github.event.pull_request.number }}
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
@@ -41,7 +41,7 @@ jobs:
       # Dependabot update checks to fail.
       - name: Setup Python
         if: ${{ steps.metadata.outputs['package-ecosystem'] == 'pip' }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: '3.11'
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- pin checkout action to commit for version 5
- pin setup-python action to commit for version 6

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c26ef4098c832d80f4e0bb8fa89206