### PR TITLE
Исправление заглушки colorama для CI

### DIFF
--- a/colorama/__init__.py
+++ b/colorama/__init__.py
@@ -38,4 +38,14 @@ def init(*args, **kwargs):  # pragma: no cover - trivial
     return None
 
 
-__all__ = ["Fore", "Style", "AnsiToWin32", "init", "__version__"]
+def deinit(*args, **kwargs):  # pragma: no cover - trivial
+    """Dummy ``deinit`` for compatibility with the real package."""
+    return None
+
+
+def reinit(*args, **kwargs):  # pragma: no cover - trivial
+    """Dummy ``reinit`` for compatibility with the real package."""
+    return None
+
+
+__all__ = ["Fore", "Style", "AnsiToWin32", "init", "deinit", "reinit", "__version__"]


### PR DESCRIPTION
## Summary
- добавить функции `deinit` и `reinit` в заглушку colorama

## Testing
- `flake8 colorama/__init__.py`
- `pytest -m "not integration"`
- `pytest -m integration` *(падает: Service at http://127.0.0.1:37299/ready did not become ready within 5.0 seconds)*

------
https://chatgpt.com/codex/tasks/task_e_68c26ed8a2e8832d8849626aecc66472