### PR TITLE
fix release drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
-    types: [opened, reopened, synchronize]
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
   workflow_dispatch:
 
 permissions:
@@ -16,9 +16,6 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
-        with:
-          fetch-depth: 0
       - name: Update release draft
         uses: release-drafter/release-drafter@7cf306f56b79636bb76931494ccf29fc893763bd # v6.1.0
         with:


### PR DESCRIPTION
## Summary
- use `pull_request` event and handle label changes
- remove unnecessary checkout step

## Testing
- `actionlint .github/workflows/release-drafter.yml`
- `pre-commit run --files .github/workflows/release-drafter.yml .github/release-drafter.yml` *(failed: pytest interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68c26f1c7298832d9502c6a774c368ad