### PR TITLE
feat: add HTTP retry with caching

### DIFF
--- a/tests/test_http_client_retry_cache.py
+++ b/tests/test_http_client_retry_cache.py
@@ -1,0 +1,51 @@
+import asyncio
+import types
+import random
+
+import httpx
+import pytest
+
+import http_client
+
+
+@pytest.mark.asyncio
+async def test_request_with_retry_metrics(monkeypatch):
+    # deterministic jitter
+    monkeypatch.setattr(random, "uniform", lambda a, b: 0)
+    calls = {"n": 0}
+
+    async def _request(method, url, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return httpx.Response(500, request=httpx.Request(method, url))
+        return httpx.Response(200, request=httpx.Request(method, url))
+
+    client = types.SimpleNamespace(request=_request)
+    http_client.RETRY_METRICS.clear()
+
+    resp = await http_client.request_with_retry(
+        "GET", "http://example", client=client, max_attempts=2, backoff_base=0
+    )
+    assert resp.status_code == 200
+    assert http_client.RETRY_METRICS["http://example"] == 1
+
+
+@pytest.mark.asyncio
+async def test_request_with_retry_cache(monkeypatch):
+    calls = {"n": 0}
+
+    async def _request(method, url, **kwargs):
+        calls["n"] += 1
+        return httpx.Response(200, json={"ok": True}, request=httpx.Request(method, url))
+
+    client = types.SimpleNamespace(request=_request)
+    http_client.REFERENCE_CACHE.clear()
+
+    resp1 = await http_client.request_with_retry(
+        "GET", "http://test/symbols", client=client
+    )
+    resp2 = await http_client.request_with_retry(
+        "GET", "http://test/symbols", client=client
+    )
+    assert calls["n"] == 1
+    assert resp1.text == resp2.text


### PR DESCRIPTION
## Summary
- add request_with_retry that retries 429/5xx with exponential backoff and jitter
- cache reference endpoints during process lifetime
- expose metrics on retry counts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3009adbdc832db2f48486499cc0e7