### PR TITLE
Ensure UTC timestamps during data loading

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -5,6 +5,7 @@ import shutil
 import time
 from io import BytesIO, StringIO
 import logging
+from bot.data_handler.utils import ensure_utc
 
 logger = logging.getLogger("TradingBot")
 
@@ -263,6 +264,11 @@ class HistoricalDataCache:
                         elapsed_time,
                     )
                 logger.info("Данные загружены из кэша (%s): %s", fmt, filename)
+                if isinstance(data, pd.DataFrame):
+                    if "timestamp" in data.columns:
+                        data["timestamp"] = ensure_utc(data["timestamp"])
+                    elif isinstance(data.index, pd.DatetimeIndex):
+                        data.index = ensure_utc(data.index)
                 return data
             if os.path.exists(legacy_json):
                 logger.info(
@@ -274,6 +280,11 @@ class HistoricalDataCache:
                     payload = json.load(f)
                 data_json = payload.get("data")
                 data = pd.read_json(StringIO(data_json), orient="split")
+                if isinstance(data, pd.DataFrame):
+                    if "timestamp" in data.columns:
+                        data["timestamp"] = ensure_utc(data["timestamp"])
+                    elif isinstance(data.index, pd.DatetimeIndex):
+                        data.index = ensure_utc(data.index)
                 if not isinstance(data, pd.DataFrame):
                     logger.error(
                         "Неверный тип данных в старом кэше %s_%s: %s",

--- a/data_handler/core.py
+++ b/data_handler/core.py
@@ -13,7 +13,7 @@ try:
 except Exception:  # pragma: no cover - optional
     pl = None  # type: ignore
 
-from .utils import expected_ws_rate
+from .utils import expected_ws_rate, ensure_utc
 
 
 class DataHandler:
@@ -88,7 +88,10 @@ class DataHandler:
         pdf = df.reset_index()
         if "timestamp" not in pdf.columns:
             pdf.rename(columns={pdf.columns[1]: "timestamp"}, inplace=True)
-        pdf["ema30"] = pdf["close"].ewm(span=getattr(self.cfg, "ema30_period", 30), adjust=False).mean()
+        pdf["timestamp"] = ensure_utc(pdf["timestamp"])
+        pdf["ema30"] = pdf["close"].ewm(
+            span=getattr(self.cfg, "ema30_period", 30), adjust=False
+        ).mean()
         self.indicators[symbol] = types.SimpleNamespace(df=pdf)
         if pl is not None:
             subset = pdf[["symbol", "timestamp", "open", "high", "low", "close", "volume"]]

--- a/data_handler/utils.py
+++ b/data_handler/utils.py
@@ -7,3 +7,25 @@ def expected_ws_rate(timeframe: str) -> int:
     seconds = pd.Timedelta(timeframe).total_seconds()
     return max(1, int(1800 / seconds))
 
+
+def ensure_utc(ts: pd.Series | pd.Index) -> pd.Series | pd.Index:
+    """Convert timestamp series or index to UTC timezone.
+
+    Вход может быть ``pd.Series`` или ``pd.Index``. Если временная зона
+    отсутствует, применяется цепочка ``tz_localize('UTC').tz_convert('UTC')``.
+    При наличии временной зоны выполняется только ``tz_convert('UTC')``.
+    """
+    if isinstance(ts, pd.Series):
+        dt = pd.to_datetime(ts)
+        if dt.dt.tz is None:
+            dt = dt.dt.tz_localize("UTC").dt.tz_convert("UTC")
+        else:  # pragma: no branch
+            dt = dt.dt.tz_convert("UTC")
+        return dt
+    dt = pd.to_datetime(ts)
+    if dt.tz is None:
+        dt = dt.tz_localize("UTC").tz_convert("UTC")
+    else:  # pragma: no branch
+        dt = dt.tz_convert("UTC")
+    return dt
+

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -1,0 +1,10 @@
+import pandas as pd
+
+
+def test_local_time_converts_to_utc():
+    local_time = pd.Timestamp.now()
+    utc_time = local_time.tz_localize('UTC').tz_convert('UTC')
+    utc_now = pd.Timestamp.utcnow().tz_convert('UTC')
+    # разница не должна превышать одну секунду
+    assert abs((utc_time - utc_now).total_seconds()) < 1
+    assert utc_time.tzname() == 'UTC'

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -447,11 +447,18 @@ class TradeManager:
                         self.positions = df.set_index(["symbol", "timestamp"])
                     else:
                         self.positions = df
-                if (
-                    "timestamp" in self.positions.index.names
-                    and self.positions.index.get_level_values("timestamp").tz is None
-                ):
-                    self.positions = self.positions.tz_localize("UTC", level="timestamp")
+                if "timestamp" in self.positions.index.names:
+                    ts_level = self.positions.index.get_level_values("timestamp")
+                    if ts_level.tz is None:
+                        self.positions = (
+                            self.positions
+                            .tz_localize("UTC", level="timestamp")
+                            .tz_convert("UTC", level="timestamp")
+                        )
+                    else:
+                        self.positions = self.positions.tz_convert(
+                            "UTC", level="timestamp"
+                        )
                 self._sort_positions()
             if os.path.exists(self.returns_file):
                 with open(self.returns_file, "r", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- add `ensure_utc` helper and apply it when loading data
- enforce UTC timestamps for cached data and restored positions
- add unit test comparing local time with UTC

## Testing
- `pytest tests/test_cache.py tests/test_data_handler.py tests/test_data_handler_polars.py tests/test_trade_manager.py tests/test_timezone.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c3008b3cb8832dbb5b0986c59668d4