### PR TITLE
Validate model revisions and pin fallback revision

### DIFF
--- a/server.py
+++ b/server.py
@@ -70,9 +70,9 @@ class ModelManager:
         fallback_revision = os.getenv(
             "GPT_MODEL_FALLBACK_REVISION", "5f91d94bd9cd7190a9f3216ff93cd1dd95f2c7be"
         )
-        if not re.fullmatch(r"[0-9a-f]{40}", model_revision):
+        if not re.fullmatch(r"[0-9a-f]{40}", model_revision, re.IGNORECASE):
             raise ValueError("GPT_MODEL_REVISION must be a 40-character SHA commit")
-        if not re.fullmatch(r"[0-9a-f]{40}", fallback_revision):
+        if not re.fullmatch(r"[0-9a-f]{40}", fallback_revision, re.IGNORECASE):
             raise ValueError(
                 "GPT_MODEL_FALLBACK_REVISION must be a 40-character SHA commit"
             )
@@ -132,7 +132,8 @@ class ModelManager:
 
         try:
             tokenizer_local = AutoTokenizer.from_pretrained(  # nosec  # revision validated above
-                f"{fallback_model}@{fallback_revision}",
+                fallback_model,
+                revision=fallback_revision,
                 trust_remote_code=False,
                 cache_dir=cache_dir,
             )

--- a/tests/test_server_revision_validation.py
+++ b/tests/test_server_revision_validation.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import types
+import pytest
+
+
+class _DummyTokenizer:
+    @staticmethod
+    def from_pretrained(*args, **kwargs):
+        return object()
+
+
+class _DummyModel:
+    @staticmethod
+    def from_pretrained(*args, **kwargs):
+        class _Model:
+            def to(self, *args, **kwargs):
+                return self
+        return _Model()
+
+
+def test_invalid_model_revision(monkeypatch):
+    with monkeypatch.context() as m:
+        transformers = types.ModuleType("transformers")
+        transformers.AutoTokenizer = _DummyTokenizer
+        transformers.AutoModelForCausalLM = _DummyModel
+        m.setitem(sys.modules, "transformers", transformers)
+
+        torch = types.ModuleType("torch")
+        torch.cuda = types.SimpleNamespace(is_available=lambda: False)
+        m.setitem(sys.modules, "torch", torch)
+
+        os.environ["CSRF_SECRET"] = "testsecret"
+        os.environ["GPT_MODEL_REVISION"] = "invalid"
+
+        import server
+
+        with pytest.raises(ValueError, match="GPT_MODEL_REVISION must be a 40-character SHA commit"):
+            server.model_manager.load_model()
+
+    os.environ.pop("CSRF_SECRET", None)
+    os.environ.pop("GPT_MODEL_REVISION", None)
+    try:
+        del sys.modules["server"]
+    except KeyError:
+        pass


### PR DESCRIPTION
## Summary
- verify GPT_MODEL_REVISION and GPT_MODEL_FALLBACK_REVISION are 40-char SHAs
- pass trust_remote_code=False and explicit revision to all model/tokenizer loads
- add regression test for invalid model revision

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3008666c0832d89899f0d3294376e