### PR TITLE
chore: update docker publish login secrets

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -121,15 +121,14 @@ jobs:
         if: env.TRIVY_ENABLED == 'true'
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
 
-      - name: Login to GHCR
-        uses: docker/login-action@v3
+      - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83  # v6.18.0


### PR DESCRIPTION
## Summary
- use GHCR_TOKEN for ghcr.io login in docker-publish workflow
- read Docker Hub credentials from environment variables

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c300a33c50832db64e1e505aa65539