### PR TITLE
chore: restrict docker publish permissions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,7 +4,6 @@ name: Build and Push Docker image
 permissions:
   contents: read
   packages: write
-  actions: write
 
 on:
   push:


### PR DESCRIPTION
## Summary
- remove unnecessary `actions: write` from docker publish permissions

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml`
- `curl -I -H "Authorization: Bearer $GHCR_TOKEN" https://api.github.com/user` *(fails: 401 Unauthorized)*

------
https://chatgpt.com/codex/tasks/task_e_68c300a6ae3c832d8778189fa6975758