### PR TITLE
ci: add ruff, mypy and bandit checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
           device: ${{ matrix.device }}
       - name: Install development requirements
         run: pip install -r requirements.txt -r requirements-dev.txt
+      - run: ruff bot tests --output-format=github
+      - run: mypy bot
+      - run: bandit -r bot -x tests -ll
       - name: Audit dependencies
         id: audit
         working-directory: /mnt


### PR DESCRIPTION
## Summary
- add ruff, mypy and bandit steps after installing dev requirements

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(fails: ModuleNotFoundError: pandas)*
- `pytest` *(fails: ModuleNotFoundError: pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68c300af5f40832d9428737165f99284