### PR TITLE
Compute EMA indicator and clean imports

### DIFF
--- a/data_handler/__init__.py
+++ b/data_handler/__init__.py
@@ -1,10 +1,6 @@
-
-from typing import Iterable
-
 from collections.abc import Iterable
 
 import numpy as np
-from typing import Iterable
 
 from .core import DataHandler
 try:  # pragma: no cover - optional dependency

--- a/data_handler/core.py
+++ b/data_handler/core.py
@@ -88,8 +88,12 @@ class DataHandler:
         pdf = df.reset_index()
         if "timestamp" not in pdf.columns:
             pdf.rename(columns={pdf.columns[1]: "timestamp"}, inplace=True)
+
+        span = getattr(self.cfg, "ema30_period", 30)
+        pdf["ema30"] = pdf["close"].ewm(span=span, adjust=False).mean().shift(1)
+
         self.indicators[symbol] = types.SimpleNamespace(df=pdf)
-        if pl is not None:
+        if getattr(self.cfg, "use_polars", False) and pl is not None:
             subset = pdf[["symbol", "timestamp", "open", "high", "low", "close", "volume"]]
             self._ohlcv = pl.DataFrame(subset.to_dict("list"))
 


### PR DESCRIPTION
## Summary
- add ema30 calculation with lookahead protection
- ensure polars usage only when configured
- remove redundant imports from data_handler package

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c3036a8de0832daed239686939d640