### PR TITLE
feat: use CPU docker compose in CI

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -16,6 +16,7 @@ on:
   workflow_dispatch:
 
 env:
+  DOCKERFILE: Dockerfile.cpu
   GPT_OSS_API: http://127.0.0.1:8009
   GPT_OSS_TIMEOUT: 5
   TEST_MODE: "1"
@@ -103,6 +104,10 @@ jobs:
             rm server.pid
             test ! -f server.pid
           fi
+      - name: Run docker compose
+        run: |
+          docker compose -f docker-compose.yml -f docker-compose.cpu.yml up --build --abort-on-container-exit --exit-code-from gptoss_check
+          docker compose -f docker-compose.yml -f docker-compose.cpu.yml down
       - name: Cleanup buildx
         if: always()
         run: docker buildx prune -af || true


### PR DESCRIPTION
## Summary
- set DOCKERFILE to Dockerfile.cpu in CI workflow
- run docker compose with CPU config and exit code propagation

## Testing
- `pre-commit run --files .github/workflows/ci_cpu.yml`

------
https://chatgpt.com/codex/tasks/task_e_68c300accc20832daa735b4616cad8db