### PR TITLE
Add historical OHLCV endpoint and preload data

### DIFF
--- a/services/data_handler_service.py
+++ b/services/data_handler_service.py
@@ -1,5 +1,5 @@
 """Simple reference data handler service fetching real prices from Bybit."""
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request
 from typing import Any
 try:  # optional dependency
     from flask.typing import ResponseReturnValue
@@ -10,6 +10,14 @@ import threading
 import ccxt
 import os
 from dotenv import load_dotenv
+try:  # optional dependency
+    import pandas as pd
+except Exception:  # pragma: no cover - pandas not installed
+    pd = None  # type: ignore
+try:
+    from bot.cache import HistoricalDataCache
+except Exception:  # pragma: no cover - cache module missing
+    HistoricalDataCache = None  # type: ignore
 try:  # optional dependency
     from werkzeug.exceptions import HTTPException
 except Exception:  # pragma: no cover - fallback when werkzeug absent
@@ -27,7 +35,44 @@ if hasattr(app, "config"):
     app.config["MAX_CONTENT_LENGTH"] = 1 * 1024 * 1024  # 1 MB limit
 
 exchange = None
+history_cache = (
+    HistoricalDataCache(os.getenv("CACHE_DIR", "/tmp/cache"))
+    if HistoricalDataCache
+    else None
+)
 _init_lock = threading.Lock()
+
+
+def _load_initial_history() -> None:
+    """Fetch and cache initial OHLCV history for configured symbols."""
+    if exchange is None or history_cache is None or pd is None:
+        return
+    symbols = [
+        s.strip()
+        for s in os.getenv("STREAM_SYMBOLS", "").split(",")
+        if s.strip()
+    ]
+    if not symbols:
+        return
+    timeframe = os.getenv("HISTORY_TIMEFRAME", "1m")
+    limit = int(os.getenv("HISTORY_LIMIT", "200"))
+    for sym in symbols:
+        try:
+            ohlcv = exchange.fetch_ohlcv(sym, timeframe=timeframe, limit=limit)
+            df = pd.DataFrame(
+                ohlcv,
+                columns=[
+                    "timestamp",
+                    "open",
+                    "high",
+                    "low",
+                    "close",
+                    "volume",
+                ],
+            )
+            history_cache.save_cached_data(sym, timeframe, df)
+        except Exception as exc:  # pragma: no cover - unexpected fetch errors
+            logging.exception("Failed to prefetch history for %s: %s", sym, exc)
 
 
 def init_exchange() -> None:
@@ -40,6 +85,7 @@ def init_exchange() -> None:
                 'secret': os.getenv('BYBIT_API_SECRET', ''),
             }
         )
+        _load_initial_history()
     except Exception as exc:  # pragma: no cover - config errors
         logging.exception("Failed to initialize Bybit client: %s", exc)
         raise RuntimeError("Invalid Bybit configuration") from exc
@@ -91,6 +137,58 @@ def price(symbol: str) -> ResponseReturnValue:
     except CCXT_BASE_ERROR as exc:
         logging.exception("Exchange error fetching price for '%s': %s", symbol, exc)
         return jsonify({'error': 'exchange error fetching price'}), 502
+
+
+@app.route('/history/<symbol>', methods=['GET'])
+def history(symbol: str) -> ResponseReturnValue:
+    """Return OHLCV history for ``symbol``."""
+    if exchange is None:
+        return jsonify({'error': 'exchange not initialized'}), 503
+    timeframe = request.args.get('timeframe', '1m')
+    limit_str = request.args.get('limit')
+    try:
+        limit = int(limit_str) if limit_str is not None else 200
+    except ValueError:
+        limit = 200
+    try:
+        ohlcv = None
+        if history_cache is not None and pd is not None:
+            try:
+                cached = history_cache.load_cached_data(symbol, timeframe)
+            except Exception:
+                cached = None
+            if cached is not None and hasattr(cached, 'values'):
+                ohlcv = (
+                    cached[
+                        ['timestamp', 'open', 'high', 'low', 'close', 'volume']
+                    ]
+                    .values.tolist()
+                )
+        if ohlcv is None:
+            ohlcv = exchange.fetch_ohlcv(symbol, timeframe=timeframe, limit=limit)
+            if history_cache is not None and pd is not None:
+                try:
+                    df = pd.DataFrame(
+                        ohlcv,
+                        columns=[
+                            'timestamp',
+                            'open',
+                            'high',
+                            'low',
+                            'close',
+                            'volume',
+                        ],
+                    )
+                    history_cache.save_cached_data(symbol, timeframe, df)
+                except Exception:
+                    pass
+        return jsonify({'history': ohlcv})
+    except CCXT_NETWORK_ERROR as exc:  # pragma: no cover - network errors
+        logging.exception("Network error fetching history for '%s': %s", symbol, exc)
+        return jsonify({'error': 'network error contacting exchange'}), 503
+    except CCXT_BASE_ERROR as exc:
+        logging.exception("Exchange error fetching history for '%s': %s", symbol, exc)
+        return jsonify({'error': 'exchange error fetching history'}), 502
 
 @app.route('/ping')
 def ping() -> ResponseReturnValue:

--- a/tests/test_service_scripts.py
+++ b/tests/test_service_scripts.py
@@ -43,6 +43,18 @@ def test_data_handler_service_price(ctx):
         assert resp.json()['price'] == 42.0
 
 
+@pytest.mark.integration
+def test_data_handler_service_history(ctx):
+    port = get_free_port()
+    p = ctx.Process(target=_run_dh, args=(port,))
+    with service_process(p, url=f'http://127.0.0.1:{port}/ping'):
+        resp = httpx.get(
+            f'http://127.0.0.1:{port}/history/BTCUSDT', timeout=5, trust_env=False
+        )
+        assert resp.status_code == 200
+        assert resp.json()['history'] == [[1, 1, 1, 1, 1, 1]]
+
+
 def _run_dh_fail(port: int):
     class DummyExchange:
         def fetch_ticker(self, symbol):

--- a/tests/test_trading_bot_history.py
+++ b/tests/test_trading_bot_history.py
@@ -1,0 +1,34 @@
+import asyncio
+
+import pytest
+
+import trading_bot
+
+
+class DummyClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get(self, url, timeout=5):
+        class Resp:
+            status_code = 200
+
+            def json(self):
+                return {"history": [[0, 0, 0, 0, 10, 0], [0, 0, 0, 0, 11, 0]]}
+
+        return Resp()
+
+
+@pytest.mark.asyncio
+async def test_fetch_initial_history(monkeypatch):
+    monkeypatch.setattr(trading_bot, "httpx", type("X", (), {"AsyncClient": DummyClient}))
+    env = {"data_handler_url": "http://test"}
+    trading_bot._PRICE_HISTORY.clear()
+    await trading_bot.fetch_initial_history("SYM", env)
+    assert list(trading_bot._PRICE_HISTORY) == [10.0, 11.0]


### PR DESCRIPTION
## Summary
- add `/history/<symbol>` endpoint to data handler service and prefetch OHLCV on startup
- load initial price history in trading bot to seed indicators
- cover new behaviors with tests

## Testing
- `pytest tests/test_service_scripts.py::test_data_handler_service_history tests/test_trading_bot_history.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c306e0f0fc832d9723c315fc1b84a1