### PR TITLE
feat: warn on missing stop orders

### DIFF
--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -16,7 +16,8 @@ import os
 from dotenv import load_dotenv
 import logging
 import threading
-from utils import validate_host, safe_int
+import time
+from utils import validate_host, safe_int, logger
 
 load_dotenv()
 app = Flask(__name__)
@@ -150,28 +151,51 @@ def open_position() -> ResponseReturnValue:
             opp_side = 'sell' if side == 'buy' else 'buy'
             if sl is not None:
                 stop_order = None
-                try:
-                    stop_order = exchange.create_order(
-                        symbol, 'stop', opp_side, amount, sl
-                    )
-                except CCXT_BASE_ERROR as exc:
-                    app.logger.debug('stop order failed: %s', exc)
+                delay = 1.0
+                for attempt in range(3):
                     try:
                         stop_order = exchange.create_order(
-                            symbol, 'stop_market', opp_side, amount, sl
+                            symbol, 'stop', opp_side, amount, sl
                         )
                     except CCXT_BASE_ERROR as exc:
-                        app.logger.debug('stop_market order failed: %s', exc)
-                        stop_order = None
+                        app.logger.debug('stop order failed: %s', exc)
+                        try:
+                            stop_order = exchange.create_order(
+                                symbol, 'stop_market', opp_side, amount, sl
+                            )
+                        except CCXT_BASE_ERROR as exc:
+                            app.logger.debug('stop_market order failed: %s', exc)
+                            stop_order = None
+                    if stop_order and stop_order.get('id') is not None:
+                        break
+                    if attempt < 2:
+                        time.sleep(delay)
+                        delay *= 2
+                if not stop_order or stop_order.get('id') is None:
+                    warn_msg = f"не удалось создать stop loss ордер для {symbol}"
+                    app.logger.warning(warn_msg)
+                    logger.warning(warn_msg)
                 orders.append(stop_order)
             if tp is not None:
-                try:
-                    tp_order = exchange.create_order(
-                        symbol, 'limit', opp_side, amount, tp
-                    )
-                except CCXT_BASE_ERROR as exc:
-                    app.logger.debug('take profit order failed: %s', exc)
-                    tp_order = None
+                tp_order = None
+                delay = 1.0
+                for attempt in range(3):
+                    try:
+                        tp_order = exchange.create_order(
+                            symbol, 'limit', opp_side, amount, tp
+                        )
+                    except CCXT_BASE_ERROR as exc:
+                        app.logger.debug('take profit order failed: %s', exc)
+                        tp_order = None
+                    if tp_order and tp_order.get('id') is not None:
+                        break
+                    if attempt < 2:
+                        time.sleep(delay)
+                        delay *= 2
+                if not tp_order or tp_order.get('id') is None:
+                    warn_msg = f"не удалось создать take profit ордер для {symbol}"
+                    app.logger.warning(warn_msg)
+                    logger.warning(warn_msg)
                 orders.append(tp_order)
             if trailing_stop is not None and price > 0:
                 tprice = price - trailing_stop if side == 'buy' else price + trailing_stop


### PR DESCRIPTION
## Summary
- add explicit result checks for stop loss and take profit orders
- warn and send Telegram notification when stop/take-profit creation fails
- retry stop and take-profit order placement with exponential backoff

## Testing
- `pre-commit run --files services/trade_manager_service.py` *(failed: KeyError: 'ema30')*
- `pytest tests/test_data_handler_polars.py::test_synchronize_and_update_polars` *(failed: AssertionError: 'ema30' not in columns)*

------
https://chatgpt.com/codex/tasks/task_e_68c306d90ab4832d85c29510ebf84f3e