### PR TITLE
Вычисление amount из конфигурации

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,6 @@ GPU-зависимости вынесены в отдельный файл `requ
       `environment:` в `docker-compose.yml`. `DataHandler` и `TradeManager`
       проверяют эти переменные при запуске и выводят предупреждение, если они
       отсутствуют. В этом случае Telegram уведомления отправляться не будут.
-    - `TRADE_RISK_USD` — величина риска в долларах для расчёта размера позиции,
-      если `/open_position` получает только `price`.
     - `GPT_MODEL` — имя модели (по умолчанию `openai/gpt-oss-20b`).
       Модель загружается лениво при запуске сервера, поэтому первые запросы к API
       могут получать код `503`, пока загрузка не завершена.
@@ -380,8 +378,7 @@ service supports multi-class problems via
 contain only a single class.
 `trade_manager_service.py` opens and closes positions on Bybit via
 `/open_position` and `/close_position` and also provides `/positions`, `/ping`
-and `/ready` routes. The `/open_position` endpoint accepts either `amount` or
-`price`, calculating the size from `TRADE_RISK_USD` when only a price is given.
+and `/ready` routes. The `/open_position` endpoint требует явный `amount`.
 
 `trade_manager_service.py` uses a simple token-based authentication. Set the
 `TRADE_MANAGER_TOKEN` environment variable on the service and supply the same

--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -117,10 +117,6 @@ def open_position() -> ResponseReturnValue:
     tp = float(tp) if tp is not None else None
     sl = float(sl) if sl is not None else None
     trailing_stop = float(trailing_stop) if trailing_stop is not None else None
-    if amount <= 0:
-        risk_usd = float(os.getenv('TRADE_RISK_USD', '0') or 0)
-        if risk_usd > 0 and price > 0:
-            amount = risk_usd / price
     if exchange is None:
         return jsonify({'error': 'exchange not initialized'}), 503
     if not symbol or amount <= 0:

--- a/tests/test_env_parsing.py
+++ b/tests/test_env_parsing.py
@@ -61,7 +61,7 @@ async def test_send_trade_timeout_invalid_env(monkeypatch):
     monkeypatch.setattr(trading_bot, "HTTP_CLIENT", dummy)
     monkeypatch.setenv("TRADE_MANAGER_TIMEOUT", "oops")
     await trading_bot.send_trade_async(
-        dummy, "BTCUSDT", "buy", 1.0, {"trade_manager_url": "http://tm"}
+        dummy, "BTCUSDT", "buy", 1.0, 1.0, {"trade_manager_url": "http://tm"}
     )
     assert called["timeout"] == 5.0
 

--- a/tests/test_service_scripts.py
+++ b/tests/test_service_scripts.py
@@ -246,7 +246,6 @@ def _run_tm(
     env = {
         'HOST': '127.0.0.1',
         'TRADE_MANAGER_TOKEN': 'test-token',
-        'TRADE_RISK_USD': os.environ.get('TRADE_RISK_USD', '10'),
         'TEST_MODE': '1',
     }
     with patch.dict(os.environ, env):

--- a/tests/test_trading_bot.py
+++ b/tests/test_trading_bot.py
@@ -157,7 +157,7 @@ async def test_send_trade_timeout_env(monkeypatch):
     monkeypatch.setattr(trading_bot, 'HTTP_CLIENT', dummy)
     monkeypatch.setenv('TRADE_MANAGER_TIMEOUT', '9')
     ok, err = await trading_bot.send_trade_async(
-        dummy, 'BTCUSDT', 'buy', 100.0, {'trade_manager_url': 'http://tm'}
+        dummy, 'BTCUSDT', 'buy', 100.0, 1.0, {'trade_manager_url': 'http://tm'}
     )
     assert called['timeout'] == 9.0
     assert ok is True and err is None
@@ -167,7 +167,7 @@ async def test_send_trade_timeout_env(monkeypatch):
 def test_build_trade_payload_invalid_side(side):
     with pytest.raises(ValueError, match="'buy' or 'sell'"):
         trading_bot._build_trade_payload(
-            "BTCUSDT", side, 1.0, None, None, None
+            "BTCUSDT", side, 1.0, 1.0, None, None, None
         )
 
 
@@ -242,7 +242,7 @@ async def test_send_trade_latency_alert(monkeypatch, fast_sleep):
     monkeypatch.setattr(trading_bot, 'send_telegram_alert', fake_alert)
     trading_bot.CONFIRMATION_TIMEOUT = 0.0
     await trading_bot.send_trade_async(
-        dummy, 'BTCUSDT', 'buy', 1.0, {'trade_manager_url': 'http://tm'}
+        dummy, 'BTCUSDT', 'buy', 1.0, 1.0, {'trade_manager_url': 'http://tm'}
     )
     assert called
 
@@ -269,7 +269,7 @@ async def test_send_trade_http_error_alert(monkeypatch):
 
     monkeypatch.setattr(trading_bot, 'send_telegram_alert', fake_alert)
     await trading_bot.send_trade_async(
-        dummy, 'BTCUSDT', 'sell', 1.0, {'trade_manager_url': 'http://tm'}
+        dummy, 'BTCUSDT', 'sell', 1.0, 1.0, {'trade_manager_url': 'http://tm'}
     )
     assert called
 
@@ -290,7 +290,7 @@ async def test_send_trade_exception_alert(monkeypatch):
 
     monkeypatch.setattr(trading_bot, 'send_telegram_alert', fake_alert)
     await trading_bot.send_trade_async(
-        dummy, 'BTCUSDT', 'sell', 1.0, {'trade_manager_url': 'http://tm'}
+        dummy, 'BTCUSDT', 'sell', 1.0, 1.0, {'trade_manager_url': 'http://tm'}
     )
     assert called
 
@@ -427,6 +427,7 @@ async def test_send_trade_forwards_params(monkeypatch):
         'BTCUSDT',
         'buy',
         1.0,
+        1.0,
         {'trade_manager_url': 'http://tm'},
         tp=10,
         sl=5,
@@ -460,7 +461,7 @@ async def test_send_trade_reports_error_field(monkeypatch):
 
     monkeypatch.setattr(trading_bot, 'send_telegram_alert', fake_alert)
     ok, err = await trading_bot.send_trade_async(
-        dummy, 'BTCUSDT', 'buy', 1.0, {'trade_manager_url': 'http://tm'}
+        dummy, 'BTCUSDT', 'buy', 1.0, 1.0, {'trade_manager_url': 'http://tm'}
     )
     assert not ok
     assert err


### PR DESCRIPTION
## Summary
- Рассчитывать размер позиции в trading_bot по параметрам `min_risk_per_trade` и `max_risk_per_trade`
- Передавать рассчитанный `amount` в `/open_position`
- Упростить `trade_manager_service`, убрав зависимость от `TRADE_RISK_USD`

## Testing
- `pytest -q` *(2 tests failed: synchronize_and_update_polars, data_handler_ema_shift)*

------
https://chatgpt.com/codex/tasks/task_e_68c306d21b14832d8a1a6be41aacaca7