### PR TITLE
Potential fix for code scanning alert no. 2184: Deserialization of user-controlled data

### DIFF
--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -113,6 +113,11 @@ else:  # scikit-learn fallback used by tests
         return (MODEL_DIR / f"{safe}.pkl").resolve()
 
     def _load_state(symbol: str) -> None:
+        # Only allow models that actually exist in the MODEL_DIR.
+        allowed_symbols = {p.stem for p in MODEL_DIR.glob("*.pkl")}
+        if symbol not in allowed_symbols:
+            app.logger.warning("Refused to load model: %r is not whitelisted", symbol)
+            return
         path = _model_path(symbol)
         if path.exists():
             data = joblib.load(path)


### PR DESCRIPTION
Potential fix for [https://github.com/averinaleks/bot/security/code-scanning/2184](https://github.com/averinaleks/bot/security/code-scanning/2184)

The best way to fix this problem is to avoid deserializing pickle files based on user-provided identifiers/filenames, as pickle and joblib are inherently insecure with untrusted sources. The safest solution is either to use a safer serialization format for models (such as JSON, for compatible model types) or to ensure that *only* trusted values can be used for loading models, strictly validating or whitelisting user inputs.

If you cannot immediately switch formats, you should ensure only predefined, trusted model names are accepted. Add a set of allowed model symbols (such as those produced by the service itself), and reject or sanitize all others before use. This can be done by checking that `symbol` exists in a server-side registry such as the keys of `_models` or explicitly defined allowed model names, and refusing to load any unknown symbol.

Thus, you should:

- Before calling `_model_path(symbol)` in `_load_state`, check that `symbol` is in the expected set of model names (those created by the service itself, e.g., already present in `MODEL_DIR`).
- Alternatively, list all `.pkl` files in `MODEL_DIR` and accept only `symbol`s corresponding to those names.
- Reject or refuse to load/expose non-existent or non-whitelisted models.

Apply this fix within the `_load_state` function in services/model_builder_service.py.

You do not need to install new packages. No method signatures otherwise change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
