### PR TITLE
Fix Docker build and GHCR login

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -127,7 +127,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83  # v6.18.0

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -14,7 +14,7 @@ RUN apt-get install -y --no-install-recommends \
     python3 python3-venv python3-dev \
     zlib1g-dev \
     && apt-get install -y --only-upgrade libpam0g libpam-modules \
-
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 
 COPY requirements-core.txt .


### PR DESCRIPTION
## Summary
- fix incomplete package installation in Dockerfile.cpu
- use GITHUB_TOKEN for GHCR login in docker-publish workflow

## Testing
- `hadolint Dockerfile.cpu`
- `yamllint .github/workflows/docker-publish.yml`
- `actionlint .github/workflows/docker-publish.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c30fefe77c832daa226b4502480e07