### PR TITLE
Implement run_once_async trading cycle

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -928,10 +928,35 @@ async def reactive_trade(symbol: str, env: dict | None = None) -> None:
 
 async def run_once_async() -> None:
     """Execute a single trading cycle."""
-
-
-
-
+    env = _load_env()
+    price = await fetch_price(SYMBOL, env)
+    if price is None or price <= 0:
+        return
+    features = await build_feature_vector(price)
+    pdata = await get_prediction(SYMBOL, features, env)
+    if not pdata:
+        return
+    signal = pdata.get("signal")
+    if not isinstance(signal, str):
+        return
+    logger.info("Prediction: %s", signal)
+    if not should_trade(signal):
+        return
+    tp, sl, trailing_stop = _parse_trade_params(
+        pdata.get("tp"), pdata.get("sl"), pdata.get("trailing_stop")
+    )
+    tp, sl, trailing_stop = _resolve_trade_params(tp, sl, trailing_stop, price)
+    async with httpx.AsyncClient(trust_env=False) as client:
+        await send_trade_async(
+            client,
+            SYMBOL,
+            signal,
+            price,
+            env,
+            tp=tp,
+            sl=sl,
+            trailing_stop=trailing_stop,
+        )
 async def main_async() -> None:
     """Run the trading bot until interrupted."""
     train_task = None


### PR DESCRIPTION
## Summary
- implement `run_once_async` to perform a single trading cycle with env loading, prediction, GPT advice check and trade submission

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c31635e65c832d94e2b903d3aea323