### PR TITLE
Fix Bandit warnings

### DIFF
--- a/http_client.py
+++ b/http_client.py
@@ -11,6 +11,9 @@ from collections import defaultdict
 from typing import AsyncGenerator, Generator, TYPE_CHECKING, Any, Dict, Tuple
 import random
 
+# Use system-level randomness for jitter to avoid predictable retry delays
+_RNG = random.SystemRandom()
+
 import httpx
 if TYPE_CHECKING:  # pragma: no cover - imported for type hints only
     import requests  # type: ignore[import-untyped]
@@ -179,6 +182,6 @@ async def request_with_retry(
             raise RuntimeError("HTTP request failed without response")
 
         RETRY_METRICS[url] += 1
-        delay = backoff_base * (2 ** attempt) + random.uniform(0, jitter)
+        delay = backoff_base * (2 ** attempt) + _RNG.uniform(0, jitter)
         await asyncio.sleep(delay)
 

--- a/model_builder.py
+++ b/model_builder.py
@@ -1299,8 +1299,10 @@ class ModelBuilder:
             X = X[~bad_rows.to_numpy()]
             y = y[~bad_rows.to_numpy()]
             X_df = pd.DataFrame(X.reshape(X.shape[0], -1))
-        assert not pd.isna(X_df).any().any()
-        assert np.isfinite(X_df.to_numpy()).all()
+        if pd.isna(X_df).any().any():
+            raise ValueError("Training data contains NaN values")
+        if not np.isfinite(X_df.to_numpy()).all():
+            raise ValueError("Training data contains infinite values")
         train_task = _train_model_remote
         if self.nn_framework in {"pytorch", "lightning"}:
             torch_mods = _get_torch_modules()
@@ -1475,8 +1477,10 @@ class ModelBuilder:
             X = X[~bad_rows.to_numpy()]
             y = y[~bad_rows.to_numpy()]
             X_df = pd.DataFrame(X.reshape(X.shape[0], -1))
-        assert not pd.isna(X_df).any().any()
-        assert np.isfinite(X_df.to_numpy()).all()
+        if pd.isna(X_df).any().any():
+            raise ValueError("Training data contains NaN values")
+        if not np.isfinite(X_df.to_numpy()).all():
+            raise ValueError("Training data contains infinite values")
         existing = self.predictive_models.get(symbol)
         init_state = None
         if existing is not None:
@@ -2197,8 +2201,10 @@ def train_route():
         df = df[~bad_rows]
         labels = labels[~bad_rows.to_numpy()]
     features = df.to_numpy(dtype=np.float32)
-    assert not pd.isna(df).any().any()
-    assert np.isfinite(features).all()
+    if pd.isna(df).any().any():
+        raise ValueError("Training data contains NaN values")
+    if not np.isfinite(features).all():
+        raise ValueError("Training data contains infinite values")
     if features.size == 0 or len(features) != len(labels):
         return jsonify({"error": "invalid training data"}), 400
     if len(np.unique(labels)) < 2:

--- a/services/data_handler_service.py
+++ b/services/data_handler_service.py
@@ -184,8 +184,10 @@ def history(symbol: str) -> ResponseReturnValue:
                         ],
                     )
                     history_cache.save_cached_data(symbol, timeframe, df)
-                except Exception:
-                    pass
+                except Exception as exc:  # pragma: no cover - logging best effort
+                    logging.exception(
+                        "Failed to cache history for %s on %s: %s", symbol, timeframe, exc
+                    )
         return jsonify({'history': ohlcv})
     except CCXT_NETWORK_ERROR as exc:  # pragma: no cover - network errors
         logging.exception("Network error fetching history for '%s': %s", symbol, exc)

--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -180,8 +180,10 @@ def train() -> ResponseReturnValue:
         df = df[~bad_rows]
         labels = labels[~bad_rows.to_numpy()]
     features = df.to_numpy(dtype=np.float32)
-    assert not pd.isna(df).any().any()
-    assert np.isfinite(features).all()
+    if pd.isna(df).any().any():
+        return jsonify({"error": "training data contains NaN values"}), 400
+    if not np.isfinite(features).all():
+        return jsonify({"error": "training data contains infinite values"}), 400
     if len(np.unique(labels)) < 2:
         return jsonify({"error": "labels must contain at least two classes"}), 400
     scaler = StandardScaler().fit(features)


### PR DESCRIPTION
## Summary
- use system randomness for HTTP retry jitter
- add data validation instead of asserts in model building services
- log cache failures instead of swallowing exceptions

## Testing
- `bandit -r . -ll -ii -x ./tests,./scripts,./gptoss_check`
- `pre-commit run --files http_client.py model_builder.py services/data_handler_service.py services/model_builder_service.py` *(failed: AssertionError in tests/test_trading_bot.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c316408384832dbce1bdf4cae8b4e9