### PR TITLE
chore: fix dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,4 +1,5 @@
 ---
+# yamllint disable rule:line-length
 name: Dependabot Auto Merge
 
 on:  # yamllint disable-line rule:truthy


### PR DESCRIPTION
## Summary
- disable yamllint line-length rule in dependabot workflow

## Testing
- `yamllint .github/workflows/dependabot.yml`
- `pytest -q` *(fails: test_run_once_forwards_prediction_params, test_run_once_env_fallback, test_run_once_config_fallback, test_run_once_ignores_invalid_env, test_run_once_logs_prediction)*

------
https://chatgpt.com/codex/tasks/task_e_68c31683da04832d895bd00ed23637aa