### PR TITLE
chore: use minimal dependencies for graph

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements-ci.txt
       - name: Component detection
         # yamllint disable-line rule:line-length
         uses: advanced-security/component-detection-dependency-submission-action@v0.1.0


### PR DESCRIPTION
## Summary
- use requirements-ci.txt for dependency graph workflow

## Testing
- `pre-commit run --files .github/workflows/dependency-graph.yml` *(fails: tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68c3169a6984832d859bcf505155e9cc