### PR TITLE
fix: improve release drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
+    branches:
+      - main
     types: [opened, reopened, synchronize, labeled, unlabeled]
   workflow_dispatch:
 
@@ -17,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update release draft
-        uses: release-drafter/release-drafter@7cf306f56b79636bb76931494ccf29fc893763bd # v6.1.0
+        uses: release-drafter/release-drafter@v6
         with:
           config-name: release-drafter.yml
         env:


### PR DESCRIPTION
## Summary
- ensure Release Drafter runs with `pull_request_target` on `main`
- use latest Release Drafter action v6

## Testing
- `pre-commit run --files .github/workflows/release-drafter.yml` *(fails: 5 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c316b48814832d8ba5493fb7ae9ff6