### PR TITLE
fix: correct trivy action input

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -167,7 +167,7 @@ jobs:
           TMPDIR: /mnt/trivy-tmp
           TRIVY_CACHE_DIR: /mnt/trivy-cache
         with:
-          version: v0.65.0
+          trivy_version: v0.65.0
           image-ref: docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ matrix.image }}:latest
           format: table
           output: ${{ matrix.artifact }}.txt


### PR DESCRIPTION
## Summary
- fix trivy action input name

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml` *(fails: assert 'Prediction: buy' in [])*

------
https://chatgpt.com/codex/tasks/task_e_68c3211a0d74832da122c67703c02d6a