### PR TITLE
Fix Dependabot workflow comment formatting

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -67,7 +67,8 @@ jobs:
         if: >-
           ${{ steps.metadata.outputs['update-type'] != 'version-update:semver-major' }}
         # v3.0.0
-        uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d  # yamllint disable-line rule:line-length
+        # yamllint disable-line rule:line-length
+        uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d
         with:
           pull-request-number: ${{ github.event.pull_request.number }}
           merge-method: squash


### PR DESCRIPTION
## Summary
- move yamllint comment to its own line in Dependabot auto-merge workflow for clarity

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c3242f39bc832d982e3cdcd29e1038