### PR TITLE
fix: import missing modules

### DIFF
--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -17,6 +17,8 @@ import os
 from dotenv import load_dotenv
 import logging
 import threading
+import time
+from pathlib import Path
 from utils import validate_host, safe_int
 
 load_dotenv()


### PR DESCRIPTION
## Summary
- add missing time and Path imports in trade manager service to avoid runtime errors

## Testing
- `pre-commit run --files services/trade_manager_service.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c324bda230832d8a3fd35933787636