### PR TITLE
fix missing imports in trade manager service

### DIFF
--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -17,6 +17,8 @@ import os
 from dotenv import load_dotenv
 import logging
 import threading
+import time
+from pathlib import Path
 from utils import validate_host, safe_int
 
 load_dotenv()


### PR DESCRIPTION
## Summary
- add missing time and Path imports in trade_manager_service

## Testing
- `python -m flake8 --exclude venv .`
- `python -m mypy --no-site-packages --exclude venv .`
- `pytest tests/test_trade_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3250808e0832d9ffd817ea6e91be8