### PR TITLE
fix: import missing modules in trade manager service

### DIFF
--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -7,6 +7,8 @@ environment variables.
 
 from flask import Flask, request, jsonify
 from typing import Any
+from pathlib import Path
+import time
 try:  # optional dependency
     from flask.typing import ResponseReturnValue
 except Exception:  # pragma: no cover - fallback when flask.typing missing


### PR DESCRIPTION
## Summary
- add missing pathlib.Path and time imports to trade manager service

## Testing
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c325275970832da40547dcda984947