### PR TITLE
fix: pin docker login action

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -118,12 +118,12 @@ jobs:
 
       - name: Login to Docker Hub
         if: env.TRIVY_ENABLED == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3
         with:
           username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ env.DOCKERHUB_TOKEN }}
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
## Summary
- pin docker/login-action to a specific commit for Docker Hub and GHCR logins

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c32769fa60832d8677be2ad2ebb23a