### PR TITLE
Add tests for GPT advice, security, and backtest fees

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,5 +39,8 @@ jobs:
       - name: Lint (flake8)
         run: flake8 .
         continue-on-error: true
+      - name: Security lint (bandit)
+        run: bandit -r . -ll -x ./tests,./scripts,./gptoss_check
+        continue-on-error: true
       - name: Run tests (pytest)
-        run: pytest -q --maxfail=1 --disable-warnings
+        run: pytest -q --maxfail=1 --disable-warnings --cov=bot --cov-fail-under=0

--- a/portfolio_backtest.py
+++ b/portfolio_backtest.py
@@ -28,6 +28,7 @@ def _simulate_trades(
     base_thr: float,
     sl_mult: float,
     tp_mult: float,
+    trading_fee: float,
     max_positions: int,
     n_symbols: int,
 ):
@@ -70,6 +71,7 @@ def _simulate_trades(
                     returns[count] = (
                         (positions_tp[pos_idx] - positions_entry[pos_idx])
                         / positions_entry[pos_idx]
+                        - 2 * trading_fee
                     )
                     count += 1
                     positions_symbol[pos_idx] = -1
@@ -77,6 +79,7 @@ def _simulate_trades(
                     returns[count] = (
                         (positions_sl[pos_idx] - positions_entry[pos_idx])
                         / positions_entry[pos_idx]
+                        - 2 * trading_fee
                     )
                     count += 1
                     positions_symbol[pos_idx] = -1
@@ -85,6 +88,7 @@ def _simulate_trades(
                     returns[count] = (
                         (positions_entry[pos_idx] - positions_tp[pos_idx])
                         / positions_entry[pos_idx]
+                        - 2 * trading_fee
                     )
                     count += 1
                     positions_symbol[pos_idx] = -1
@@ -92,6 +96,7 @@ def _simulate_trades(
                     returns[count] = (
                         (positions_entry[pos_idx] - positions_sl[pos_idx])
                         / positions_entry[pos_idx]
+                        - 2 * trading_fee
                     )
                     count += 1
                     positions_symbol[pos_idx] = -1
@@ -133,9 +138,9 @@ def _simulate_trades(
             side = positions_side[j]
             last = last_close[sym]
             if side == 1:
-                returns[count] = (last - entry) / entry
+                returns[count] = (last - entry) / entry - 2 * trading_fee
             else:
-                returns[count] = (entry - last) / entry
+                returns[count] = (entry - last) / entry - 2 * trading_fee
             count += 1
 
     return returns[:count]
@@ -217,6 +222,7 @@ def portfolio_backtest(
         base_thr = params.get("base_probability_threshold", 0.6)
         sl_mult = params.get("sl_multiplier", 1.0)
         tp_mult = params.get("tp_multiplier", 2.0)
+        trading_fee = params.get("trading_fee", 0.0)
 
         # Convert columns to numpy arrays for numba function
         symbol_codes, uniques = pd.factorize(combined["symbol"])
@@ -232,6 +238,7 @@ def portfolio_backtest(
             float(base_thr),
             float(sl_mult),
             float(tp_mult),
+            float(trading_fee),
             int(max_positions),
             int(len(uniques)),
         )

--- a/tests/test_portfolio_backtest.py
+++ b/tests/test_portfolio_backtest.py
@@ -1,0 +1,58 @@
+import importlib
+import sys
+import numpy as np
+import pytest
+
+
+def _reload_module(monkeypatch):
+    monkeypatch.setenv("NUMBA_DISABLE_JIT", "1")
+    monkeypatch.setitem(sys.modules, "numba", None)
+    import bot.portfolio_backtest as pb
+    importlib.reload(pb)
+    return pb
+
+
+def test_simulate_trades_applies_fee(monkeypatch):
+    pb = _reload_module(monkeypatch)
+    symbol_ids = np.array([0, 0], dtype=np.int32)
+    close = np.array([100, 100], dtype=np.float32)
+    high = np.array([100, 103], dtype=np.float32)
+    low = np.array([100, 99], dtype=np.float32)
+    ema_fast = np.array([2, 2], dtype=np.float32)
+    ema_slow = np.array([1, 1], dtype=np.float32)
+    atr = np.array([1, 1], dtype=np.float32)
+    prob = np.array([0.7, 0.7], dtype=np.float32)
+
+    no_fee = pb._simulate_trades(
+        symbol_ids,
+        close,
+        high,
+        low,
+        ema_fast,
+        ema_slow,
+        atr,
+        prob,
+        0.6,
+        1.0,
+        2.0,
+        0.0,
+        1,
+        1,
+    )
+    with_fee = pb._simulate_trades(
+        symbol_ids,
+        close,
+        high,
+        low,
+        ema_fast,
+        ema_slow,
+        atr,
+        prob,
+        0.6,
+        1.0,
+        2.0,
+        0.001,
+        1,
+        1,
+    )
+    assert with_fee[0] == pytest.approx(no_fee[0] - 0.002)

--- a/tests/test_trading_bot.py
+++ b/tests/test_trading_bot.py
@@ -736,6 +736,12 @@ def test_run_once_skips_on_gpt(monkeypatch):
     assert not sent
 
 
+def test_should_trade_invalid_gpt_signal():
+    trading_bot.GPT_ADVICE.signal = "maybe"
+    assert not trading_bot.should_trade("buy")
+    trading_bot.GPT_ADVICE.signal = None
+
+
 def test_run_once_env_fallback(monkeypatch):
     sent = {}
     async def fake_fetch_price2(*a, **k):


### PR DESCRIPTION
## Summary
- check that invalid GPT advice defaults to holding
- ensure GPT client disables proxy usage
- verify backtest returns subtract commission
- run bandit with pytest coverage in CI workflow

## Testing
- `python -m flake8 portfolio_backtest.py tests/test_trading_bot.py tests/test_gpt_client.py tests/test_portfolio_backtest.py`
- `python -m bandit -r . -ll -x ./tests,./scripts,./gptoss_check`
- `pytest tests/test_trading_bot.py::test_should_trade_invalid_gpt_signal tests/test_gpt_client.py::test_query_gpt_no_env_leak tests/test_portfolio_backtest.py::test_simulate_trades_applies_fee -q`

------
https://chatgpt.com/codex/tasks/task_e_68c329394a6c832da2eb29e975e3a369