### PR TITLE
feat: add short action and rl close handling

### DIFF
--- a/tests/test_trading_env.py
+++ b/tests/test_trading_env.py
@@ -21,7 +21,7 @@ def test_step_rewards(sample_ohlcv):
     env.reset()
     _, r1, _, _ = env.step(1)
     assert r1 == 1.0
-    _, r2, done, _ = env.step(2)
+    _, r2, done, _ = env.step(3)
     assert r2 == 1.0
     assert done
     assert env.balance == 2.0

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -1175,7 +1175,7 @@ class TradeManager:
                     [float(prediction), num_positions / max(1, self.max_positions)],
                 ).astype(np.float32)
                 rl_signal = self.rl_agent.predict(symbol, rl_feat)
-                if rl_signal and rl_signal != "hold":
+                if rl_signal in ("open_long", "open_short", "close"):
                     logger.info("RL action for %s: %s", symbol, rl_signal)
                     if rl_signal == "close":
                         await self.close_position(symbol, current_price, "RL Signal")
@@ -1615,13 +1615,15 @@ class TradeManager:
                     [float(prediction), num_positions / max(1, self.max_positions)],
                 ).astype(np.float32)
                 rl_signal = self.rl_agent.predict(symbol, rl_feat)
-                if rl_signal and rl_signal != "hold":
+                if rl_signal in ("open_long", "open_short", "close"):
                     logger.info("RL action for %s: %s", symbol, rl_signal)
-            if rl_signal in ("open_long", "open_short", "close"):
-                final = (
-                    "buy" if rl_signal == "open_long" else
-                    "sell" if rl_signal == "open_short" else "close"
-                )
+            final_mapping = {
+                "open_long": "buy",
+                "open_short": "sell",
+                "close": "close",
+            }
+            if rl_signal in final_mapping:
+                final = final_mapping[rl_signal]
                 return (final, float(prediction)) if return_prob else final
 
             ema_signal = None


### PR DESCRIPTION
## Summary
- expand TradingEnv action space to 4 actions including short and close
- map RLAgent outputs to hold/open_long/open_short/close
- handle new RL actions in trade manager logic

## Testing
- `pytest tests/test_trading_env.py tests/test_rl_agent.py tests/test_trade_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_68c32d1a2270832d93673bfeaffa7bf9