### PR TITLE
feat: enhance data cleanup and indicators

### DIFF
--- a/data_handler/core.py
+++ b/data_handler/core.py
@@ -103,3 +103,15 @@ class DataHandler:
                 self._ohlcv = self._ohlcv.filter(pl.col("timestamp") >= cutoff)
             if pl is not None and isinstance(self._ohlcv_2h, pl.DataFrame) and self._ohlcv_2h.height > 0:
                 self._ohlcv_2h = self._ohlcv_2h.filter(pl.col("timestamp") >= cutoff)
+            if isinstance(self._ohlcv, pd.DataFrame) and not self._ohlcv.empty:
+                ts_index = self._ohlcv.index.get_level_values("timestamp")
+                self._ohlcv = self._ohlcv[ts_index >= cutoff]
+                history = getattr(self.cfg, "history_retention", 0)
+                if history > 0 and len(self._ohlcv) > history:
+                    self._ohlcv = self._ohlcv.groupby(level="symbol").tail(history)
+            if isinstance(self._ohlcv_2h, pd.DataFrame) and not self._ohlcv_2h.empty:
+                ts_index = self._ohlcv_2h.index.get_level_values("timestamp")
+                self._ohlcv_2h = self._ohlcv_2h[ts_index >= cutoff]
+                history = getattr(self.cfg, "history_retention", 0)
+                if history > 0 and len(self._ohlcv_2h) > history:
+                    self._ohlcv_2h = self._ohlcv_2h.groupby(level="symbol").tail(history)

--- a/data_handler/feature_engineering.py
+++ b/data_handler/feature_engineering.py
@@ -10,6 +10,87 @@ from __future__ import annotations
 
 import numpy as np
 import pandas as pd
+import types
+from typing import Any
+
+try:  # pragma: no cover - optional dependency
+    import ta  # type: ignore
+except Exception:  # pragma: no cover - ta not installed
+    ta = None  # type: ignore
+
+
+def compute_indicators(df: pd.DataFrame, cfg: Any) -> types.SimpleNamespace:
+    """Рассчитать набор индикаторов для ``df``.
+
+    Если установлен пакет ``ta``, используется его реализация, иначе
+    применяется упрощённый расчёт на ``pandas``.
+    """
+
+    close = df["close"]
+    ema30 = close.ewm(span=getattr(cfg, "ema30_period", 30), adjust=False).mean()
+    ema100 = close.ewm(span=getattr(cfg, "ema100_period", 100), adjust=False).mean()
+    ema200 = close.ewm(span=getattr(cfg, "ema200_period", 200), adjust=False).mean()
+
+    if ta is not None:  # pragma: no branch - import guard
+        rsi = ta.momentum.RSIIndicator(
+            close, window=getattr(cfg, "rsi_window", 14)
+        ).rsi()
+        adx = ta.trend.ADXIndicator(
+            df["high"], df["low"], close, window=getattr(cfg, "adx_window", 14)
+        ).adx()
+        macd = ta.trend.MACD(
+            close,
+            window_slow=getattr(cfg, "macd_window_slow", 26),
+            window_fast=getattr(cfg, "macd_window_fast", 12),
+            window_sign=getattr(cfg, "macd_window_sign", 9),
+        ).macd()
+        atr = ta.volatility.AverageTrueRange(
+            df["high"], df["low"], close, window=getattr(cfg, "atr_period_default", 14)
+        ).average_true_range()
+    else:
+        window = getattr(cfg, "rsi_window", 14)
+        delta = close.diff()
+        gain = delta.clip(lower=0)
+        loss = -delta.clip(upper=0)
+        avg_gain = gain.rolling(window=window, min_periods=window).mean()
+        avg_loss = loss.rolling(window=window, min_periods=window).mean()
+        rs = avg_gain / avg_loss.replace(0, np.nan)
+        rsi = 100 - (100 / (1 + rs))
+
+        adx_window = getattr(cfg, "adx_window", 14)
+        plus_dm = df["high"].diff().clip(lower=0)
+        minus_dm = (-df["low"].diff()).clip(lower=0)
+        tr = pd.concat(
+            [
+                (df["high"] - df["low"]).abs(),
+                (df["high"] - close.shift()).abs(),
+                (df["low"] - close.shift()).abs(),
+            ],
+            axis=1,
+        ).max(axis=1)
+        atr = tr.rolling(window=getattr(cfg, "atr_period_default", 14), min_periods=1).mean()
+        plus_di = 100 * plus_dm.ewm(alpha=1 / adx_window, min_periods=adx_window).mean() / atr
+        minus_di = 100 * minus_dm.ewm(alpha=1 / adx_window, min_periods=adx_window).mean() / atr
+        dx = ((plus_di - minus_di).abs() / (plus_di + minus_di).replace(0, np.nan)) * 100
+        adx = dx.ewm(alpha=1 / adx_window, min_periods=adx_window).mean()
+
+        fast = close.ewm(
+            span=getattr(cfg, "macd_window_fast", 12), adjust=False
+        ).mean()
+        slow = close.ewm(
+            span=getattr(cfg, "macd_window_slow", 26), adjust=False
+        ).mean()
+        macd = fast - slow
+
+    return types.SimpleNamespace(
+        ema30=ema30,
+        ema100=ema100,
+        ema200=ema200,
+        rsi=rsi,
+        adx=adx,
+        macd=macd,
+        atr=atr,
+    )
 
 
 def compute_features(df: pd.DataFrame, h: int, lag: int = 1, ema_span: int | None = None) -> pd.DataFrame:
@@ -61,4 +142,4 @@ def compute_features(df: pd.DataFrame, h: int, lag: int = 1, ema_span: int | Non
     return result
 
 
-__all__ = ["compute_features"]
+__all__ = ["compute_features", "compute_indicators"]

--- a/model_builder.py
+++ b/model_builder.py
@@ -1255,6 +1255,7 @@ class ModelBuilder:
         def _maybe_add(name: str, series: pd.Series, window_key: str | None = None):
             """Add indicator ``name`` if sufficient history is available."""
             if not isinstance(series, pd.Series):
+                logger.debug("Missing indicator %s for %s", name, symbol)
                 return
             if window_key is not None:
                 window = self.config.get(window_key, 0)

--- a/tests/test_data_handler.py
+++ b/tests/test_data_handler.py
@@ -148,3 +148,41 @@ async def test_load_from_disk_buffer_loop(tmp_path):
     loop_task.cancel()
     with contextlib.suppress(asyncio.CancelledError):
         await loop_task
+
+
+@pytest.mark.asyncio
+async def test_cleanup_old_data_pandas(monkeypatch, tmp_path):
+    cfg = BotConfig(
+        cache_dir=str(tmp_path),
+        data_cleanup_interval=0,
+        forget_window=10,
+        history_retention=5,
+    )
+    dh = DataHandler(cfg, None, None, exchange=DummyExchange({"BTCUSDT": 1.0}))
+    symbol = "BTCUSDT"
+    now = pd.Timestamp.now(tz="UTC")
+    timestamps = [now - pd.Timedelta(seconds=i) for i in range(14, -1, -1)]
+    idx = pd.MultiIndex.from_product([[symbol], timestamps], names=["symbol", "timestamp"])
+    df = pd.DataFrame({"open": 1, "high": 1, "low": 1, "close": 1, "volume": 1}, index=idx)
+    dh._ohlcv = df.copy()
+    dh._ohlcv_2h = df.copy()
+
+    orig_sleep = asyncio.sleep
+
+    async def fast_sleep(_):
+        await orig_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", fast_sleep)
+
+    task = asyncio.create_task(dh.cleanup_old_data())
+    with contextlib.suppress(asyncio.TimeoutError):
+        await asyncio.wait_for(task, 0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert len(dh._ohlcv) == cfg.history_retention
+    assert len(dh._ohlcv_2h) == cfg.history_retention
+    cutoff = now - pd.Timedelta(seconds=cfg.forget_window)
+    assert dh._ohlcv.index.get_level_values("timestamp").min() >= cutoff
+    assert dh._ohlcv_2h.index.get_level_values("timestamp").min() >= cutoff


### PR DESCRIPTION
## Summary
- handle pandas-based cleanup with cutoff and history retention
- add TA-based indicator calculations with fallbacks
- log missing indicators in LSTM feature preparation and test cleanup

## Testing
- `pytest tests/test_data_handler.py tests/test_data_handler_polars.py tests/test_model_builder.py tests/test_model_builder_cache.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c32d2eeca4832d9972d249542a15ff