### PR TITLE
Fix RL signal indentation for RL agent handling

### DIFF
--- a/trade_manager.py
+++ b/trade_manager.py
@@ -1184,19 +1184,19 @@ class TradeManager:
                     [float(prediction), num_positions / max(1, self.max_positions)],
                 ).astype(np.float32)
                 rl_signal = self.rl_agent.predict(symbol, rl_feat)
-                    if rl_signal == "close":
-                        await self.close_position(symbol, current_price, "RL Signal")
-                        return
-                    if rl_signal == "open_long" and position["side"] == "sell":
-                        await self.close_position(symbol, current_price, "RL Reverse")
-                        params = await self.data_handler.parameter_optimizer.optimize(symbol)
-                        await self.open_position(symbol, "buy", current_price, params)
-                        return
-                    if rl_signal == "open_short" and position["side"] == "buy":
-                        await self.close_position(symbol, current_price, "RL Reverse")
-                        params = await self.data_handler.parameter_optimizer.optimize(symbol)
-                        await self.open_position(symbol, "sell", current_price, params)
-                        return
+                if rl_signal == "close":
+                    await self.close_position(symbol, current_price, "RL Signal")
+                    return
+                if rl_signal == "open_long" and position["side"] == "sell":
+                    await self.close_position(symbol, current_price, "RL Reverse")
+                    params = await self.data_handler.parameter_optimizer.optimize(symbol)
+                    await self.open_position(symbol, "buy", current_price, params)
+                    return
+                if rl_signal == "open_short" and position["side"] == "buy":
+                    await self.close_position(symbol, current_price, "RL Reverse")
+                    params = await self.data_handler.parameter_optimizer.optimize(symbol)
+                    await self.open_position(symbol, "sell", current_price, params)
+                    return
             long_threshold, short_threshold = (
                 await self.model_builder.adjust_thresholds(symbol, prediction)
             )


### PR DESCRIPTION
## Summary
- fix indentation for RL signal checks in `trade_manager`

## Testing
- `pre-commit run --files trade_manager.py .github/workflows/dependabot.yml` *(fails: fastapi_csrf_protect is required)*

------
https://chatgpt.com/codex/tasks/task_e_68c3c8dade10832da356d7a73bd71489