### PR TITLE
chore: pin release drafter action

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update release draft
-        uses: release-drafter/release-drafter@v6
+        uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6
         with:
           config-name: release-drafter.yml
         env:


### PR DESCRIPTION
## Summary
- pin Release Drafter GitHub Action to a specific commit to avoid unpinned action warnings

## Testing
- `pre-commit run --files .github/workflows/release-drafter.yml .github/release-drafter.yml` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68c3c905bda0832daffd4a0ed25ff433