### PR TITLE
Fix docstring and server import issues

### DIFF
--- a/server.py
+++ b/server.py
@@ -19,10 +19,18 @@ load_dotenv()
 from fastapi import FastAPI, HTTPException, Request, Response
 
 try:
-
-from pydantic import BaseModel, Field, ValidationError
+    from pydantic import BaseModel, Field, ValidationError
+except ImportError as exc:  # pragma: no cover - dependency required
+    raise RuntimeError(
+        "pydantic is required. Install it with 'pip install pydantic'."
+    ) from exc
 
 API_KEYS: set[str] = set()
+
+try:  # pragma: no cover - handled in tests
+    from fastapi_csrf_protect import CsrfProtect, CsrfProtectError
+except Exception:  # pragma: no cover - fallback to test stubs
+    from test_stubs import CsrfProtect, CsrfProtectError
 
 
 class ModelManager:
@@ -220,7 +228,7 @@ class CsrfSettings(BaseModel):
 
 @CsrfProtect.load_config
 def get_csrf_config() -> CsrfSettings:
-    return CsrfSettings(secret_key=secret_key)
+    return CsrfSettings(secret_key=os.getenv("CSRF_SECRET", "changeme"))
 
 
 csrf_protect = CsrfProtect()

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -28,7 +28,7 @@ CFG = BotConfig()
 
 
 class GPTAdviceModel(BaseModel):
-    """Model for parsing GPT advice responses.
+    """Model for parsing GPT advice responses."""
 
     tp_mult: float | None = None
     sl_mult: float | None = None
@@ -40,7 +40,10 @@ class GPTAdviceModel(BaseModel):
             super().__setattr__("tp_mult", None)
             super().__setattr__("sl_mult", None)
 
+
 GPT_ADVICE = GPTAdviceModel()
+
+
 class ServiceUnavailableError(Exception):
     """Raised when required services are not reachable."""
 
@@ -438,11 +441,11 @@ async def build_feature_vector(price: float) -> list[float]:
 
     The vector includes:
 
-    1. ``price`` – latest price.
-    2. ``volume`` – price change since last observation as a proxy for volume.
-    3. ``sma`` – simple moving average of recent prices.
-    4. ``volatility`` – standard deviation of recent price changes.
-    5. ``rsi`` – Relative Strength Index over the recent window.
+    1. ``price`` - latest price.
+    2. ``volume`` - price change since last observation as a proxy for volume.
+    3. ``sma`` - simple moving average of recent prices.
+    4. ``volatility`` - standard deviation of recent price changes.
+    5. ``rsi`` - Relative Strength Index over the recent window.
     """
 
     async with PRICE_HISTORY_LOCK:
@@ -915,6 +918,9 @@ async def refresh_gpt_advice() -> None:
     GPT_ADVICE = GPTAdviceModel()
     try:
         env = _load_env()
+        price = await fetch_price(SYMBOL, env)
+        if price is None:
+            return
         features = await build_feature_vector(price)
         rsi = features[-1]
         ema = _compute_ema(list(_PRICE_HISTORY))
@@ -1049,8 +1055,9 @@ async def run_once_async() -> None:
         sl=sl,
         trailing_stop=trailing_stop,
     )
+
 async def main_async() -> None:
-    """Run the trading bot until interrupted."""
+    # Run the trading bot until interrupted.
     train_task = None
     monitor_task = None
     gpt_task = None


### PR DESCRIPTION
## Summary
- fix bullet list dashes and add price fetch in `refresh_gpt_advice`
- handle optional CsrfProtect import and CSRF secret config

## Testing
- `pytest -q` *(fails: NameError, AttributeError, assertion mismatches)*
- `pre-commit run --files trading_bot.py server.py` *(fails: pytest hook interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68c427b35f6c832d9ce78b7fb8456c10