### PR TITLE
chore: fix docker publish workflow conditions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,7 +21,6 @@ jobs:
     env:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-      TRIVY_ENABLED: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -117,7 +116,7 @@ jobs:
           df -h /mnt
 
       - name: Login to Docker Hub
-        if: env.TRIVY_ENABLED == 'true'
+        if: env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != ''
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3
         with:
           username: ${{ env.DOCKERHUB_USERNAME }}
@@ -136,7 +135,7 @@ jobs:
           file: ${{ matrix.file }}
           push: true
           tags: >-
-            ${{ env.TRIVY_ENABLED == 'true' &&
+            ${{ (env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '') &&
                 format('ghcr.io/{0}/{1}:latest,docker.io/{2}/{1}:latest',
                        github.repository_owner, matrix.image, env.DOCKERHUB_USERNAME) ||
                 format('ghcr.io/{0}/{1}:latest', github.repository_owner, matrix.image) }}
@@ -149,17 +148,17 @@ jobs:
           mv "$GITHUB_WORKSPACE/.buildx-cache-new" "$GITHUB_WORKSPACE/.buildx-cache"
 
       - name: Cleanup before Trivy scan
-        if: env.TRIVY_ENABLED == 'true'
+        if: env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != ''
         run: |
           sudo find /tmp -maxdepth 1 -name 'trivy-*' -exec rm -rf {} + || true
           sudo rm -rf /mnt/trivy-cache /mnt/trivy-tmp || true
           rm -rf ~/.cache/trivy || true
           mkdir -p /mnt/trivy-cache
       - name: Prepare Trivy temp
-        if: env.TRIVY_ENABLED == 'true'
+        if: env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != ''
         run: mkdir -p /mnt/trivy-tmp
       - name: Run Trivy vulnerability scanner
-        if: env.TRIVY_ENABLED == 'true'
+        if: env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != ''
         id: trivy
         uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8  # 0.33.1
         continue-on-error: true
@@ -172,13 +171,12 @@ jobs:
           format: table
           output: ${{ matrix.artifact }}.txt
           scanners: vuln
-
       - name: Show Trivy scan results
-        if: env.TRIVY_ENABLED == 'true' && steps.trivy.outcome == 'success'
+        if: env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' && steps.trivy.outcome == 'success'
         run: cat ${{ matrix.artifact }}.txt
 
       - name: Upload Trivy report artifact
-        if: env.TRIVY_ENABLED == 'true' && steps.trivy.outcome == 'success'
+        if: env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' && steps.trivy.outcome == 'success'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: ${{ matrix.artifact }}


### PR DESCRIPTION
## Summary
- simplify Docker Hub credential checks in docker publish workflow
- guard Trivy scan and Docker login behind credential presence

## Testing
- `actionlint .github/workflows/docker-publish.yml`
- `pre-commit run --files .github/workflows/docker-publish.yml` *(fails: ModuleNotFoundError: No module named 'tenacity')*


------
https://chatgpt.com/codex/tasks/task_e_68c427c12514832dbecb206b8afc023b