### PR TITLE
fix: checkout ref for dependabot

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -35,7 +35,8 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
+          # Use the Dependabot branch ref instead of the specific commit SHA
+          ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- use branch ref instead of commit SHA when checking out Dependabot PRs

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml` *(fails: SyntaxError in trading_bot.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c42806f194832dbdc119be7f21151a