### PR TITLE
fix server imports and hyphenate feature doc

### DIFF
--- a/server.py
+++ b/server.py
@@ -19,8 +19,11 @@ load_dotenv()
 from fastapi import FastAPI, HTTPException, Request, Response
 
 try:
-
-from pydantic import BaseModel, Field, ValidationError
+    from pydantic import BaseModel, Field, ValidationError
+except ImportError as exc:  # pragma: no cover - dependency required
+    raise RuntimeError(
+        "pydantic is required. Install it with 'pip install pydantic'."
+    ) from exc
 
 API_KEYS: set[str] = set()
 

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -438,11 +438,11 @@ async def build_feature_vector(price: float) -> list[float]:
 
     The vector includes:
 
-    1. ``price`` – latest price.
-    2. ``volume`` – price change since last observation as a proxy for volume.
-    3. ``sma`` – simple moving average of recent prices.
-    4. ``volatility`` – standard deviation of recent price changes.
-    5. ``rsi`` – Relative Strength Index over the recent window.
+    1. ``price`` - latest price.
+    2. ``volume`` - price change since last observation as a proxy for volume.
+    3. ``sma`` - simple moving average of recent prices.
+    4. ``volatility`` - standard deviation of recent price changes.
+    5. ``rsi`` - Relative Strength Index over the recent window.
     """
 
     async with PRICE_HISTORY_LOCK:


### PR DESCRIPTION
## Summary
- fix pydantic import guard in server startup
- use hyphen instead of en dash in feature vector docs

## Testing
- `python -m py_compile trading_bot.py` *(fails: SyntaxError: unterminated triple-quoted string literal)*
- `pytest tests/test_env_parsing.py tests/test_gpt_integration.py tests/test_http_client_cleanup.py tests/test_run_async.py tests/test_trading_bot.py tests/test_trading_bot_history.py` *(fails: SyntaxError: unterminated triple-quoted string literal)*

------
https://chatgpt.com/codex/tasks/task_e_68c42813dd0c832d957f933deff1ad25