### PR TITLE
fix csrf config in server

### DIFF
--- a/server.py
+++ b/server.py
@@ -227,6 +227,9 @@ class CsrfSettings(BaseModel):
 
 @CsrfProtect.load_config
 def get_csrf_config() -> CsrfSettings:
+    """Return CSRF settings for FastAPI CsrfProtect."""
+    secret = os.getenv("CSRF_SECRET", "change-me")
+    return CsrfSettings(secret_key=secret)
 
 
 csrf_protect = CsrfProtect()


### PR DESCRIPTION
## Summary
- add default CSRF settings provider for FastAPI server

## Testing
- `pytest -q` *(fails: NameError: name 'price' is not defined, AttributeError: module 'httpx' has no attribute 'Request')*

------
https://chatgpt.com/codex/tasks/task_e_68c427ec5988832d97c95431652f34b7