### PR TITLE
Simplify dependency graph workflow

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -17,14 +17,6 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
-      - name: Set up Python
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
-        with:
-          python-version: '3.11'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-ci.txt
       - name: Component detection
         # yamllint disable-line rule:line-length
         uses: advanced-security/component-detection-dependency-submission-action@v0.1.0


### PR DESCRIPTION
## Summary
- remove unnecessary Python setup and dependency installation from dependency-graph workflow

## Testing
- `pre-commit run --files .github/workflows/dependency-graph.yml` *(fails: ImportError: cannot import name 'CsrfProtect'; assert 0.0 == 1.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c44cd16a0c832d9a85a7726999cfdd