### PR TITLE
fix release drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,15 +10,14 @@ on:
     types: [opened, reopened, synchronize, labeled, unlabeled]
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Update release draft
         uses: release-drafter/release-drafter@v6
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- fix release drafter workflow permissions and token

## Testing
- `/root/.local/share/mise/installs/go/1.24.3/bin/actionlint .github/workflows/release-drafter.yml && echo OK`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'polars')*

------
https://chatgpt.com/codex/tasks/task_e_68c44d2ffc58832d92def7196c1c745e