### PR TITLE
Fix Dependabot workflow tests

### DIFF
--- a/model_builder.py
+++ b/model_builder.py
@@ -1699,6 +1699,8 @@ class TradingEnv(gym.Env if gym else object):
     def reset(self):
         self.current_step = 0
         self.position = 0
+        self.balance = 0.0
+        self.max_balance = 0.0
         return self._get_obs()
 
     def _get_obs(self):
@@ -1710,6 +1712,9 @@ class TradingEnv(gym.Env if gym else object):
         prev_position = self.position
         if action == 1:  # open long
             self.position = 1
+        elif action == 2:  # open short
+            self.position = -1
+        elif action == 3:  # close position
             self.position = 0
 
         if self.current_step < len(self.df) - 1:

--- a/server.py
+++ b/server.py
@@ -28,8 +28,10 @@ API_KEYS: set[str] = set()
 
 try:  # pragma: no cover - handled in tests
     from fastapi_csrf_protect import CsrfProtect, CsrfProtectError
-except Exception:  # pragma: no cover - fallback to test stubs
-    from test_stubs import CsrfProtect, CsrfProtectError
+except Exception as exc:  # pragma: no cover - dependency required
+    raise RuntimeError(
+        "fastapi-csrf-protect is required. Install it with 'pip install fastapi-csrf-protect'."
+    ) from exc
 
 
 class ModelManager:


### PR DESCRIPTION
## Summary
- handle missing fastapi-csrf-protect as runtime error
- correct TradingEnv position handling and reset balance

## Testing
- `pytest -m "not integration" -q`


------
https://chatgpt.com/codex/tasks/task_e_68c44d07393c832da087b4dc20b827d3