### PR TITLE
chore: silence yamllint truthy rule

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -1,5 +1,5 @@
 # .github/workflows/gptoss_review.yml
-# yamllint disable rule:line-length
+# yamllint disable rule:line-length rule:truthy
 ---
 name: GPT-OSS Code Review
 


### PR DESCRIPTION
## Summary
- silence yamllint `truthy` warning in GPT-OSS workflow

## Testing
- `yamllint .github/workflows/gptoss_review.yml`
- `actionlint -no-color .github/workflows/gptoss_review.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c44d1fe754832d86a4ce4cebe35b43