### PR TITLE
test: skip optional deps when missing

### DIFF
--- a/tests/test_no_lookahead.py
+++ b/tests/test_no_lookahead.py
@@ -4,8 +4,10 @@ import types
 import pytest
 
 from bot.data_handler import DataHandler
-from bot.services import model_builder_service as mbs
 from pathlib import Path
+
+pytest.importorskip("sklearn")
+from bot.services import model_builder_service as mbs
 
 
 class Cfg:

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -4,6 +4,7 @@ import pytest
 
 pytest.importorskip("transformers")
 pytest.importorskip("httpx")
+pytest.importorskip("fastapi")
 pytest.importorskip("fastapi_csrf_protect")
 
 try:

--- a/tests/test_server_csrf_unexpected.py
+++ b/tests/test_server_csrf_unexpected.py
@@ -3,6 +3,7 @@ import pytest
 
 pytest.importorskip("transformers")
 pytest.importorskip("httpx")
+pytest.importorskip("fastapi")
 pytest.importorskip("fastapi_csrf_protect")
 
 os.environ.setdefault("CSRF_SECRET", "testsecret")

--- a/tests/test_server_missing_api_keys.py
+++ b/tests/test_server_missing_api_keys.py
@@ -3,6 +3,7 @@ import sys
 import pytest
 
 pytest.importorskip("httpx")
+pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
 
 

--- a/tests/test_server_request_validation.py
+++ b/tests/test_server_request_validation.py
@@ -2,6 +2,7 @@ import os
 import pytest
 pytest.importorskip("transformers")
 pytest.importorskip("httpx")
+pytest.importorskip("fastapi")
 pytest.importorskip("fastapi_csrf_protect")
 
 os.environ.setdefault("CSRF_SECRET", "testsecret")


### PR DESCRIPTION
## Summary
- ensure server tests skip when FastAPI missing
- avoid sklearn dependency for no_lookahead test

## Testing
- `PYTEST_ADDOPTS='tests/test_server_auth.py tests/test_server_csrf_unexpected.py tests/test_server_missing_api_keys.py tests/test_server_request_validation.py tests/test_no_lookahead.py' pre-commit run --files tests/test_server_auth.py tests/test_server_csrf_unexpected.py tests/test_server_missing_api_keys.py tests/test_server_request_validation.py tests/test_no_lookahead.py`
- `pytest tests/test_server_auth.py tests/test_server_csrf_unexpected.py tests/test_server_missing_api_keys.py tests/test_server_request_validation.py tests/test_no_lookahead.py`

------
https://chatgpt.com/codex/tasks/task_e_68c44d408fd0832d9c404381fb0fb9e1