### PR TITLE
Fix CSRF dependency handling and reward logic

### DIFF
--- a/model_builder.py
+++ b/model_builder.py
@@ -1710,6 +1710,9 @@ class TradingEnv(gym.Env if gym else object):
         prev_position = self.position
         if action == 1:  # open long
             self.position = 1
+        elif action == 2:  # open short
+            self.position = -1
+        elif action == 3:  # close position
             self.position = 0
 
         if self.current_step < len(self.df) - 1:

--- a/server.py
+++ b/server.py
@@ -28,8 +28,10 @@ API_KEYS: set[str] = set()
 
 try:  # pragma: no cover - handled in tests
     from fastapi_csrf_protect import CsrfProtect, CsrfProtectError
-except Exception:  # pragma: no cover - fallback to test stubs
-    from test_stubs import CsrfProtect, CsrfProtectError
+except Exception as exc:  # pragma: no cover - dependency required
+    raise RuntimeError(
+        "fastapi-csrf-protect is required. Install it with 'pip install fastapi-csrf-protect'."
+    ) from exc
 
 
 class ModelManager:

--- a/test_stubs.py
+++ b/test_stubs.py
@@ -94,6 +94,29 @@ class FlaskWithASGI(Protocol):
 IS_TEST_MODE = False
 
 
+class CsrfProtectError(Exception):
+    pass
+
+
+class CsrfProtect:
+    @classmethod
+    def load_config(cls, func):
+        return func
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def generate_csrf_token(self) -> str:
+        return "test-token"
+
+    def generate_csrf_tokens(self):
+        token = self.generate_csrf_token()
+        return token, token
+
+    async def validate_csrf(self, request) -> None:  # pragma: no cover - simple stub
+        return
+
+
 def apply() -> None:
     """Patch heavy dependencies with lightweight stubs in test mode."""
     global IS_TEST_MODE
@@ -294,30 +317,8 @@ def apply() -> None:
 
     # ------------------------------------------------ fastapi_csrf_protect
     csrf_mod = cast(ModuleType, types.ModuleType("fastapi_csrf_protect"))
-
-    class _CsrfProtectError(Exception):
-        pass
-
-    class _CsrfProtect:
-        @classmethod
-        def load_config(cls, func):
-            return func
-
-        def __init__(self, *args, **kwargs):
-            pass
-
-        def generate_csrf_token(self) -> str:
-            return "test-token"
-
-        def generate_csrf_tokens(self):
-            token = self.generate_csrf_token()
-            return token, token
-
-        async def validate_csrf(self, request) -> None:
-            return
-
-    setattr(csrf_mod, "CsrfProtect", _CsrfProtect)
-    setattr(csrf_mod, "CsrfProtectError", _CsrfProtectError)
+    setattr(csrf_mod, "CsrfProtect", CsrfProtect)
+    setattr(csrf_mod, "CsrfProtectError", CsrfProtectError)
     sys.modules["fastapi_csrf_protect"] = csrf_mod
 
     # ------------------------------------------------------------------- torch
@@ -345,5 +346,5 @@ def apply() -> None:
 apply()
 
 
-__all__ = ["IS_TEST_MODE", "apply"]
+__all__ = ["IS_TEST_MODE", "apply", "CsrfProtect", "CsrfProtectError"]
 


### PR DESCRIPTION
## Summary
- make `fastapi-csrf-protect` a hard requirement instead of falling back to stubs
- correct `TradingEnv.step` so positions and rewards update properly
- expose `CsrfProtect` stubs to avoid import errors in tests

## Testing
- `pre-commit run --files test_stubs.py model_builder.py server.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c44cfbda08832d86b35561cd8d78d6