### PR TITLE
Fix CI ruff step and clean test imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           device: ${{ matrix.device }}
       - name: Install development requirements
         run: pip install -r requirements.txt -r requirements-dev.txt
-      - run: ruff bot tests --output-format=github
+      - run: ruff check bot tests --output-format=github
       - run: mypy bot
       - run: bandit -r bot -x tests -ll
       - name: Audit dependencies

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,5 +1,4 @@
 import time
-import random
 import socket
 import multiprocessing
 from contextlib import contextmanager

--- a/tests/test_backtest_loop.py
+++ b/tests/test_backtest_loop.py
@@ -2,7 +2,6 @@ import asyncio
 import contextlib
 import logging
 import types
-import os
 import sys
 import pytest
 from bot.config import BotConfig

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -3,8 +3,9 @@ import os
 import pickle
 import pandas as pd
 import pytest
-psutil = pytest.importorskip("psutil")
 from bot.cache import HistoricalDataCache
+
+psutil = pytest.importorskip("psutil")
 
 
 def _mock_virtual_memory():

--- a/tests/test_force_cpu.py
+++ b/tests/test_force_cpu.py
@@ -1,5 +1,4 @@
 import importlib
-import os
 import sys
 from bot import utils
 

--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -6,8 +6,6 @@ import json
 
 import pytest
 import httpx
-
-sys.modules.pop("tenacity", None)
 import tenacity  # noqa: F401  # re-import after pop
 
 from bot.gpt_client import (
@@ -24,6 +22,8 @@ from bot.gpt_client import (
     query_gpt_async,
     query_gpt_json_async,
 )
+
+sys.modules.pop("tenacity", None)
 
 
 class DummyStream:

--- a/tests/test_gptoss_check.py
+++ b/tests/test_gptoss_check.py
@@ -20,8 +20,8 @@ _fake_client.query_gpt = lambda *args, **kwargs: None
 
 sys.modules.setdefault("gpt_client", _fake_client)
 
-import gptoss_check.check_code as check_code
-from gptoss_check import main as gptoss_main
+import gptoss_check.check_code as check_code  # noqa: E402
+from gptoss_check import main as gptoss_main  # noqa: E402
 
 
 def test_skip_message(caplog, tmp_path):

--- a/tests/test_http_client_cleanup.py
+++ b/tests/test_http_client_cleanup.py
@@ -9,8 +9,7 @@ os.environ.setdefault("TEST_MODE", "1")
 stub_data_handler = types.ModuleType("data_handler")
 stub_data_handler.get_settings = lambda: None
 sys.modules.setdefault("data_handler", stub_data_handler)
-
-from bot.trading_bot import get_http_client, close_http_client
+from bot.trading_bot import get_http_client, close_http_client  # noqa: E402
 
 
 @pytest.mark.asyncio

--- a/tests/test_import_order.py
+++ b/tests/test_import_order.py
@@ -2,7 +2,6 @@ import importlib
 import sys
 import types
 import logging
-import os
 import pytest
 
 

--- a/tests/test_indicators_cache.py
+++ b/tests/test_indicators_cache.py
@@ -3,9 +3,9 @@ import types
 import pandas as pd
 import numpy as np
 import pytest
+from bot.config import BotConfig
 
 ta = pytest.importorskip("ta")
-from bot.config import BotConfig
 
 optimizer_stubbed = False
 if 'optimizer' not in sys.modules and 'bot.optimizer' not in sys.modules:

--- a/tests/test_indicators_gpu.py
+++ b/tests/test_indicators_gpu.py
@@ -1,13 +1,13 @@
-import os
 import sys
+import types
+
 import numpy as np
 import pandas as pd
 import pytest
-ta = pytest.importorskip("ta")
-import types
 from bot import utils
 
-import importlib.util
+ta = pytest.importorskip("ta")
+
 
 # Stub heavy dependencies before importing data_handler
 ccxt_mod = types.ModuleType('ccxt')

--- a/tests/test_integration_services.py
+++ b/tests/test_integration_services.py
@@ -1,4 +1,3 @@
-import os
 import httpx
 import multiprocessing
 import sys
@@ -124,7 +123,6 @@ def test_services_communicate(monkeypatch, ctx):
 
 @pytest.mark.integration
 def test_service_availability_check(monkeypatch, ctx):
-    from bot import trading_bot  # noqa: E402
     dh_port = get_free_port()
     mb_port = get_free_port()
     tm_port = get_free_port()

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -1,11 +1,9 @@
-import os
 import sys
 
 import numpy as np
 import pandas as pd
 import types
 import pytest
-import importlib.util
 import contextlib
 from bot.config import BotConfig
 import asyncio
@@ -15,8 +13,8 @@ from collections import deque
 # Skip tests if required optional packages are missing
 pytest.importorskip("gymnasium", reason="requires gymnasium")
 sklearn = pytest.importorskip("sklearn", reason="requires scikit-learn")
-from sklearn.preprocessing import StandardScaler  # type: ignore
-from sklearn.metrics import brier_score_loss  # type: ignore
+from sklearn.preprocessing import StandardScaler  # type: ignore  # noqa: E402
+from sklearn.metrics import brier_score_loss  # type: ignore  # noqa: E402
 
 pytestmark = pytest.mark.requires_sklearn
 
@@ -56,8 +54,8 @@ if "stable_baselines3" not in sys.modules:
     sys.modules["stable_baselines3.common"] = common
     sys.modules["stable_baselines3.common.vec_env"] = vec_env
 
-from bot import model_builder
-from bot.model_builder import (
+from bot import model_builder  # noqa: E402
+from bot.model_builder import (  # noqa: E402
     ModelBuilder,
     _train_model_remote,
     prepare_features,
@@ -417,8 +415,8 @@ async def test_base_threshold_convergence(tmp_path):
     mb = ModelBuilder(cfg, dh, tm)
     mb.prediction_history["BTCUSDT"] = deque([], maxlen=10)
     data = [(0.7, 1), (0.3, 0), (0.8, 1), (0.2, 0), (0.6, 0)]
-    for p, l in data:
-        mb.prediction_history["BTCUSDT"].append((p, l))
+    for p, label in data:
+        mb.prediction_history["BTCUSDT"].append((p, label))
         mb.compute_prediction_metrics("BTCUSDT")
     assert mb.base_thresholds["BTCUSDT"] == pytest.approx(0.8)
     long_thr, short_thr = await mb.adjust_thresholds("BTCUSDT", 0.5)
@@ -447,8 +445,8 @@ async def test_base_threshold_clamped_min(tmp_path):
     mb = ModelBuilder(cfg, dh, tm)
     mb.prediction_history["BTCUSDT"] = deque([], maxlen=10)
     data = [(0.1, 1), (0.2, 1), (0.3, 1), (0.8, 0), (0.6, 0)]
-    for p, l in data:
-        mb.prediction_history["BTCUSDT"].append((p, l))
+    for p, label in data:
+        mb.prediction_history["BTCUSDT"].append((p, label))
         mb.compute_prediction_metrics("BTCUSDT")
     assert mb.base_thresholds["BTCUSDT"] == pytest.approx(0.5)
     long_thr, short_thr = await mb.adjust_thresholds("BTCUSDT", 0.5)

--- a/tests/test_model_builder_cache.py
+++ b/tests/test_model_builder_cache.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import types
 import numpy as np

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1,4 +1,3 @@
-import os
 import sys
 
 import pytest

--- a/tests/test_rl_agent.py
+++ b/tests/test_rl_agent.py
@@ -1,11 +1,12 @@
 import sys
 import types
 import importlib
-import pandas as pd
-import numpy as np
-import pytest
 import importlib.util
 import os
+
+import numpy as np
+import pandas as pd
+import pytest
 
 ROOT = os.path.dirname(os.path.dirname(__file__))
 spec = importlib.util.spec_from_file_location("utils_real", os.path.join(ROOT, "utils.py"))
@@ -59,10 +60,11 @@ if "gymnasium" not in sys.modules:
     gym_stub.spaces = types.SimpleNamespace(Discrete=DummyDiscrete, Box=DummyBox)
     sys.modules["gymnasium"] = gym_stub
 
-from bot import model_builder
+from bot import model_builder  # noqa: E402
+from bot.config import BotConfig  # noqa: E402
+from bot.model_builder import RLAgent  # noqa: E402
+
 importlib.reload(model_builder)
-from bot.config import BotConfig
-from bot.model_builder import RLAgent
 
 
 class DummyModelBuilder:

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import pytest
 
 pytest.importorskip("transformers")

--- a/tests/test_server_missing_api_keys.py
+++ b/tests/test_server_missing_api_keys.py
@@ -1,4 +1,3 @@
-import importlib
 import sys
 import pytest
 

--- a/tests/test_server_model_loading.py
+++ b/tests/test_server_model_loading.py
@@ -1,4 +1,9 @@
-import sys, types, asyncio, pytest, importlib, os
+import sys
+import types
+import asyncio
+import pytest
+import importlib
+import os
 
 
 class _FailingLoader:

--- a/tests/test_service_scripts.py
+++ b/tests/test_service_scripts.py
@@ -29,7 +29,6 @@ def _run_dh(port: int):
     import sys
     sys.modules['ccxt'] = ccxt
     with patch.dict(os.environ, {'STREAM_SYMBOLS': '', 'HOST': '127.0.0.1', 'TEST_MODE': '1'}):
-        import utils
         from bot.services import data_handler_service
         data_handler_service.app.run(host='127.0.0.1', port=port)
 
@@ -66,7 +65,6 @@ def _run_dh_fail(port: int):
     import sys
     sys.modules['ccxt'] = ccxt
     with patch.dict(os.environ, {'STREAM_SYMBOLS': '', 'HOST': '127.0.0.1', 'TEST_MODE': '1'}):
-        import utils
         from bot.services import data_handler_service
         data_handler_service.app.run(host='127.0.0.1', port=port)
 
@@ -110,7 +108,6 @@ def _run_mb(model_dir: str, port: int):
     sys.modules['sklearn.linear_model'] = linear_model
 
     with patch.dict(os.environ, {'MODEL_DIR': model_dir, 'TEST_MODE': '1'}):
-        import utils
         from bot.services import model_builder_service
         model_builder_service.app.run(port=port)
 
@@ -197,7 +194,6 @@ def _run_mb_fail(model_file: str, port: int):
     sys.modules['sklearn.linear_model'] = linear_model
 
     with patch.dict(os.environ, {'MODEL_FILE': model_file, 'TEST_MODE': '1'}):
-        import utils
         from bot.services import model_builder_service
         model_builder_service._load_model()
         model_builder_service.app.run(port=port)
@@ -268,7 +264,6 @@ def _run_tm(
         'TEST_MODE': '1',
     }
     with patch.dict(os.environ, env):
-        import utils
         from bot.services import trade_manager_service
         trade_manager_service.app.run(host='127.0.0.1', port=port)
 

--- a/tests/test_shap_cache.py
+++ b/tests/test_shap_cache.py
@@ -1,4 +1,3 @@
-import asyncio
 import types
 import numpy as np
 import pytest

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import sys
 import types

--- a/tests/test_strategy_optimizer.py
+++ b/tests/test_strategy_optimizer.py
@@ -6,8 +6,11 @@ from bot.config import BotConfig
 
 sys.modules.pop('strategy_optimizer', None)
 sys.modules.pop('bot.strategy_optimizer', None)
-from bot.strategy_optimizer import StrategyOptimizer, _portfolio_backtest_remote
-from bot.portfolio_backtest import portfolio_backtest
+from bot.strategy_optimizer import (  # noqa: E402
+    StrategyOptimizer,
+    _portfolio_backtest_remote,
+)
+from bot.portfolio_backtest import portfolio_backtest  # noqa: E402
 
 
 class DummyDataHandler:

--- a/tests/test_telegram_logger.py
+++ b/tests/test_telegram_logger.py
@@ -5,7 +5,6 @@ import asyncio
 import pytest
 import sys
 import threading
-import time
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 from bot.telegram_logger import TelegramLogger

--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -4,7 +4,6 @@ import pytest
 import sys
 import types
 import logging
-import os
 import math
 import contextlib
 import tempfile
@@ -57,7 +56,7 @@ joblib_mod.dump = lambda *a, **k: None
 joblib_mod.load = lambda *a, **k: {}
 sys.modules.setdefault('joblib', joblib_mod)
 
-import asyncio
+import asyncio  # noqa: E402
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -84,7 +83,8 @@ def _cleanup_telegram_logger(_import_trade_manager):
     asyncio.run(trade_manager.TelegramLogger.shutdown())
 
 def test_utils_injected_before_trade_manager_import():
-    import importlib, sys
+    import importlib
+    import sys
     tm = importlib.reload(sys.modules.get("bot.trade_manager", trade_manager))
     tm.TelegramLogger = _TL
     assert tm.TelegramLogger is _TL
@@ -1532,7 +1532,9 @@ async def test_execute_top_signals_ranking(monkeypatch):
 
 
 def test_shutdown_shuts_down_ray(monkeypatch):
-    import importlib, sys, types
+    import importlib
+    import sys
+    import types
 
     ray_stub = types.ModuleType("ray")
     called = {"done": False}
@@ -1557,7 +1559,9 @@ def test_shutdown_shuts_down_ray(monkeypatch):
 
 
 def test_shutdown_calls_ray_shutdown_in_test_mode(monkeypatch):
-    import importlib, sys, types
+    import importlib
+    import sys
+    import types
 
     ray_stub = types.ModuleType("ray")
     called = {"done": False}
@@ -1577,7 +1581,9 @@ def test_shutdown_calls_ray_shutdown_in_test_mode(monkeypatch):
 
 
 def test_shutdown_handles_missing_is_initialized(monkeypatch):
-    import importlib, sys, types
+    import importlib
+    import sys
+    import types
 
     monkeypatch.setenv("TEST_MODE", "0")
 

--- a/tests/test_trade_manager_loops.py
+++ b/tests/test_trade_manager_loops.py
@@ -3,7 +3,6 @@ import contextlib
 import logging
 import sys
 import types
-import os
 import pandas as pd
 import pytest
 import tempfile

--- a/tests/test_trading_bot_history.py
+++ b/tests/test_trading_bot_history.py
@@ -1,4 +1,3 @@
-import asyncio
 
 import pytest
 


### PR DESCRIPTION
## Summary
- run `ruff check` in CI to match new CLI
- clean up test imports, add late-import exceptions, and rename ambiguous variables for ruff

## Testing
- `ruff check bot tests --output-format=github`
- `mypy bot`
- `bandit -r bot -x tests -ll` *(command not found)*
- `flake8 .` *(command not found)*
- `pip-audit --strict -f json -o /tmp/pip-audit.json` *(command not found)*
- `pytest -m "not integration"` *(missing dependencies: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68c44ced48bc832db589dc687abbd7d7