### PR TITLE
fix: ensure Dependabot workflow triggers for bot PRs

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   dependabot:
     # Run this job only for Dependabot PRs.
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - name: Dependabot metadata


### PR DESCRIPTION
## Summary
- run Dependabot auto-merge workflow for any Dependabot-authored PR

## Testing
- `SKIP=pytest pre-commit run --files .github/workflows/dependabot.yml`
- `pytest -m "not integration" -q`

------
https://chatgpt.com/codex/tasks/task_e_68c453f64cbc832d832b18e8d289a291