### PR TITLE
docs: update history endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ waitress-serve services.data_handler_service:app
 ```
 
 `data_handler_service.py` fetches prices from Bybit using `ccxt` and exposes
-`/price/<symbol>` and `/ohlcv/<symbol>`.
+`/price/<symbol>` и `/history/<symbol>`.
 `model_builder_service.py` trains a small logistic regression when you POST
 features to `/train`.  Predictions are requested via `/predict` using
 `{"features": [...]}` where the first element usually represents the price.


### PR DESCRIPTION
## Summary
- replace outdated `/ohlcv/<symbol>` references with `/history/<symbol>`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c45858c498832d88b3354a773315b9