### PR TITLE
Handle GPT hold signals and validate GPT JSON

### DIFF
--- a/gpt_client.py
+++ b/gpt_client.py
@@ -367,6 +367,11 @@ async def query_gpt_json_async(prompt: str) -> dict:
         raise GPTClientJSONError("Invalid JSON response from GPT OSS API") from exc
     if not isinstance(data, dict):
         raise GPTClientResponseError("Unexpected response structure from GPT OSS API")
+    required = {"signal", "tp_mult", "sl_mult"}
+    if not required.issubset(data):
+        missing = sorted(required - set(data))
+        logger.error("Missing fields in GPT response: %s", missing)
+        return {"signal": "hold"}
     return data
 
 

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -847,10 +847,11 @@ def _resolve_trade_params(
 
     tp_mult = CFG.tp_multiplier
     sl_mult = CFG.sl_multiplier
-    if GPT_ADVICE.tp_mult is not None and isinstance(GPT_ADVICE.signal, (str, type(None))):
-        tp_mult *= float(GPT_ADVICE.tp_mult)
-    if GPT_ADVICE.sl_mult is not None and isinstance(GPT_ADVICE.signal, (str, type(None))):
-        sl_mult *= float(GPT_ADVICE.sl_mult)
+    if GPT_ADVICE.signal in {"buy", "sell"}:
+        if GPT_ADVICE.tp_mult is not None:
+            tp_mult *= float(GPT_ADVICE.tp_mult)
+        if GPT_ADVICE.sl_mult is not None:
+            sl_mult *= float(GPT_ADVICE.sl_mult)
 
     tp = _resolve(tp, env_tp, tp_mult)
     sl = _resolve(sl, env_sl, sl_mult)
@@ -878,10 +879,7 @@ def should_trade(model_signal: str) -> bool:
         elif prices[-1] < ema:
             ema_signal = "sell"
 
-    weights = {
-        "model": CFG.transformer_weight,
-        "ema": CFG.ema_weight,
-    }
+    weights = {"model": CFG.transformer_weight, "ema": CFG.ema_weight}
     scores = {"buy": 0.0, "sell": 0.0}
     if model_signal == "buy":
         scores["buy"] += weights["model"]
@@ -891,12 +889,12 @@ def should_trade(model_signal: str) -> bool:
         scores["buy"] += weights["ema"]
     elif ema_signal == "sell":
         scores["sell"] += weights["ema"]
-    if gpt_signal in ("buy", "sell"):
+    if gpt_signal == "buy":
         weights["gpt"] = CFG.gpt_weight
-        if gpt_signal == "buy":
-            scores["buy"] += weights["gpt"]
-        else:
-            scores["sell"] += weights["gpt"]
+        scores["buy"] += weights["gpt"]
+    elif gpt_signal == "sell":
+        weights["gpt"] = CFG.gpt_weight
+        scores["sell"] += weights["gpt"]
 
     total_weight = sum(weights.values())
     final = None


### PR DESCRIPTION
## Summary
- Apply GPT-provided TP/SL multipliers only for buy/sell signals; ignore them on hold
- Validate GPT JSON responses and fall back to a default hold when mandatory fields are missing
- Consider GPT weight in trading decisions only for buy/sell signals

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c458527cd8832d953f86040d5d4709