### PR TITLE
Fix prediction threshold check

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -1091,6 +1091,7 @@ async def run_once_async(symbol: str | None = None) -> None:
 
     logger.info("Prediction for %s: %s", symbol, signal)
 
+    if prob < threshold:
         return
 
     tp, sl, trailing_stop = _parse_trade_params(


### PR DESCRIPTION
## Summary
- add missing probability threshold check when making trades

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'configure_logging', TypeError: StubTL() takes no arguments, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c540db79c8832db9707bf08a4963cd