### PR TITLE
Fix should_trade logic in trading bot

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -914,6 +914,13 @@ def _resolve_trade_params(
     return tp, sl, trailing_stop
 
 
+def should_trade(
+    model_signal: str,
+    prob: float = 1.0,
+    threshold: float = 0.5,
+    symbol: str | None = None,
+) -> bool:
+    """Return ``True`` if combined signals confirm ``model_signal``."""
 
     if symbol is None:
         symbol = SYMBOLS[0]
@@ -1091,6 +1098,10 @@ async def run_once_async(symbol: str | None = None) -> None:
 
     logger.info("Prediction for %s: %s", symbol, signal)
 
+    if prob < threshold:
+        return
+
+    if not should_trade(signal, prob, threshold, symbol):
         return
 
     tp, sl, trailing_stop = _parse_trade_params(


### PR DESCRIPTION
## Summary
- restore missing should_trade function and use in run_once_async
- add probability threshold check before trading

## Testing
- `pre-commit run --files trading_bot.py` *(fails: StubTL() takes no arguments)*
- `pytest tests/test_trading_bot.py::test_should_trade_gpt_hold -q`

------
https://chatgpt.com/codex/tasks/task_e_68c540e93018832d98eda517965913fa