### PR TITLE
Add offline stubs and OFFLINE_MODE toggle

### DIFF
--- a/config.py
+++ b/config.py
@@ -13,7 +13,11 @@ from pathlib import Path
 from dataclasses import MISSING, dataclass, field, fields, asdict
 from typing import Any, Dict, List, Optional, Union, get_args, get_origin, get_type_hints
 import threading
+from dotenv import dotenv_values
 
+
+_env = dotenv_values()
+OFFLINE_MODE = os.getenv("OFFLINE_MODE", _env.get("OFFLINE_MODE", "0")) == "1"
 
 logger = logging.getLogger(__name__)
 

--- a/services/offline.py
+++ b/services/offline.py
@@ -1,0 +1,71 @@
+"""Offline stubs for external services."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from types import SimpleNamespace
+
+logger = logging.getLogger("TradingBot")
+
+
+class OfflineBybit:
+    """Dummy Bybit client returning canned responses."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        self.orders: list[dict] = []
+
+    def create_order(self, symbol: str, order_type: str, side: str, amount: float, price: float | None = None, *args, **kwargs) -> dict:
+        order = {
+            "id": len(self.orders) + 1,
+            "symbol": symbol,
+            "type": order_type,
+            "side": side,
+            "amount": amount,
+            "price": price,
+        }
+        self.orders.append(order)
+        return order
+
+    def create_order_with_trailing_stop(self, *args, **kwargs) -> dict:
+        return self.create_order(*args, **kwargs)
+
+    def create_order_with_take_profit_and_stop_loss(self, *args, **kwargs) -> dict:
+        return self.create_order(*args, **kwargs)
+
+    def fetch_positions(self) -> list[dict]:
+        return self.orders
+
+
+class OfflineTelegram(logging.Handler):
+    """Stub Telegram logger that logs messages locally."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__()
+        self.chat_id = kwargs.get("chat_id")
+
+    async def send_telegram_message(self, message: str, urgent: bool = False) -> None:
+        logger.info("[OFFLINE TELEGRAM] %s", message)
+
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - logging
+        pass
+
+    @staticmethod
+    async def shutdown() -> None:
+        return None
+
+
+class OfflineGPT:
+    """Return predefined responses for GPT queries."""
+
+    @staticmethod
+    def query(prompt: str) -> str:
+        return "offline response"
+
+    @staticmethod
+    async def query_async(prompt: str) -> str:
+        return OfflineGPT.query(prompt)
+
+    @staticmethod
+    async def query_json_async(prompt: str) -> dict:
+        return {"signal": "hold"}

--- a/telegram_logger.py
+++ b/telegram_logger.py
@@ -15,6 +15,9 @@ import time
 from typing import Any, Optional
 
 import httpx
+from config import OFFLINE_MODE
+if OFFLINE_MODE:
+    from services.offline import OfflineTelegram
 try:  # pragma: no cover - optional dependency
     from telegram.error import BadRequest, Forbidden, RetryAfter
 except Exception as exc:  # pragma: no cover - missing telegram
@@ -241,4 +244,8 @@ class TelegramLogger(logging.Handler):
         cls._queue = None
         cls._stop_event = None
         cls._bot = None
+
+
+if OFFLINE_MODE:
+    TelegramLogger = OfflineTelegram  # type: ignore
 

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -1,11 +1,18 @@
 """Compatibility wrapper for the TradeManager service."""
 
-from bot.utils import TelegramLogger  # re-export for test injection
-from bot.trade_manager.service import *  # noqa: F401,F403
-from bot.trade_manager.core import TradeManager
-from bot.utils import TelegramLogger
+from config import OFFLINE_MODE
+
+if OFFLINE_MODE:
+    from services.offline import OfflineBybit as TradeManager, OfflineTelegram as TelegramLogger
+else:  # pragma: no cover - real implementation
+    from bot.utils import TelegramLogger  # re-export for test injection
+    from bot.trade_manager.service import *  # noqa: F401,F403
+    from bot.trade_manager.core import TradeManager
 
 if __name__ == "__main__":  # pragma: no cover - manual execution
-    from bot.trade_manager.service import main
+    if OFFLINE_MODE:
+        print("Offline mode: trade manager not started")
+    else:
+        from bot.trade_manager.service import main
 
-    main()
+        main()


### PR DESCRIPTION
## Summary
- add OFFLINE_MODE flag loaded from .env
- provide offline stubs for Bybit, Telegram and GPT services
- use offline stubs in trade manager, GPT client and Telegram logger when OFFLINE_MODE=1

## Testing
- `pytest` *(fails: IndentationError in trading_bot.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c54831f91c832db80be85e19354397