### PR TITLE
Fix docker publish workflow tags generation

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -131,8 +131,10 @@ jobs:
 
       - name: Prepare image tags
         id: tags
+        env:
+          MATRIX_IMAGE: ${{ matrix.image }}
         run: |
-          tags="ghcr.io/$GITHUB_REPOSITORY_OWNER/$MATRIX_IMAGE:latest"
+          tags="ghcr.io/${GITHUB_REPOSITORY_OWNER}/${MATRIX_IMAGE}:latest"
           if [ -n "$DOCKERHUB_USERNAME" ] && [ -n "$DOCKERHUB_TOKEN" ]; then
             tags="$tags"$'\n'"docker.io/$DOCKERHUB_USERNAME/$MATRIX_IMAGE:latest"
           fi


### PR DESCRIPTION
## Summary
- fix Docker tags generation by exposing matrix image variable to shell

## Testing
- `actionlint .github/workflows/docker-publish.yml`
- `pre-commit run --files .github/workflows/docker-publish.yml` *(fails: IndentationError in trading_bot.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c54962d99c832da5f395bca441ac7d