### PR TITLE
Fix TradeManager docstring and GPT advice handling

### DIFF
--- a/bot/trade_manager/core.py
+++ b/bot/trade_manager/core.py
@@ -2,6 +2,7 @@
 
 This module coordinates order placement, risk management and Telegram
 notifications while interacting with the :class:`ModelBuilder` and exchange.
+"""
 
 
 import asyncio
@@ -38,6 +39,7 @@ import numpy as np  # type: ignore
 from bot import test_stubs
 test_stubs.apply()
 from bot.test_stubs import IS_TEST_MODE
+from telegram_logger import TelegramLogger
 
 import ray
 import httpx
@@ -1669,7 +1671,7 @@ class TradeManager:
             
             gpt_signal = None
             try:
-                import trading_bot as tb
+                from bot import trading_bot as tb
                 gpt_signal = tb.GPT_ADVICE.signal
             except Exception:
                 gpt_signal = None

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -1118,6 +1118,10 @@ async def run_once_async(symbol: str | None = None) -> None:
 
     logger.info("Prediction for %s: %s", symbol, signal)
 
+    if not should_trade(signal, prob, threshold, symbol):
+        logger.info("Trade for %s vetoed by weighted advice", symbol)
+        return
+
     if prob < threshold:
         logger.info(
             "Probability %.3f below threshold %.3f for %s",


### PR DESCRIPTION
## Summary
- close unclosed module docstring and import TelegramLogger in TradeManager
- read GPT advice from the proper module
- veto trades when weighted advice disagrees with model signal

## Testing
- `pytest -m "not integration" -q`


------
https://chatgpt.com/codex/tasks/task_e_68c54c63988c832d88074260f472d136