### PR TITLE
fix: improve release drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,13 +10,17 @@ on:
     types: [opened, reopened, synchronize, labeled, unlabeled]
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update_release_draft:
-    permissions:
-      contents: write
-      pull-requests: write
     runs-on: ubuntu-latest
+    # Skip forked pull requests that lack write permissions
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
+      - uses: actions/checkout@v4
       - name: Update release draft
         uses: release-drafter/release-drafter@v6
         env:


### PR DESCRIPTION
## Summary
- move release drafter permissions to workflow level
- skip forked PRs and add checkout step

## Testing
- `pre-commit run --files .github/workflows/release-drafter.yml .github/release-drafter.yml` *(fails: SyntaxError: unterminated triple-quoted string literal in bot/trade_manager/core.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c54c9c5a4c832d84938ed9a3640ed1