### PR TITLE
chore: ensure jq available for gpt review

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -3,7 +3,7 @@
 ---
 name: GPT-OSS Code Review
 
-'on':
+on:
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
   issue_comment:
@@ -46,6 +46,9 @@ jobs:
         with:
           fetch-depth: 0
           ref: refs/pull/${{ env.PR_NUMBER }}/head
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
 
       - name: Start vLLM container
         env:


### PR DESCRIPTION
## Summary
- fix workflow event key
- ensure jq installed before LLM review

## Testing
- `pre-commit run --files .github/workflows/gptoss_review.yml`
- `/tmp/actionlint -shellcheck=on .github/workflows/gptoss_review.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c550677080832d90a9df2070f76bc7