### PR TITLE
fix: ensure repository owner is set for image tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -133,8 +133,9 @@ jobs:
         id: tags
         env:
           MATRIX_IMAGE: ${{ matrix.image }}
+          OWNER: ${{ github.repository_owner }}
         run: |
-          tags="ghcr.io/${GITHUB_REPOSITORY_OWNER}/${MATRIX_IMAGE}:latest"
+          tags="ghcr.io/${OWNER}/${MATRIX_IMAGE}:latest"
           if [ -n "$DOCKERHUB_USERNAME" ] && [ -n "$DOCKERHUB_TOKEN" ]; then
             tags="$tags"$'\n'"docker.io/$DOCKERHUB_USERNAME/$MATRIX_IMAGE:latest"
           fi


### PR DESCRIPTION
## Summary
- fix docker image tag generation by explicitly providing repository owner

## Testing
- `python -m pre_commit run --files .github/workflows/docker-publish.yml`

------
https://chatgpt.com/codex/tasks/task_e_68c58eff1c3c832dbf8d72489412652a