### PR TITLE
fix concurrency string in gptoss review workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -15,7 +15,8 @@ permissions:
   issues: write
 
 concurrency:
-  group: gptoss-review-${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref_name || github.run_id }}
+  group: >-
+    gptoss-review-${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref_name || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- fix concurrency group formatting in GPT-OSS review workflow

## Testing
- `pre-commit run --files .github/workflows/gptoss_review.yml`
- `actionlint .github/workflows/gptoss_review.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c58f320214832daa79025eeedf2841