### PR TITLE
Add pytest-cov to CI requirements

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -5,6 +5,7 @@ flake8==7.3.0
 bandit==1.7.9
 pytest==8.4.2
 pytest-asyncio==1.1.0
+pytest-cov==7.0.0
 tenacity>=8.5,<10
 fastapi==0.116.1
 fastapi-csrf-protect==1.0.6


### PR DESCRIPTION
## Summary
- ensure GitHub Actions can run tests with coverage by adding missing pytest-cov dependency

## Testing
- `flake8 .`
- `bandit -r . -ll -x ./tests,./scripts,./gptoss_check`
- `pytest -q --maxfail=1 --disable-warnings --cov=bot --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68c58f424224832d83a74790d530ea2e