### PR TITLE
Исправление lint и типизации в trade_manager

### DIFF
--- a/bot/trade_manager/__init__.py
+++ b/bot/trade_manager/__init__.py
@@ -1,9 +1,21 @@
-from .core import TradeManager, get_http_client, close_http_client
+"""Public interface for :mod:`bot.trade_manager`.
+
+This module re-exports the main entry points of the trade manager package while
+mapping the asynchronous HTTP client helpers to simple ``get``/``close``
+aliases.  The previous implementation imported ``get_http_client`` and
+``close_http_client`` from ``core`` and then redefined them with the async
+variants, which triggered a redefinition warning from the linter (F811).  To
+avoid that, we only import :class:`TradeManager` from ``core`` and explicitly
+alias the asynchronous helpers.
+"""
+
+from .core import TradeManager
 from .service import api_app, asgi_app, create_trade_manager
-from bot.http_client import (
-    get_async_http_client as get_http_client,
-    close_async_http_client as close_http_client,
-)
+from bot.http_client import get_async_http_client, close_async_http_client
+
+# Provide the expected public names for HTTP helpers
+get_http_client = get_async_http_client
+close_http_client = close_async_http_client
 
 __all__ = [
     "TradeManager",


### PR DESCRIPTION
## Summary
- устранены конфликты импорта и переопределения HTTP‑клиента
- упорядочены импорты и заглушки, добавлены подавления mypy
- упрощён сервис и добавлены проверки типа для ASGI

## Testing
- `ruff check bot tests`
- `mypy bot`
- `bandit -r bot -x tests -ll`
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c58f1be548832d85ea89d729d2969c