### PR TITLE
Нормализация HOST в utils.validate_host

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -197,6 +197,14 @@ def test_validate_host_accepts_localhost(monkeypatch, caplog):
     assert 'localhost' in caplog.text
 
 
+def test_validate_host_strips_and_normalizes(monkeypatch, caplog):
+    monkeypatch.setenv('HOST', '  LOCALHOST  ')
+    with caplog.at_level('INFO'):
+        host = utils.validate_host()
+    assert host == '127.0.0.1'
+    assert 'localhost' in caplog.text
+
+
 def test_validate_host_empty_string(monkeypatch, caplog):
     monkeypatch.setenv('HOST', '')
     with caplog.at_level('INFO'):

--- a/utils.py
+++ b/utils.py
@@ -143,12 +143,12 @@ _BYBIT_INTERVALS = {
 
 def validate_host() -> str:
     """Проверить допустимость значения переменной окружения ``HOST``."""
-    host = os.getenv("HOST")
+    host = os.getenv("HOST", "").strip()
     if not host:
         logger.info("HOST не установлен, используется 127.0.0.1")
         return "127.0.0.1"
 
-    if host == "localhost":
+    if host.lower() == "localhost":
         logger.info("HOST 'localhost' интерпретирован как 127.0.0.1")
         return "127.0.0.1"
 
@@ -161,11 +161,11 @@ def validate_host() -> str:
             raise ValueError(f"Некорректный IP: {host}")
         logger.warning("HOST '%s' не локальный хост", host)
         raise ValueError(f"HOST '{host}' не локальный хост")
-
-    if host != "127.0.0.1":
-        logger.warning("HOST '%s' не локальный хост", host)
-        raise ValueError(f"HOST '{host}' не локальный хост")
-    return host
+    else:
+        if ip != ipaddress.ip_address("127.0.0.1"):
+            logger.warning("HOST '%s' не локальный хост", host)
+            raise ValueError(f"HOST '{host}' не локальный хост")
+        return str(ip)
 
 
 def safe_int(


### PR DESCRIPTION
## Summary
- обрабатывает HOST без учёта регистра и лишних пробелов
- добавлен тест на нормализацию HOST

## Testing
- `pre-commit run --files utils.py tests/test_utils.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c597ab09d4832db81c6bbad817f38a