### PR TITLE
chore: update release drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,7 +18,9 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          fetch-depth: 0
       - name: Update release draft
         uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5
         with:


### PR DESCRIPTION
## Summary
- update checkout action to v5 with full history
- ensure release drafter runs with complete git context

## Testing
- `actionlint -ignore 'SC2086' .github/workflows/release-drafter.yml`
- `pre-commit run --files .github/workflows/release-drafter.yml .github/release-drafter.yml` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68c5979d9714832da7d3fcc08715c3a2