### PR TITLE
Ensure GPT-OSS readiness check closes responses

### DIFF
--- a/gptoss_check/check_code.py
+++ b/gptoss_check/check_code.py
@@ -27,8 +27,10 @@ def wait_for_api(api_url: str, timeout: int | None = None) -> None:
             with get_httpx_client(timeout=5, trust_env=False) as client:
                 health_url = urljoin(api_url, "/v1/models")
                 response = client.get(health_url)
-                response.raise_for_status()
-                response.close()
+                try:
+                    response.raise_for_status()
+                finally:
+                    response.close()
             return
         except httpx.HTTPError:
             time.sleep(1)


### PR DESCRIPTION
## Summary
- close HTTP responses in `wait_for_api` to avoid resource leaks
- test HTTP error path to verify response is closed

## Testing
- `pre-commit run --files gptoss_check/check_code.py tests/test_gptoss_check.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5978f1354832d84ff1fcf7b1250ee