### PR TITLE
Fix mypy torch amp

### DIFF
--- a/bot/trade_manager/core.py
+++ b/bot/trade_manager/core.py
@@ -14,7 +14,7 @@ import json
 import logging
 import re
 import time
-from typing import Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple, cast
 import shutil
 try:  # pragma: no cover - optional dependency
     import aiohttp  # type: ignore
@@ -68,8 +68,10 @@ from bot.http_client import (  # noqa: E402
     close_async_http_client as close_http_client,
 )
 
+torch: Any
 try:  # pragma: no cover - optional dependency
-    import torch  # type: ignore  # noqa: E402
+    import torch as _torch  # type: ignore  # noqa: E402
+    torch = cast(Any, _torch)
 except ImportError as exc:  # optional dependency may not be installed
     logging.getLogger(__name__).warning("torch import failed: %s", exc)
     torch = types.ModuleType("torch")  # type: ignore[assignment]


### PR DESCRIPTION
## Summary
- handle torch amp typing for mypy

## Testing
- `python -m flake8 --exclude venv .`
- `python -m mypy --no-site-packages --exclude venv .`
- `pytest`
- `docker compose -f docker-compose.yml -f docker-compose.cpu.yml up --build --abort-on-container-exit --exit-code-from gptoss_check` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68c59781dacc832d90239c9cb4c9b8d8