### PR TITLE
Make ccxt optional in trading_bot

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -17,7 +17,10 @@ from typing import Awaitable, Callable, TypeVar
 from model_builder_client import schedule_retrain, retrain
 
 import httpx
-import ccxt
+try:  # pragma: no cover - optional dependency
+    import ccxt  # type: ignore
+except Exception:  # noqa: BLE001 - broad to avoid test import errors
+    ccxt = type("ccxt_stub", (), {})()
 from dotenv import load_dotenv
 from tenacity import retry, stop_after_attempt, wait_exponential
 


### PR DESCRIPTION
## Summary
- avoid hard dependency on ccxt by using optional import

## Testing
- `python -m flake8 --exclude venv .`
- `python -m mypy --no-site-packages --exclude venv .`
- `pytest -ra`
- `docker compose -f docker-compose.yml -f docker-compose.cpu.yml config` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c58856f4832d93b509fa37033a66