### PR TITLE
fix: update release drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,25 +4,24 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     branches:
       - main
     types: [opened, reopened, synchronize, labeled, unlabeled]
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-        with:
-          fetch-depth: 0
       - name: Update release draft
-        uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5
+        uses: release-drafter/release-drafter@09c613e259eb8d4e7c81c2cb00618eb5fc4575a7
         with:
           config-name: release-drafter.yml
         env:


### PR DESCRIPTION
## Summary
- use pull_request event and refine permissions
- pin release-drafter action and remove redundant checkout

## Testing
- `pre-commit run --files .github/workflows/release-drafter.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5c5c7b658832d908df9e539159b89