### PR TITLE
Remove deprecated logistic regression multi_class parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,8 +419,8 @@ waitress-serve services.data_handler_service:app
 features to `/train`.  Predictions are requested via `/predict` using
 `{"features": [...]}` where the first element usually represents the price.
 For backward compatibility a single `price` value is also accepted.  The
-service supports multi-class problems via
-`LogisticRegression(multi_class="auto")` and returns an error if the labels
+service supports multi-class problems via `LogisticRegression()` and returns an
+error if the labels
 contain only a single class.
 `trade_manager_service.py` opens and closes positions on Bybit via
 `/open_position` and `/close_position` and also provides `/positions`, `/ping`

--- a/model_builder.py
+++ b/model_builder.py
@@ -1933,7 +1933,12 @@ def fit_scaler(features: np.ndarray, labels: np.ndarray):
     pipeline = Pipeline(
         [
             ("scaler", StandardScaler()),
-            ("model", LogisticRegression(multi_class="auto")),
+            # ``multi_class`` параметр в sklearn >=1.5 всегда равен "multinomial",
+            # поэтому явное указание ``multi_class="auto"`` вызывает предупреждение
+            # о устаревании. Оставляем значение по умолчанию, чтобы избежать
+            # лишних предупреждений и сохранить совместимость с будущими версиями
+            # библиотеки.
+            ("model", LogisticRegression()),
         ]
     )
     pipeline.fit(features, labels)

--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -189,7 +189,12 @@ def train() -> ResponseReturnValue:
         return jsonify({"error": "labels must contain at least two classes"}), 400
     scaler = StandardScaler().fit(features)
     features = scaler.transform(features)
-    model = LogisticRegression(multi_class="auto")
+    # Параметр ``multi_class="auto"`` больше не нужен в новых версиях
+    # scikit-learn: логистическая регрессия всегда работает в режиме
+    # ``multinomial``. Убираем явное указание, чтобы не появлялись
+    # предупреждения об устаревании и чтобы код оставался совместимым
+    # с будущими релизами библиотеки.
+    model = LogisticRegression()
     model.fit(features, labels)
     _models[symbol] = model
     _scalers[symbol] = scaler


### PR DESCRIPTION
## Summary
- avoid scikit-learn deprecation by relying on default LogisticRegression multi_class behavior
- update documentation to reflect simplified LogisticRegression call

## Testing
- `flake8 .`
- `bandit -r . -ll -x ./tests,./scripts,./gptoss_check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5c5d3ffac832d874242353bcdfa8d