### PR TITLE
fix: harden docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -80,12 +80,12 @@ jobs:
         run: |
           set -euo pipefail
           if command -v systemctl >/dev/null; then
-            sudo systemctl stop docker
+            sudo systemctl stop docker || true
           else
-            sudo service docker stop
+            sudo service docker stop || true
           fi
-          sudo mv /var/lib/docker /mnt/docker
-          sudo ln -s /mnt/docker /var/lib/docker
+          sudo mv /var/lib/docker /mnt/docker || true
+          sudo ln -sfn /mnt/docker /var/lib/docker
           if command -v systemctl >/dev/null; then
             sudo systemctl start docker
           else
@@ -117,13 +117,13 @@ jobs:
 
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1  # v3
         with:
           username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ env.DOCKERHUB_TOKEN }}
 
       - name: Login to GHCR
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1  # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
## Summary
- handle docker stop/cleanup more gracefully in publish workflow
- address yamllint spacing for login steps

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml`
- `yamllint .github/workflows/docker-publish.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c5c57095c4832da83c2ca752c634e3