### PR TITLE
fix: simplify dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -3,7 +3,7 @@
 name: Dependabot Auto Merge
 
 on:  # yamllint disable-line rule:truthy
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize]
 
 permissions:
@@ -31,14 +31,10 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-number: ${{ github.event.pull_request.number }}
       - name: Checkout code
-        # v5
+        # v5.0.0
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          # Use the Dependabot branch ref instead of the specific commit SHA
-          ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       # Set up a lightweight Python environment and install only the
       # dependencies required to run the unit tests.  This avoids the


### PR DESCRIPTION
## Summary
- switch Dependabot workflow to `pull_request` event
- simplify checkout step and remove unnecessary inputs

## Testing
- `actionlint .github/workflows/dependabot.yml`
- `yamllint .github/workflows/dependabot.yml`
- `pre-commit run --files .github/workflows/dependabot.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5c7764d44832d9d6cc11771ca9eb3