### PR TITLE
chore: pin actions in gptoss review workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -125,14 +125,14 @@ jobs:
 
       - name: Upload review artifact
         if: steps.llm_review.outputs.has_content == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: gptoss-review-${{ env.PR_NUMBER }}
           path: review.md
 
       - name: Comment PR
         if: steps.llm_review.outputs.has_content == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
## Summary
- pin upload-artifact and github-script to specific commits in gptoss review workflow

## Testing
- `pre-commit run --files .github/workflows/gptoss_review.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6a1c6dcb0832dabf2a13a55651bb8