### PR TITLE
fix: update trivy action input and pre-commit

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -175,7 +175,7 @@ jobs:
           TMPDIR: /mnt/trivy-tmp
           TRIVY_CACHE_DIR: /mnt/trivy-cache
         with:
-          trivy_version: v0.65.0
+          version: v0.65.0
           image-ref: docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ matrix.image }}:latest
           format: table
           output: ${{ matrix.artifact }}.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
     rev: 7.3.0
     hooks:
       - id: flake8
+        types: [python]
   - repo: local
     hooks:
       - id: pytest


### PR DESCRIPTION
## Summary
- correct Trivy action input name
- limit flake8 pre-commit hook to Python files

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml .pre-commit-config.yaml` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a1970c7c832d95a71654811c7642