### PR TITLE
Use pull_request_target for Dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -3,7 +3,7 @@
 name: Dependabot Auto Merge
 
 on:  # yamllint disable-line rule:truthy
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
 
 permissions:


### PR DESCRIPTION
## Summary
- use `pull_request_target` event in Dependabot auto-merge workflow to ensure required permissions

## Testing
- `pytest -m "not integration" -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6a1bc401c832d9e5a6542d80e37e9