### PR TITLE
fix: tidy up healthcheck in docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -228,3 +228,4 @@ jobs:
         if: always() && steps.start_service.outputs.service_running == 'true'
         run: |
           kill "$(cat "$GITHUB_WORKSPACE/service.pid")" || true
+          rm -f "$GITHUB_WORKSPACE/service.pid"


### PR DESCRIPTION
## Summary
- delete service PID file during docker publish healthcheck cleanup

## Testing
- `python -m pre_commit run flake8 --files .github/workflows/docker-publish.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6ab940f64832db93452b5ae032461