### PR TITLE
Handle GPT OSS API base paths

### DIFF
--- a/gpt_client.py
+++ b/gpt_client.py
@@ -10,7 +10,7 @@ import os
 import json
 import socket
 from enum import Enum
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urljoin
 from ipaddress import ip_address
 import asyncio
 import threading
@@ -219,7 +219,8 @@ def _get_api_url_timeout() -> tuple[str, float, str, set[str]]:
         )
         timeout = 5.0
 
-    url = api_url.rstrip("/") + "/v1/completions"
+    api_url = api_url.rstrip("/")
+    url = urljoin(api_url + "/", "v1/completions")
     return url, timeout, hostname, allowed_ips
 
 

--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -408,6 +408,18 @@ def test_get_api_url_timeout_invalid(monkeypatch, caplog):
     assert "Invalid GPT_OSS_TIMEOUT value 'abc'; defaulting to 5.0" in caplog.text
 
 
+def test_get_api_url_timeout_respects_base_path(monkeypatch):
+    monkeypatch.setenv("GPT_OSS_API", "http://localhost/api")
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *a, **k: [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0))],
+    )
+    url, timeout, hostname, ips = _get_api_url_timeout()
+    assert url == "http://localhost/api/v1/completions"
+    assert hostname == "localhost"
+
+
 @pytest.mark.asyncio
 async def test_query_gpt_json_async(monkeypatch):
     monkeypatch.setenv("GPT_OSS_API", "https://example.com")


### PR DESCRIPTION
## Summary
- handle GPT OSS API base paths via `urljoin`
- test `_get_api_url_timeout` with base path

## Testing
- `python -m pre_commit run --files gpt_client.py tests/test_gpt_client.py`
- `pytest tests/test_gpt_client.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6aba96998832db6b876b973b86f07