### PR TITLE
Добавлен TelegramLogger при наличии токенов

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -11,6 +11,10 @@ JSON arrays (e.g. `["ws://a", "ws://b"]`) or as comma-separated values such as
 Boolean parameters are case-insensitive and accept `1`/`true`/`yes`/`on` for
 enabled and `0`/`false`/`no`/`off` for disabled values.
 
+If both `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` environment variables are
+defined, a Telegram logger is automatically attached and forwards `ERROR`
+messages to the specified chat.
+
 The GPT analysis service should return JSON with the following fields:
 `signal` ("buy"/"sell"/"hold"), `tp_mult` and `sl_mult` — multipliers applied
 to take‑profit and stop‑loss distances.

--- a/bot/logging/__init__.py
+++ b/bot/logging/__init__.py
@@ -1,0 +1,5 @@
+"""Logging utilities for the trading bot."""
+
+from .configure import configure_logging
+
+__all__ = ["configure_logging"]

--- a/bot/logging/configure.py
+++ b/bot/logging/configure.py
@@ -1,0 +1,29 @@
+"""Logging configuration helpers."""
+from __future__ import annotations
+
+import logging
+import os
+
+from bot.utils import configure_logging as _base_configure_logging
+from bot.telegram_logger import TelegramLogger
+
+
+def configure_logging() -> None:
+    """Configure standard handlers and optional Telegram logging."""
+    _base_configure_logging()
+
+    token = os.getenv("TELEGRAM_BOT_TOKEN")
+    chat_id = os.getenv("TELEGRAM_CHAT_ID")
+    if not token or not chat_id:
+        return
+    try:
+        from telegram import Bot
+
+        bot = Bot(token)
+        handler = TelegramLogger(bot, chat_id, level=logging.ERROR)
+        root = logging.getLogger()
+        root.addHandler(handler)
+    except Exception as exc:  # pragma: no cover - best effort
+        logging.getLogger("TradingBot").exception(
+            "Failed to initialize Telegram logger: %s", exc
+        )


### PR DESCRIPTION
## Summary
- add optional TelegramLogger to root logger when TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID are set
- document automatic Telegram logging in CONFIG.md

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6b324ca10832d822da917423f6612