### PR TITLE
chore: update release drafter action

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update release draft
-        uses: release-drafter/release-drafter@09c613e259eb8d4e7c81c2cb00618eb5fc4575a7
+        uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         with:
           config-name: release-drafter.yml
         env:


### PR DESCRIPTION
## Summary
- fix release drafter workflow by updating action to v6.1.0 commit

## Testing
- `pre-commit run --files .github/workflows/release-drafter.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c6b3884684832d9d121e2cf6ae9dfd