### PR TITLE
Preserve rows when filtering z-score outliers

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -654,14 +654,16 @@ def filter_outliers_zscore(df, column="close", threshold=3.0):
         z_scores = pd.Series(zscore(filled.to_numpy()), index=df.index)
 
         mask = (np.abs(z_scores) <= threshold) | series.isna()
-        df_filtered = df[mask]
-        if len(df_filtered) < len(df):
+        df_filtered = df.copy()
+        outliers = ~mask
+        if outliers.any():
             logger.info(
-                "Удалено %s аномалий в %s с z-оценкой, порог=%.2f",
-                len(df) - len(df_filtered),
+                "Заменено %s аномалий в %s с z-оценкой, порог=%.2f",
+                int(outliers.sum()),
                 column,
                 threshold,
             )
+            df_filtered.loc[outliers, column] = np.nan
         return df_filtered
     except (KeyError, TypeError) as e:
         logger.error("Ошибка фильтрации аномалий в %s: %s", column, e)


### PR DESCRIPTION
## Summary
- keep original DataFrame size in `filter_outliers_zscore`
- log and replace outliers with NaN instead of dropping rows

## Testing
- `python -m flake8 .`
- `python -m bandit -r . -ll -x ./tests,./scripts,./gptoss_check`
- `python -m pre_commit run flake8 --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6b3950e64832da8ecd31ad350ab84