### PR TITLE
Fix mypy errors and improve HTTP retry logic

### DIFF
--- a/data_handler/core.py
+++ b/data_handler/core.py
@@ -32,6 +32,8 @@ class DataHandler:
         self.ws_min_process_rate = expected_ws_rate(cfg.timeframe)
         self.disk_buffer: Dict[int, list] = {}
         self.indicators: Dict[str, Any] = {}
+        self._ohlcv: Any
+        self._ohlcv_2h: Any
         if getattr(cfg, "use_polars", False) and pl is not None:
             self._ohlcv = pl.DataFrame()
             self._ohlcv_2h = pl.DataFrame()

--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -15,6 +15,7 @@ from typing import Any, Dict
 
 import joblib
 import numpy as np
+from numpy.typing import NDArray
 import pandas as pd
 from dotenv import load_dotenv
 from flask import Flask, jsonify, request
@@ -157,6 +158,7 @@ def train() -> ResponseReturnValue:
             return jsonify({"error": "training failed"}), 500
 
     prices = data.get("prices")
+    features: NDArray[np.float32]
     if prices is not None:
         features = _compute_ema(prices).reshape(-1, 1)
     else:
@@ -255,8 +257,9 @@ def predict() -> ResponseReturnValue:
     features = data.get("features")
     if features is None:
         price_val = float(data.get("price", 0.0))
-        features = [price_val]
-    features = np.array(features, dtype=np.float32)
+        features = np.array([price_val], dtype=np.float32)
+    else:
+        features = np.array(features, dtype=np.float32)
     if features.ndim == 0:
         features = np.array([[features]], dtype=np.float32)
     elif features.ndim == 1:


### PR DESCRIPTION
## Summary
- ensure tenacity fallback uses typed RetryCallState and Callable
- annotate DataHandler OHLCV fields to satisfy mypy
- normalize training and prediction features in model builder

## Testing
- `mypy .`
- `pytest`
- `pre-commit run --files http_client.py data_handler/core.py services/model_builder_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6b37c7d98832d83386e1f5e0e4d8a