### PR TITLE
chore: ensure docker workflow cleanup

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -152,9 +152,10 @@ jobs:
           cache-to: type=local,dest=${{ github.workspace }}/.buildx-cache-new,mode=max
 
       - name: Update buildx cache
+        if: ${{ always() }}
         run: |
           rm -rf "$GITHUB_WORKSPACE/.buildx-cache"
-          mv "$GITHUB_WORKSPACE/.buildx-cache-new" "$GITHUB_WORKSPACE/.buildx-cache"
+          mv "$GITHUB_WORKSPACE/.buildx-cache-new" "$GITHUB_WORKSPACE/.buildx-cache" || true
 
       - name: Cleanup before Trivy scan
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
@@ -191,6 +192,7 @@ jobs:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}.txt
       - name: Cleanup Docker
+        if: ${{ always() }}
         run: |
           docker buildx prune -af || true
           docker system prune -af || true


### PR DESCRIPTION
## Summary
- ensure docker build cache directory is reset even on failed builds
- always prune docker data to free space after workflow runs

## Testing
- `yamllint .github/workflows/docker-publish.yml`
- `actionlint .github/workflows/docker-publish.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6c36e6f6c832db1fde80be457ab66