### PR TITLE
fix: checkout PR head in dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       # Set up a lightweight Python environment and install only the
       # dependencies required to run the unit tests.  This avoids the


### PR DESCRIPTION
## Summary
- ensure dependabot workflow checks out the PR head commit

## Testing
- `yamllint .github/workflows/dependabot.yml`
- `pytest -m "not integration" -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6c9545520832d955133d3eaaccf13