### PR TITLE
Fix concurrency group in gptoss review workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -15,7 +15,9 @@ permissions:
   issues: write
 
 concurrency:
-  group: gptoss-review-${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref_name || github.run_id }}
+  group: >
+    gptoss-review-${{ github.workflow }}-${{ github.event.pull_request.number ||
+    github.event.issue.number || github.ref_name || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- fix concurrency group string in gptoss_review workflow

## Testing
- `pre-commit run --files .github/workflows/gptoss_review.yml`

------
https://chatgpt.com/codex/tasks/task_e_68c6c9655eb8832db0adba12c43b8cbf