### PR TITLE
Fix dependency graph submission

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,28 +1,23 @@
----
-name: Dependency Graph Auto Submission
+name: dependency-submission
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
+    paths:
+      - "requirements*.txt"
+      - "requirements*.in"
   workflow_dispatch:
 
-permissions:
-  contents: write
-  id-token: write
-
 jobs:
-  auto-submission:
+  submit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: '3.x'
-      - name: Component detection
-        # yamllint disable-line rule:line-length
-        uses: advanced-security/component-detection-dependency-submission-action@d433c2f467e149a8009c8fbce92cc708ed15ef7b # v0.1.0
+      - uses: actions/checkout@v4
+      - name: Prepare requirements
+        run: |
+          sed '/^ccxtpro/d' requirements.out > requirements-submission.txt
+      - name: Submit dependency graph
+        uses: github/dependency-submission-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          detectorArgs: Pip=EnableIfDefaultOff
+          requirements: requirements-submission.txt


### PR DESCRIPTION
## Summary
- add dependency graph workflow skipping private ccxtpro

## Testing
- `pre-commit run --files .github/workflows/dependency-graph.yml`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6cfff7c14832da9d404e3bce923c2