### PR TITLE
fix: ensure full base fetch in LLM review

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -97,7 +97,7 @@ jobs:
           base_sha=$(echo "$pull_info" | jq -r .base.sha)
           base_ref=$(echo "$pull_info" | jq -r .base.ref)
           [ -n "$base_sha" ] && [ "$base_sha" != "null" ] && [ -n "$base_ref" ] && [ "$base_ref" != "null" ]
-          git fetch --no-tags --depth=50 origin "$base_ref"
+          git fetch --no-tags origin "$base_ref"
           git diff "$base_sha"...HEAD -- ':(glob)**/*.py' > diff.patch || true
           if [ ! -s diff.patch ]; then
             echo "has_diff=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- ensure full history of base branch is fetched before generating diff for LLM review

## Testing
- `pytest`
- `pre-commit run --files .github/workflows/gptoss_review.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c6d01b3448832dbd14f8c83b50e4f1