### PR TITLE
Fix dependency graph workflow permissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -2,20 +2,25 @@ name: dependency-submission
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
     paths:
       - "requirements*.txt"
       - "requirements*.in"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   submit:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Prepare requirements
-        run: |
-          sed '/^ccxtpro/d' requirements.out > requirements-submission.txt
+        run: sed '/^ccxtpro/d' requirements.out > requirements-submission.txt
       - name: Submit dependency graph
         uses: github/dependency-submission-action@v4
         with:


### PR DESCRIPTION
## Summary
- ensure dependency submission workflow has required write permissions
- tidy push triggers and requirement preparation

## Testing
- `python -m pre_commit run --files .github/workflows/dependency-graph.yml`

------
https://chatgpt.com/codex/tasks/task_e_68c6d37c3634832d9ec4381285624f8d