### PR TITLE
Allow IPv6 loopback in HOST validation

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -162,7 +162,7 @@ def validate_host() -> str:
         logger.warning("HOST '%s' не локальный хост", host)
         raise ValueError(f"HOST '{host}' не локальный хост")
     else:
-        if ip != ipaddress.ip_address("127.0.0.1"):
+        if not ip.is_loopback:
             logger.warning("HOST '%s' не локальный хост", host)
             raise ValueError(f"HOST '{host}' не локальный хост")
         return str(ip)


### PR DESCRIPTION
## Summary
- allow IPv6 localhost addresses in HOST validation

## Testing
- `pytest -q`
- `pre-commit run --files utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6d3ba2f28832dbaa57feb9a9fe717