### PR TITLE
Allow bracketed IPv6 addresses in HOST validation

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -152,6 +152,9 @@ def validate_host() -> str:
         logger.info("HOST 'localhost' интерпретирован как 127.0.0.1")
         return "127.0.0.1"
 
+    if host.startswith("[") and host.endswith("]"):
+        host = host[1:-1]
+
     try:
         ip = ipaddress.ip_address(host)
         if ip.is_unspecified:


### PR DESCRIPTION
## Summary
- handle HOST values like `[::1]` by stripping brackets before validation

## Testing
- `pytest -q`
- `flake8 --exclude venv .`
- `mypy --no-site-packages --exclude venv .`
- `SKIP=pytest pre-commit run --files utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6e65ae8a8832d8ae543708574d801