### PR TITLE
ci: login to ghcr before starting gpt-oss

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -53,6 +53,13 @@ jobs:
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
 
+      - name: Login to GHCR
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
       - name: Start vLLM container
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN || '' }}


### PR DESCRIPTION
## Summary
- authenticate with ghcr.io before launching gpt-oss container to avoid registry errors

## Testing
- `/root/.local/share/mise/installs/go/1.24.3/bin/actionlint .github/workflows/gptoss_review.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6ed555fa8832db6a214a151312a35