### PR TITLE
fix: handle dependabot automerge

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -62,7 +62,8 @@ jobs:
         run: pytest -m "not integration" -q
 
       - name: Enable auto-merge for Dependabot PRs
-        if: ${{ steps.metadata.outputs['update-type'] != 'version-update:semver-major' }}
+        if: ${{ steps.metadata.outputs['update-type'] != 'version-update:semver-major' && github.event.repository.allow_auto_merge }}
+        continue-on-error: true
         # v3.0.0
         # yamllint disable-line rule:line-length
         uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d


### PR DESCRIPTION
## Summary
- guard dependabot automerge step

## Testing
- `pre-commit run --files .github/workflows/dependabot.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c6ed9098c8832db01b1da535779d9d