### PR TITLE
chore: fix dependabot auto-merge condition

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -62,7 +62,9 @@ jobs:
         run: pytest -m "not integration" -q
 
       - name: Enable auto-merge for Dependabot PRs
-        if: ${{ steps.metadata.outputs['update-type'] != 'version-update:semver-major' && github.event.repository.allow_auto_merge }}
+        if: >-
+          ${{ steps.metadata.outputs['update-type'] != 'version-update:semver-major'
+              && github.event.repository.allow_auto_merge }}
         continue-on-error: true
         # v3.0.0
         # yamllint disable-line rule:line-length


### PR DESCRIPTION
## Summary
- improve readability of Dependabot auto-merge condition to avoid parsing issues

## Testing
- `pytest -m "not integration" -q`
- `python -m pre_commit run --files .github/workflows/dependabot.yml` *(fails: Interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f0b77fc0832d91d64110b862a577