### PR TITLE
chore: speed up CI tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,10 +28,9 @@ jobs:
             pyproject.toml
       - name: Install pip/setuptools/wheel with fixed versions
         run: python -m pip install "pip==24.0" "setuptools<72" "wheel<0.44"
-      - name: Install deps (core + ci + extras if exist)
+      - name: Install deps (ci + extras if exist)
         run: |
           set -eux
-          test -f requirements.txt && python -m pip install -r requirements.txt || true
           test -f requirements-ci.txt && python -m pip install -r requirements-ci.txt || true
           test -f requirements-extras.txt && python -m pip install -r requirements-extras.txt || true
       - name: Install torch (cpu)


### PR DESCRIPTION
## Summary
- avoid installing full requirements set in CI tests workflow
- run tests with only minimal dependencies to prevent timeouts

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6f0d38bf4832d9ab41030f996754a