### PR TITLE
ci: add actions permission for docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,6 +4,7 @@ name: Build and Push Docker image
 permissions:
   contents: read
   packages: write
+  actions: write
 
 on:
   push:


### PR DESCRIPTION
## Summary
- fix docker publish workflow by granting actions write permission

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml`
- `pytest tests/test_dockerhub_push.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c704daf48c832d8ac454da74fcc738