### PR TITLE
Fix TEST_MODE env handling in safe_api_call

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -46,6 +46,17 @@ async def test_safe_api_call_test_mode():
 
 
 @pytest.mark.asyncio
+async def test_safe_api_call_env_var_false(monkeypatch):
+    monkeypatch.setenv("TEST_MODE", "0")
+    exch = DummyExchange()
+
+    with pytest.raises(RuntimeError):
+        await utils.safe_api_call(exch, 'fail')
+
+    assert exch.calls == 5
+
+
+@pytest.mark.asyncio
 async def test_safe_api_call_unhandled(monkeypatch):
     monkeypatch.delenv("TEST_MODE", raising=False)
 

--- a/utils.py
+++ b/utils.py
@@ -284,7 +284,7 @@ async def safe_api_call(
 ):
     """Call a ccxt method with retry, status and retCode verification."""
     if test_mode is None:
-        test_mode = bool(os.getenv("TEST_MODE"))
+        test_mode = os.getenv("TEST_MODE", "").strip().lower() in {"1", "true", "yes"}
 
     if test_mode:
         # During unit tests we do not want to spend time in the retry loop.


### PR DESCRIPTION
## Summary
- ensure TEST_MODE env var only enables test mode for truthy values
- cover case TEST_MODE="0" with a dedicated unit test

## Testing
- `ruff check bot tests`
- `mypy bot`
- `bandit -r bot -x tests -ll`
- `flake8 .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c704e73064832d8b8aeefc169a01c7