### PR TITLE
ci: restrict dependabot auto-merge to non-major updates

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -62,7 +62,7 @@ jobs:
         run: pytest -m "not integration" -q
 
       - name: Enable auto-merge for Dependabot PRs
-        continue-on-error: true
+        if: ${{ steps.metadata.outputs['update-type'] != 'version-update:semver-major' }}
         # v3.0.0
         # yamllint disable-line rule:line-length
         uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d


### PR DESCRIPTION
## Summary
- avoid auto-merge for major dependabot updates

## Testing
- `python -m pre_commit run --files .github/workflows/dependabot.yml`

------
https://chatgpt.com/codex/tasks/task_e_68c705006fb0832d83ca8c58c9f74a72