### PR TITLE
chore: fix release drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     branches:
       - main
     types: [opened, reopened, synchronize, labeled, unlabeled]


### PR DESCRIPTION
## Summary
- refactor release drafter workflow to use pull_request event

## Testing
- `pre-commit run --files .github/workflows/release-drafter.yml`

------
https://chatgpt.com/codex/tasks/task_e_68c7051fc270832d9f567f04ab3e2911