### PR TITLE
refactor: resolve bandit warnings

### DIFF
--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -160,7 +160,8 @@ def train() -> ResponseReturnValue:
     symbol = data.get("symbol", "default")
     if NN_FRAMEWORK != "sklearn":
         import asyncio
-        assert _model_builder is not None
+        if _model_builder is None:
+            raise RuntimeError("Model builder is not initialized")
 
         try:
             asyncio.run(_model_builder.retrain_symbol(symbol))
@@ -229,7 +230,8 @@ def predict() -> ResponseReturnValue:
     data = request.get_json(force=True)
     symbol = data.get("symbol", "default")
     if NN_FRAMEWORK != "sklearn":
-        assert _model_builder is not None
+        if _model_builder is None:
+            raise RuntimeError("Model builder is not initialized")
         features = np.array(data.get("features", []), dtype=np.float32)
         if features.ndim == 1:
             features = features.reshape(1, -1)


### PR DESCRIPTION
## Summary
- avoid subprocess usage in model_builder to satisfy Bandit
- replace asserts with explicit checks in model_builder_service
- log torch import failures instead of silently passing

## Testing
- `bandit -r . -ll -ii -x ./tests,./scripts,./gptoss_check -f sarif -o bandit.sarif`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7115fe590832da74b9eec00561012