### PR TITLE
Fix ModelBuilder service predict indentation error

### DIFF
--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -229,6 +229,7 @@ def predict() -> ResponseReturnValue:
     symbol = data.get("symbol", "default")
     if NN_FRAMEWORK != "sklearn":
         if _model_builder is None:
+            return jsonify({"error": "ModelBuilder not initialized"}), 500
         features = np.array(data.get("features", []), dtype=np.float32)
         if features.ndim == 1:
             features = features.reshape(1, -1)


### PR DESCRIPTION
## Summary
- fix missing body for `_model_builder is None` check in `model_builder_service.predict`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c713911c70832d9403baea778630e3