### PR TITLE
Pin CI dependencies for stable tests

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -13,7 +13,8 @@ flask>=3.0.3,<4
 pydantic==2.11.7
 # gymnasium and scikit-learn are unavailable on some Python versions
 gymnasium==1.2.0; python_version<'3.12'
-pandas>=2.2.0
+# Pin older pandas to avoid incompatibilities with numpy
+pandas==2.1.4
 polars>=1.6.0
 pyarrow>=15.0.0
 python-dotenv>=1.0.0
@@ -21,7 +22,9 @@ psutil>=5.9.0
 werkzeug>=3.0.2,<4
 requests>=2.31.0
 httpx>=0.27.0
-scikit-learn>=1.3; python_version<'3.12'
+# Newer scikit-learn releases pull in SciPy builds incompatible with our
+# pinned numpy; lock to a known working version.
+scikit-learn==1.4.2; python_version<'3.12'
 joblib>=1.3
 setuptools>=70.0.0
 types-requests


### PR DESCRIPTION
## Summary
- fix pandas MultiIndex creation error by pinning pandas to 2.1.4
- lock scikit-learn to 1.4.2 to avoid SciPy/numpy incompatibility

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7122e44d0832d8a7ef2df521f76a8