### PR TITLE
fix: handle ccxtpro removal in dependency graph

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -20,7 +20,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Prepare requirements
-        run: sed '/^ccxtpro/d' requirements.out > requirements-submission.txt
+        run: |
+          awk '/^ccxtpro/ {skip=1; next} skip && /^[ \t]/ {next} {skip=0; print}' \
+            requirements.out > requirements-submission.txt
       - name: Submit dependency graph
         uses: github/dependency-submission-action@v4
         with:


### PR DESCRIPTION
## Summary
- improve dependency graph workflow: strip ccxtpro requirement along with its comments

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c71ed49c1c832da35d7a99196eabf6