### PR TITLE
fix: stabilize docker image workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -100,6 +100,7 @@ jobs:
 
       - name: Cache Docker layers
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4
+        continue-on-error: true
         with:
           path: ${{ github.workspace }}/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ matrix.image }}-${{ github.sha }}

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -33,6 +33,7 @@ RUN python3 -m venv $VIRTUAL_ENV && \
     find $VIRTUAL_ENV -type f -name '*.pyc' -delete
 
 FROM ubuntu:24.04
+ARG DEBIAN_FRONTEND=noninteractive
 
 # Обновляем систему перед установкой зависимостей выполнения
 RUN apt-get update && apt-get dist-upgrade -y

--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -1,4 +1,5 @@
 FROM python:3.11-slim
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libtbbmalloc2 libnuma1 curl git \


### PR DESCRIPTION
## Summary
- avoid interactive prompts in CPU and GPT-OSS Docker builds
- ensure Docker layer cache step doesn't fail workflow

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c71eeaa55c832da26e560880d9607a