### PR TITLE
Fix Bandit configuration to ignore tests

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,4 +1,2 @@
 [bandit]
-exclude = tests/*,scripts/*,gptoss_check/*
-targets = .
-recursive = True
+exclude = */tests/*,*/scripts/*,*/gptoss_check/*


### PR DESCRIPTION
## Summary
- exclude tests, scripts, and helper dirs from Bandit scan

## Testing
- `bandit -r .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c71eddcb50832d9a89c3eedb1d3f9b