### PR TITLE
Разрешить использование GITHUB_TOKEN в скрипте Dependabot

### DIFF
--- a/scripts/run_dependabot.sh
+++ b/scripts/run_dependabot.sh
@@ -7,9 +7,9 @@ if [[ -z "${GITHUB_REPOSITORY:-}" ]]; then
 fi
 repo="${GITHUB_REPOSITORY}"
 
-token="${TOKEN:-}"
+token="${TOKEN:-${GITHUB_TOKEN:-}}"
 if [[ -z "${token}" ]]; then
-    echo "TOKEN is not set; export a PAT with repo and security_events scopes" >&2
+    echo "TOKEN or GITHUB_TOKEN is not set; export a PAT with repo and security_events scopes" >&2
     exit 1
 fi
 

--- a/tests/test_run_dependabot_script.py
+++ b/tests/test_run_dependabot_script.py
@@ -8,10 +8,11 @@ def test_run_dependabot_requires_token():
     env = os.environ.copy()
     env["GITHUB_REPOSITORY"] = "owner/repo"
     env.pop("TOKEN", None)
+    env.pop("GITHUB_TOKEN", None)
 
     proc = subprocess.run(
         ["bash", str(script)], capture_output=True, text=True, env=env
     )
 
     assert proc.returncode == 1
-    assert "TOKEN is not set" in proc.stderr
+    assert "TOKEN or GITHUB_TOKEN is not set" in proc.stderr


### PR DESCRIPTION
## Summary
- поддержка GITHUB_TOKEN в скрипте scripts/run_dependabot.sh
- корректировка теста на отсутствие токена

## Testing
- `SKIP=pytest pre-commit run --files scripts/run_dependabot.sh tests/test_run_dependabot_script.py`
- `pytest tests/test_run_dependabot_script.py`


------
https://chatgpt.com/codex/tasks/task_e_68c71f2d12c0832db2e3c4b8393ee03f