### PR TITLE
fix: handle release drafter for fork PRs

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
     branches:
       - main
     types: [opened, reopened, synchronize, labeled, unlabeled]


### PR DESCRIPTION
## Summary
- switch release-drafter workflow to `pull_request_target` for proper permissions on fork PRs

## Testing
- `SKIP=pytest pre-commit run --files .github/workflows/release-drafter.yml`
- `actionlint .github/workflows/release-drafter.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c71f59cdfc832d9122f20e26f16dfd