### PR TITLE
fix: restore dependency graph workflow

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -18,11 +18,14 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.x'
       - name: Prepare requirements
+        run: sed -i '/^ccxtpro/d' requirements.out
+      - name: Component detection
+        uses: advanced-security/component-detection-dependency-submission-action@d433c2f467e149a8009c8fbce92cc708ed15ef7b # v0.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           detectorArgs: Pip=EnableIfDefaultOff


### PR DESCRIPTION
## Summary
- fix dependency graph workflow steps

## Testing
- `pre-commit run --files .github/workflows/dependency-graph.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c722685b6c832db72068395568a2cf