### PR TITLE
Fix Trivy workflow configuration

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: ${{ github.event_name != 'pull_request' && always() }}
-        uses: github/codeql-action/upload-sarif@ad2a4837011b42f6947b78d6417e7c253b1c504b  # yamllint disable-line rule:line-length
+        uses: github/codeql-action/upload-sarif@ad2a4837011b42f6947b78d6417e7c253b1c504b
         # v3
         with:
           sarif_file: trivy-results.sarif


### PR DESCRIPTION
## Summary
- clean up Trivy scan workflow so upload step is valid

## Testing
- `pre-commit run --files .github/workflows/trivy.yml`

------
https://chatgpt.com/codex/tasks/task_e_68c71f97fdb0832d941666c464386e35