### PR TITLE
fix dependency graph workflow action reference

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Prepare requirements
         run: sed -i '/^ccxtpro/d' requirements.out
       - name: Component detection
-        uses: advanced-security/component-detection-dependency-submission-action@d433c2f467e149a8009c8fbce92cc708ed15ef7b # v0.1.0
+        uses: advanced-security/component-detection-dependency-submission-action@v0.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           detectorArgs: Pip=EnableIfDefaultOff


### PR DESCRIPTION
## Summary
- use tagged release for dependency graph submission action

## Testing
- `pre-commit run --files .github/workflows/dependency-graph.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c724dfddcc832d980c88dc756a978c