### PR TITLE
Fix dependency graph workflow permissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -11,11 +11,13 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   submit:
     permissions:
       contents: write
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
@@ -25,7 +27,7 @@ jobs:
       - name: Prepare requirements
         run: sed -i '/^ccxtpro/d' requirements.out
       - name: Component detection
-        uses: advanced-security/component-detection-dependency-submission-action@v0.1.0
+        uses: advanced-security/component-detection-dependency-submission-action@d433c2f467e149a8009c8fbce92cc708ed15ef7b # v0.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           detectorArgs: Pip=EnableIfDefaultOff


### PR DESCRIPTION
## Summary
- grant id-token permission required for dependency submission
- pin component detection action to a specific commit for reproducibility

## Testing
- `pre-commit run --files .github/workflows/dependency-graph.yml` *(failed: interrupted)*
- `SKIP=pytest pre-commit run --files .github/workflows/dependency-graph.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c7b4a4ada4832d8ce3a2951c6dc5f4