### PR TITLE
Fix unused loop variable in GPT-OSS review workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -76,7 +76,7 @@ jobs:
         id: wait_llm
         run: |
           set -euo pipefail
-          for i in {1..180}; do
+          for _ in {1..180}; do
             if docker ps --filter "name=gptoss" --filter "status=running" | grep -q gptoss && \
                curl -sSf --retry 3 --retry-delay 1 --retry-connrefused http://127.0.0.1:8000/v1/models >/dev/null; then
               exit 0


### PR DESCRIPTION
## Summary
- avoid unused loop variable in container wait loop to satisfy shellcheck/actionlint

## Testing
- `actionlint -shellcheck shellcheck .github/workflows/gptoss_review.yml`
- `pre-commit run --files .github/workflows/gptoss_review.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c7b4eac030832d8d98334fa2f9303a