### PR TITLE
Handle host values with port numbers

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -229,3 +229,19 @@ def test_validate_host_rejects_invalid(host, monkeypatch):
     monkeypatch.setenv('HOST', host)
     with pytest.raises(ValueError):
         utils.validate_host()
+
+
+def test_validate_host_ignores_port(monkeypatch):
+    monkeypatch.setenv('HOST', '127.0.0.1:8080')
+    assert utils.validate_host() == '127.0.0.1'
+
+
+def test_validate_host_ipv6_port(monkeypatch):
+    monkeypatch.setenv('HOST', '[::1]:9000')
+    assert utils.validate_host() == '::1'
+
+
+def test_validate_host_invalid_port(monkeypatch):
+    monkeypatch.setenv('HOST', '127.0.0.1:notaport')
+    with pytest.raises(ValueError):
+        utils.validate_host()

--- a/utils.py
+++ b/utils.py
@@ -148,6 +148,27 @@ def validate_host() -> str:
         logger.info("HOST не установлен, используется 127.0.0.1")
         return "127.0.0.1"
 
+    # Support "host:port" style values by stripping any port component before
+    # validation.  This allows users to specify e.g. ``127.0.0.1:8000`` or
+    # ``[::1]:8080`` in the environment variable without triggering a
+    # ``ValueError``.
+    port = ""
+    if host.startswith("["):
+        # IPv6 address, possibly in "[addr]:port" form
+        end = host.find("]")
+        if end != -1:
+            port = host[end + 1 :]
+            host = host[1:end]
+    else:
+        if host.count(":") == 1:
+            host, port = host.split(":")
+
+    if port:
+        if port.startswith(":"):
+            port = port[1:]
+        if port and not port.isdigit():
+            raise ValueError(f"Некорректный порт: {port}")
+
     if host.lower() == "localhost":
         logger.info("HOST 'localhost' интерпретирован как 127.0.0.1")
         return "127.0.0.1"


### PR DESCRIPTION
## Summary
- Strip optional port from HOST before validation so `127.0.0.1:8000` or `[::1]:8080` are accepted
- Cover host:port cases and invalid port handling in unit tests

## Testing
- `TEST_MODE=1 pytest -q`
- `flake8 .`
- `bandit -r . -ll -x ./tests,./scripts,./gptoss_check`


------
https://chatgpt.com/codex/tasks/task_e_68c7b5097b60832da6b79edf90372953