### PR TITLE
fix: use completions endpoint for GPT-OSS health check

### DIFF
--- a/gptoss_check/check_code.py
+++ b/gptoss_check/check_code.py
@@ -31,8 +31,8 @@ def wait_for_api(api_url: str, timeout: int | None = None) -> None:
                 if v1_index != -1:
                     path = path[:v1_index]
                 base = urlunparse(parsed._replace(path=path.rstrip("/")))
-                health_url = urljoin(base.rstrip("/") + "/", "v1/models")
-                response = client.get(health_url)
+                health_url = urljoin(base.rstrip("/") + "/", "v1/completions")
+                response = client.post(health_url, json={})
                 try:
                     response.raise_for_status()
                 finally:

--- a/tests/test_gptoss_check.py
+++ b/tests/test_gptoss_check.py
@@ -100,7 +100,7 @@ def test_wait_for_api_http_error(monkeypatch):
         def __exit__(self, exc_type, exc, tb):
             return False
 
-        def get(self, url):
+        def post(self, url, json):
             return response
 
     calls = {"count": 0}
@@ -121,15 +121,15 @@ def test_wait_for_api_http_error(monkeypatch):
 @pytest.mark.parametrize(
     "api_url,expected",
     [
-        ("http://gptoss:8000/api", "http://gptoss:8000/api/v1/models"),
+        ("http://gptoss:8000/api", "http://gptoss:8000/api/v1/completions"),
         (
             "http://gptoss:8000/api/v1/chat/completions",
-            "http://gptoss:8000/api/v1/models",
+            "http://gptoss:8000/api/v1/completions",
         ),
     ],
 )
-def test_wait_for_api_uses_models_endpoint(monkeypatch, api_url, expected):
-    """wait_for_api should query /v1/models while preserving base paths."""
+def test_wait_for_api_uses_completions_endpoint(monkeypatch, api_url, expected):
+    """wait_for_api should query /v1/completions while preserving base paths."""
 
     called = {}
 
@@ -147,7 +147,7 @@ def test_wait_for_api_uses_models_endpoint(monkeypatch, api_url, expected):
         def __exit__(self, exc_type, exc, tb):
             return False
 
-        def get(self, url):
+        def post(self, url, json):
             called["url"] = url
             return DummyResponse()
 


### PR DESCRIPTION
## Summary
- probe `/v1/completions` to verify GPT-OSS availability
- adjust GPT-OSS tests for new health check behavior

## Testing
- `python -m flake8 --exclude venv .`
- `python -m mypy --no-site-packages --exclude venv .`
- `pytest -ra`
- ⚠️ `docker compose -f docker-compose.yml -f docker-compose.cpu.yml up --build --abort-on-container-exit --exit-code-from gptoss_check` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b4cbf8a0832d945807aa89cb0a61