### PR TITLE
Add tests for env validation and telegram alert logging

### DIFF
--- a/gpt_client.py
+++ b/gpt_client.py
@@ -120,7 +120,8 @@ def _validate_api_url(api_url: str) -> tuple[str, set[str]]:
                 f"GPT_OSS_API host {parsed.hostname!r} cannot be resolved"
             ) from exc
 
-    if scheme == "http" and parsed.hostname != "localhost":
+    allow_insecure = os.getenv("ALLOW_INSECURE_GPT_URL") == "1"
+    if scheme == "http" and parsed.hostname != "localhost" and not allow_insecure:
         for resolved_ip in resolved_ips:
             ip = ip_address(resolved_ip)
             if not (ip.is_loopback or ip.is_private):

--- a/tests/test_main_missing_env.py
+++ b/tests/test_main_missing_env.py
@@ -1,0 +1,22 @@
+import sys
+import types
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+import trading_bot
+
+
+def test_main_missing_required_env(monkeypatch):
+    class Dummy(BaseModel):
+        x: int
+
+    def fake_get_settings():
+        Dummy()  # raises ValidationError due to missing field
+
+    stub = types.SimpleNamespace(get_settings=fake_get_settings)
+    monkeypatch.setitem(sys.modules, "data_handler", stub)
+
+    with pytest.raises(SystemExit):
+        trading_bot.main()
+

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -129,7 +129,9 @@ async def send_telegram_alert(message: str) -> None:
             )
             if attempt == max_attempts:
                 logger.error(
-                    "Failed to send Telegram alert after %s attempts", max_attempts,
+                    "Failed to send Telegram alert after %s attempts: %s",
+                    max_attempts,
+                    message,
                 )
                 return
             await asyncio.sleep(delay)


### PR DESCRIPTION
## Summary
- log alert text when Telegram sending fails
- allow insecure GPT URL when ALLOW_INSECURE_GPT_URL=1
- add tests for env-dependent behaviors

## Testing
- `OFFLINE_MODE=1 pytest tests/test_main_missing_env.py tests/test_trading_bot.py::test_send_telegram_alert_logs_failure tests/test_gpt_client.py::test_allow_insecure_url -q`

------
https://chatgpt.com/codex/tasks/task_e_68c7b8de7cf4832d8ab20e268809c09e