### PR TITLE
feat: replace tenacity with internal retry

### DIFF
--- a/bot/trade_manager/core.py
+++ b/bot/trade_manager/core.py
@@ -51,7 +51,7 @@ test_stubs.apply()
 from bot.test_stubs import IS_TEST_MODE  # noqa: E402
 import ray  # noqa: E402
 import httpx  # noqa: E402
-from tenacity import retry, wait_exponential, stop_after_attempt  # noqa: E402
+from bot.utils import retry  # noqa: E402
 import inspect  # noqa: E402
 # Базовые утилиты импортируются всегда
 from bot.utils import (  # noqa: E402
@@ -499,9 +499,7 @@ class TradeManager:
         if not self.positions.empty:
             self.positions.sort_index(level=["symbol", "timestamp"], inplace=True)
 
-    @retry(
-        wait=wait_exponential(multiplier=1, min=2, max=5), stop=stop_after_attempt(3)
-    )
+    @retry(3, lambda attempt: min(2 ** attempt, 5))
     async def place_order(
         self,
         symbol: str,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,7 +165,7 @@ services:
         hard: 65536
   gptoss_check:
     image: python:3.11-slim
-    command: sh -c "pip install --no-cache-dir httpx tenacity && python3 gptoss_check/main.py"
+    command: sh -c "pip install --no-cache-dir httpx && python3 gptoss_check/main.py"
     working_dir: /workspace
     volumes:
       - .:/workspace

--- a/gpt_client.py
+++ b/gpt_client.py
@@ -19,12 +19,9 @@ from typing import Any, Coroutine
 # NOTE: httpx is imported for exception types only.
 import httpx
 
-import sys
 from pydantic import BaseModel, Field, ValidationError
 
-if "tenacity" in sys.modules and not getattr(sys.modules["tenacity"], "__file__", None):
-    del sys.modules["tenacity"]
-from tenacity import retry, stop_after_attempt, wait_exponential
+from bot.utils import retry
 # Absolute import ensures the project's own configuration module is used
 # instead of any unrelated ``config`` module on the import path.
 from bot.config import OFFLINE_MODE
@@ -287,9 +284,8 @@ def query_gpt(prompt: str) -> str:
         return result["value"]
 
     @retry(
-        stop=stop_after_attempt(MAX_RETRIES),
-        wait=wait_exponential(min=1, max=10),
-        reraise=True,
+        MAX_RETRIES,
+        lambda attempt: min(2 ** (attempt - 1), 10),
     )
     def _post() -> bytes:
         async def _async_post() -> bytes:
@@ -342,9 +338,8 @@ async def query_gpt_async(prompt: str) -> str:
     )
 
     @retry(
-        stop=stop_after_attempt(MAX_RETRIES),
-        wait=wait_exponential(min=1, max=10),
-        reraise=True,
+        MAX_RETRIES,
+        lambda attempt: min(2 ** (attempt - 1), 10),
     )
     async def _post() -> bytes:
         async with httpx.AsyncClient(trust_env=False, timeout=timeout) as client:

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -6,7 +6,6 @@ bandit==1.7.9
 pytest==8.4.2
 pytest-asyncio==1.1.0
 pytest-cov==7.0.0
-tenacity>=8.5,<10
 fastapi==0.116.1
 fastapi-csrf-protect==1.0.6
 flask>=3.0.3,<4

--- a/requirements-core.in
+++ b/requirements-core.in
@@ -14,7 +14,6 @@ imbalanced-learn>=0.12.3
 statsmodels>=0.14.2
 scipy>=1.13.1
 shap>=0.46.0
-tenacity>=8.5,<10
 pyarrow>=16.1.0
 numba>=0.61.0
 ray>=2.48.0

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -438,7 +438,6 @@ sympy==1.14.0
     # via torch
 ta==0.11.0
     # via -r requirements-core.in
-tenacity==9.1.2
     # via -r requirements-core.in
 tensorboardx==2.6.4
 threadpoolctl==3.6.0

--- a/requirements.out
+++ b/requirements.out
@@ -594,7 +594,6 @@ sympy==1.14.0
     #   torch
 ta==0.11.0
     # via -r requirements.txt
-tenacity==9.1.2
     # via -r requirements.txt
 tensorboardx==2.6.4
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -480,7 +480,6 @@ sympy==1.14.0
     # via torch
 ta==0.11.0
     # via -r requirements-core.in
-tenacity==9.1.2
     # via -r requirements-core.in
 threadpoolctl==3.6.0
     # via

--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -1,4 +1,3 @@
-import sys
 import asyncio
 import socket
 import logging
@@ -6,7 +5,6 @@ import json
 
 import pytest
 import httpx
-import tenacity  # noqa: F401  # re-import after pop
 
 from bot.gpt_client import (
     GPTClientError,
@@ -22,8 +20,6 @@ from bot.gpt_client import (
     query_gpt_async,
     query_gpt_json_async,
 )
-
-sys.modules.pop("tenacity", None)
 
 
 class DummyStream:

--- a/tests/test_import_order.py
+++ b/tests/test_import_order.py
@@ -26,6 +26,11 @@ def test_telegramlogger_injection_order():
     async def _safe_api_call(exchange, method: str, *args, **kwargs):
         return await getattr(exchange, method)(*args, **kwargs)
     utils_stub.safe_api_call = _safe_api_call
+    def _retry(max_attempts, delay_fn):
+        def decorator(func):
+            return func
+        return decorator
+    utils_stub.retry = _retry
     sys.modules['utils'] = utils_stub
     sys.modules['bot.utils'] = utils_stub
 

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -54,6 +54,11 @@ async def _cde(*a, **kw):
 utils.check_dataframe_empty = _cde
 utils.check_dataframe_empty_async = _cde
 utils.is_cuda_available = lambda: False
+def _retry(max_attempts, delay_fn):
+    def decorator(func):
+        return func
+    return decorator
+utils.retry = _retry
 sys.modules['utils'] = utils
 
 scipy_mod = types.ModuleType('scipy')

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,70 @@
+import asyncio
+import pytest
+
+from bot.utils import retry
+
+
+def test_retry_success_sync():
+    calls = {"count": 0, "delays": []}
+
+    def delay(base):
+        calls["delays"].append(base)
+        return 0
+
+    @retry(3, delay)
+    def flaky():
+        calls["count"] += 1
+        if calls["count"] < 3:
+            raise ValueError("boom")
+        return "ok"
+
+    assert flaky() == "ok"
+    assert calls["count"] == 3
+    assert calls["delays"] == [1, 2]
+
+
+def test_retry_exhaust_sync():
+    calls = {"count": 0}
+
+    @retry(3, lambda _: 0)
+    def always_fail():
+        calls["count"] += 1
+        raise RuntimeError("fail")
+
+    with pytest.raises(RuntimeError):
+        always_fail()
+    assert calls["count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_retry_success_async():
+    calls = {"count": 0, "delays": []}
+
+    def delay(base):
+        calls["delays"].append(base)
+        return 0
+
+    @retry(3, delay)
+    async def flaky():
+        calls["count"] += 1
+        if calls["count"] < 3:
+            raise ValueError("boom")
+        return "ok"
+
+    assert await flaky() == "ok"
+    assert calls["count"] == 3
+    assert calls["delays"] == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_retry_exhaust_async():
+    calls = {"count": 0}
+
+    @retry(3, lambda _: 0)
+    async def always_fail():
+        calls["count"] += 1
+        raise RuntimeError("fail")
+
+    with pytest.raises(RuntimeError):
+        await always_fail()
+    assert calls["count"] == 3

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -39,6 +39,11 @@ utils.is_cuda_available = lambda: False
 async def _safe_api_call(exchange, method: str, *args, **kwargs):
     return await getattr(exchange, method)(*args, **kwargs)
 utils.safe_api_call = _safe_api_call
+def _retry(max_attempts, delay_fn):
+    def decorator(func):
+        return func
+    return decorator
+utils.retry = _retry
 sys.modules['utils'] = utils
 joblib_mod = types.ModuleType('joblib')
 joblib_mod.dump = lambda *a, **k: None

--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -48,6 +48,11 @@ utils_stub.is_cuda_available = lambda: False
 async def _safe_api_call(exchange, method: str, *args, **kwargs):
     return await getattr(exchange, method)(*args, **kwargs)
 utils_stub.safe_api_call = _safe_api_call
+def _retry(max_attempts, delay_fn):
+    def decorator(func):
+        return func
+    return decorator
+utils_stub.retry = _retry
 sys.modules['utils'] = utils_stub
 sys.modules['bot.utils'] = utils_stub
 sys.modules.pop('trade_manager', None)
@@ -107,6 +112,11 @@ utils.is_cuda_available = lambda: False
 async def _safe_api_call(exchange, method: str, *args, **kwargs):
     return await getattr(exchange, method)(*args, **kwargs)
 utils.safe_api_call = _safe_api_call
+def _retry2(max_attempts, delay_fn):
+    def decorator(func):
+        return func
+    return decorator
+utils.retry = _retry2
 sys.modules['utils'] = utils
 sys.modules['bot.utils'] = utils
 

--- a/tests/test_trade_manager_loops.py
+++ b/tests/test_trade_manager_loops.py
@@ -44,6 +44,11 @@ utils_stub.is_cuda_available = lambda: False
 async def _safe_api_call(exchange, method: str, *args, **kwargs):
     return await getattr(exchange, method)(*args, **kwargs)
 utils_stub.safe_api_call = _safe_api_call
+def _retry(max_attempts, delay_fn):
+    def decorator(func):
+        return func
+    return decorator
+utils_stub.retry = _retry
 sys.modules['utils'] = utils_stub
 sys.modules.pop('trade_manager', None)
 joblib_mod = types.ModuleType('joblib')

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -22,11 +22,9 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # noqa: BLE001 - broad to avoid test import errors
     ccxt = type("ccxt_stub", (), {})()
 from dotenv import load_dotenv
-from tenacity import retry, stop_after_attempt, wait_exponential
-
 from bot.config import BotConfig
 from bot.gpt_client import GPTClientError, GPTClientJSONError, query_gpt_json_async
-from bot.utils import logger, suppress_tf_logs
+from bot.utils import logger, suppress_tf_logs, retry
 
 BybitError = getattr(ccxt, "BaseError", Exception)
 NetworkError = getattr(ccxt, "NetworkError", BybitError)
@@ -394,7 +392,7 @@ async def check_services() -> None:
 
 
 
-@retry(wait=wait_exponential(multiplier=1, min=2, max=5), stop=stop_after_attempt(3))
+@retry(3, lambda attempt: min(2 ** attempt, 5))
 async def fetch_price(symbol: str, env: dict) -> float | None:
     """Return current price or ``None`` if the request fails."""
     try:
@@ -496,7 +494,7 @@ async def build_feature_vector(symbol: str, price: float) -> list[float]:
     return [price, volume, sma, volatility, rsi]
 
 
-@retry(wait=wait_exponential(multiplier=1, min=2, max=5), stop=stop_after_attempt(3))
+@retry(3, lambda attempt: min(2 ** attempt, 5))
 async def get_prediction(symbol: str, features: list[float], env: dict) -> dict | None:
     """Return raw model prediction output for the given ``features``."""
     try:


### PR DESCRIPTION
## Summary
- add custom retry decorator with exponential backoff
- use retry instead of tenacity across modules
- drop tenacity from dependencies and related files
- add tests for retry decorator

## Testing
- `pre-commit run --files bot/trade_manager/core.py docker-compose.yml gpt_client.py http_client.py requirements-ci.txt requirements-core.in requirements-core.txt requirements.out requirements.txt tests/test_gpt_client.py tests/test_import_order.py tests/test_optimizer.py tests/test_simulation.py tests/test_trade_manager.py tests/test_trade_manager_loops.py trading_bot.py utils.py tests/test_retry.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7b8d42dd8832d99f2461d4d680d25