### PR TITLE
Ensure TelegramLogger shuts down at exit

### DIFF
--- a/telegram_logger.py
+++ b/telegram_logger.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import asyncio
+import atexit
 import logging
 import os
 import threading
@@ -257,4 +258,20 @@ class TelegramLogger(logging.Handler):
 
 if OFFLINE_MODE:
     TelegramLogger = OfflineTelegram  # type: ignore
+
+
+def _shutdown_all() -> None:
+    coro = TelegramLogger.shutdown()
+    try:
+        asyncio.run(coro)
+    except RuntimeError:
+        coro.close()
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(TelegramLogger.shutdown())
+        except RuntimeError:
+            pass
+
+
+atexit.register(_shutdown_all)
 

--- a/tests/test_telegram_logger_shutdown_all.py
+++ b/tests/test_telegram_logger_shutdown_all.py
@@ -1,0 +1,21 @@
+import atexit
+import importlib
+import sys
+from unittest.mock import AsyncMock
+import types
+
+
+def test_shutdown_all_registered_and_called(monkeypatch):
+    funcs = []
+    monkeypatch.setattr(atexit, "register", lambda func: funcs.append(func))
+    sys.modules.pop("telegram_logger", None)
+    module = importlib.import_module("telegram_logger")
+
+    mock = AsyncMock()
+    monkeypatch.setattr(module, "TelegramLogger", types.SimpleNamespace(shutdown=mock))
+
+    assert module._shutdown_all in funcs
+    for func in funcs:
+        func()
+
+    mock.assert_awaited_once()


### PR DESCRIPTION
## Summary
- add `_shutdown_all` helper to run `TelegramLogger.shutdown()` during interpreter exit
- register `_shutdown_all` via `atexit`
- verify the shutdown helper is registered and invoked

## Testing
- `pytest tests/test_telegram_logger_shutdown_all.py tests/test_telegram_logger.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c7b8c2da50832d824a84d5205c3a48