### PR TITLE
fix: mark md5 hashing as non-security

### DIFF
--- a/telegram_logger.py
+++ b/telegram_logger.py
@@ -123,7 +123,9 @@ class TelegramLogger(logging.Handler):
 
             parts = [message[i : i + 500] for i in range(0, len(message), 500)]
             for part in parts:
-                part_hash = hashlib.md5(part.encode("utf-8")).hexdigest()
+                part_hash = hashlib.md5(
+                    part.encode("utf-8"), usedforsecurity=False
+                ).hexdigest()
                 if part_hash == self.last_hash:
                     logger.debug("Повторное сообщение Telegram пропущено")
                     continue


### PR DESCRIPTION
## Summary
- mark md5 hashing in telegram logger as non-security to satisfy bandit

## Testing
- `bandit -r . -ll -ii -x ./tests,./scripts,./gptoss_check`
- `pre-commit run --files telegram_logger.py` *(fails: NameError: name 'retry' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d6b0812c832d92b164cd7ab268e9