### PR TITLE
Fix retry import and GPT URL validation

### DIFF
--- a/gpt_client.py
+++ b/gpt_client.py
@@ -121,12 +121,12 @@ def _validate_api_url(api_url: str) -> tuple[str, set[str]]:
                 f"GPT_OSS_API host {parsed.hostname!r} cannot be resolved"
             ) from exc
 
-    allow_insecure = os.getenv("ALLOW_INSECURE_GPT_URL") == "1"
-    if scheme == "http" and parsed.hostname != "localhost" and not allow_insecure:
+    allow_insecure = ALLOW_INSECURE_GPT_URL or os.getenv("ALLOW_INSECURE_GPT_URL") == "1"
+    if scheme == "http" and parsed.hostname != "localhost":
         for resolved_ip in resolved_ips:
             ip = ip_address(resolved_ip)
             if not (ip.is_loopback or ip.is_private):
-                if ALLOW_INSECURE_GPT_URL:
+                if allow_insecure:
                     logger.warning(
                         "Using insecure GPT_OSS_API URL: %s (not private or localhost)",
                         api_url,

--- a/tests/test_trading_bot.py
+++ b/tests/test_trading_bot.py
@@ -138,6 +138,9 @@ async def test_send_telegram_alert_without_env(monkeypatch, caplog):
 
 
 @pytest.mark.asyncio
+async def test_send_telegram_alert_request_error(monkeypatch, caplog):
+    class DummyClient:
+        async def post(self, url, json=None, data=None, timeout=None):
             request = httpx.Request("POST", url)
             raise httpx.RequestError("boom", request=request)
 
@@ -148,6 +151,11 @@ async def test_send_telegram_alert_without_env(monkeypatch, caplog):
     monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "token")
     monkeypatch.setenv("TELEGRAM_CHAT_ID", "chat")
     monkeypatch.setenv("TELEGRAM_ALERT_RETRIES", "1")
+
+    with caplog.at_level(logging.WARNING):
+        await trading_bot.send_telegram_alert("hi")
+
+    assert "boom" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -15,6 +15,7 @@ from contextlib import suppress
 from typing import Awaitable, Callable, TypeVar
 
 from model_builder_client import schedule_retrain, retrain
+from utils import retry
 
 import httpx
 try:  # pragma: no cover - optional dependency
@@ -29,6 +30,10 @@ BybitError = getattr(ccxt, "BaseError", Exception)
 NetworkError = getattr(ccxt, "NetworkError", BybitError)
 
 CFG = BotConfig()
+
+import logging
+
+logger = logging.getLogger("TradingBot")
 
 
 class GPTAdviceModel(BaseModel):


### PR DESCRIPTION
## Summary
- import retry and set up logger in trading_bot
- warn on insecure GPT URL when explicitly allowed
- restore Telegram alert request error test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7d6cc106c832d9e5c443d7457a504