### PR TITLE
Исправлена обработка небезопасного URL в GPT клиенте

### DIFF
--- a/gpt_client.py
+++ b/gpt_client.py
@@ -121,10 +121,12 @@ def _validate_api_url(api_url: str) -> tuple[str, set[str]]:
                 f"GPT_OSS_API host {parsed.hostname!r} cannot be resolved"
             ) from exc
 
+
     if scheme == "http" and parsed.hostname != "localhost":
         for resolved_ip in resolved_ips:
             ip = ip_address(resolved_ip)
             if not (ip.is_loopback or ip.is_private):
+                if ALLOW_INSECURE_GPT_URL or os.getenv("ALLOW_INSECURE_GPT_URL") == "1":
                     logger.warning(
                         "Using insecure GPT_OSS_API URL: %s (not private or localhost)",
                         api_url,
@@ -132,7 +134,7 @@ def _validate_api_url(api_url: str) -> tuple[str, set[str]]:
                 else:
                     logger.critical("Insecure GPT_OSS_API URL: %s", api_url)
                     raise GPTClientError(
-                        "GPT_OSS_API must use HTTPS, be a private address, or point to localhost"
+                        "GPT_OSS_API must use HTTPS, be a private address, or point to localhost",
                     )
                 break
 


### PR DESCRIPTION
## Summary
- корректно учитывается переменная ALLOW_INSECURE_GPT_URL при валидации URL
- устранена ошибка отступов

## Testing
- `pytest -m "not integration" -q`
- `pre-commit run --files gpt_client.py .github/workflows/dependabot.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c7fab3b544832d9610940fbbd901eb