### PR TITLE
fix: quote concurrency group

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -15,7 +15,7 @@ permissions:
   issues: write
 
 concurrency:
-  group: gptoss-review-${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref || github.run_id }}
+  group: "gptoss-review-${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref || github.run_id }}"
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- quote concurrency group in GPT-OSS review workflow

## Testing
- `/tmp/actionlint .github/workflows/gptoss_review.yml`
- `pre-commit run --files .github/workflows/gptoss_review.yml` *(fails: IndentationError in gpt_client.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c7fac05670832d90111d5871c3df81