### PR TITLE
Handle insecure GPT URL via runtime env check

### DIFF
--- a/gpt_client.py
+++ b/gpt_client.py
@@ -125,6 +125,7 @@ def _validate_api_url(api_url: str) -> tuple[str, set[str]]:
         for resolved_ip in resolved_ips:
             ip = ip_address(resolved_ip)
             if not (ip.is_loopback or ip.is_private):
+                if ALLOW_INSECURE_GPT_URL or os.getenv("ALLOW_INSECURE_GPT_URL") == "1":
                     logger.warning(
                         "Using insecure GPT_OSS_API URL: %s (not private or localhost)",
                         api_url,


### PR DESCRIPTION
## Summary
- fix indentation in gpt_client
- allow HTTP GPT API when `ALLOW_INSECURE_GPT_URL=1`

## Testing
- `pytest`
- `pre-commit run --files gpt_client.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7fad10e34832d919fed13e9d847e8