### PR TITLE
fix: correct release drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     branches:
       - main
     types: [opened, reopened, synchronize, labeled, unlabeled]
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update release draft
-        uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
+        uses: release-drafter/release-drafter@v6.1.0
         with:
           config-name: release-drafter.yml
         env:


### PR DESCRIPTION
## Summary
- use `pull_request` event and update action version for release drafter

## Testing
- `pre-commit run --files .github/workflows/release-drafter.yml` *(fails: IndentationError in gpt_client.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c80e3036b4832da99e0b9deefbceac