### PR TITLE
fix: validate insecure GPT_OSS_API urls

### DIFF
--- a/gpt_client.py
+++ b/gpt_client.py
@@ -132,6 +132,15 @@ def _validate_api_url(api_url: str) -> tuple[str, set[str]]:
 
 
     if scheme == "http" and parsed.hostname != "localhost":
+        if _insecure_allowed():
+            logger.warning("Using insecure GPT_OSS_API URL %s", api_url)
+        elif not all(
+            ip_address(ip).is_loopback or ip_address(ip).is_private
+            for ip in resolved_ips
+        ):
+            raise GPTClientError(
+                "Insecure GPT_OSS_API URL must resolve to a local or private address"
+            )
     return parsed.hostname, resolved_ips
 
 


### PR DESCRIPTION
## Summary
- log a warning when using an insecure GPT_OSS_API URL allowed via env
- enforce that insecure GPT_OSS_API URLs resolve to local or private addresses

## Testing
- `python -m flake8 --exclude venv .`
- `python -m mypy --exclude venv .`
- `pytest -ra`


------
https://chatgpt.com/codex/tasks/task_e_68c80e0d31c4832db8cb1eb5358bd750