### PR TITLE
Fix concurrency group in GPT-OSS review workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -15,7 +15,8 @@ permissions:
   issues: write
 
 concurrency:
-  group: "gptoss-review-${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref || github.run_id }}"
+  group: >-
+    gptoss-review-${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- simplify concurrency key expression

## Testing
- `pre-commit run --files .github/workflows/gptoss_review.yml`
- `/tmp/actionlint .github/workflows/gptoss_review.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c82011f450832da8e6dc11b87668c6