### PR TITLE
Fix Docker CI apt package pinning

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -8,7 +8,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Обновление linux-libc-dev устраняет CVE-2025-21976, а libgcrypt20 — CVE-2024-2236
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    python3 python3-venv build-essential linux-libc-dev libgcrypt20 git=1:2.43.0-1ubuntu7.3 \
+    python3 python3-venv build-essential linux-libc-dev libgcrypt20 git \
     && apt-get install -y --no-install-recommends gnupg dirmngr \
     && apt-get install -y --only-upgrade libpam0g libpam-modules \
     && python3 -m venv /venv \
@@ -35,8 +35,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Устанавливаем только необходимые пакеты выполнения
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    libssl3t64=3.0.13-0ubuntu3.5 \
-    python3.12-minimal=3.12.3-1ubuntu0.8 \
+    libssl3t64 \
+    python3.12-minimal \
     && apt-get install -y --only-upgrade openssl libssl3t64 libpam0g libpam-modules \
     && apt-get purge -y git \
     && apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- allow apt to install the current git package in the CI Docker image
- remove strict libssl3t64 and python3.12-minimal pinning so builds keep working

## Testing
- not run (docker build only)


------
https://chatgpt.com/codex/tasks/task_e_68c8544eff04832d9cef7f6d50aac0b5