### PR TITLE
Fix Dependabot updater failure for codeql upload action

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -40,7 +40,7 @@ jobs:
             echo "upload=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Upload Bandit results
-        uses: github/codeql-action/upload-sarif@ad2a4837011b42f6947b78d6417e7c253b1c504b # v3
+        uses: github/codeql-action/upload-sarif@192325c86100d080feab897ff886c34abd4c83a3 # v3.30.3
         if: steps.sarif_check.outputs.upload == 'true' && github.event_name != 'pull_request'
         with:
           sarif_file: bandit.sarif

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -33,7 +33,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
       - name: Upload SARIF report
         if: always()
-        uses: github/codeql-action/upload-sarif@ad2a4837011b42f6947b78d6417e7c253b1c504b # v3
+        uses: github/codeql-action/upload-sarif@192325c86100d080feab897ff886c34abd4c83a3 # v3.30.3
         with:
           sarif_file: results.sarif
       - name: Cleanup buildx

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -50,7 +50,7 @@ jobs:
             echo "upload=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@ad2a4837011b42f6947b78d6417e7c253b1c504b # v3
+        uses: github/codeql-action/upload-sarif@192325c86100d080feab897ff886c34abd4c83a3 # v3.30.3
         if: steps.sarif_check.outputs.upload == 'true'
         with:
           sarif_file: semgrep.sarif

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -40,8 +40,8 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: ${{ github.event_name != 'pull_request' && always() }}
-        uses: github/codeql-action/upload-sarif@ad2a4837011b42f6947b78d6417e7c253b1c504b
-        # v3
+        uses: github/codeql-action/upload-sarif@192325c86100d080feab897ff886c34abd4c83a3
+        # v3.30.3
         with:
           sarif_file: trivy-results.sarif
 


### PR DESCRIPTION
## Summary
- replace the missing github/codeql-action/upload-sarif commit with the latest v3.30.3 digest across security workflows to restore Dependabot updates

## Testing
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_e_68c85478652c832d9672d8cc8180156a