### PR TITLE
Handle GPT JSON errors with safe mode fallback

### DIFF
--- a/gpt_client.py
+++ b/gpt_client.py
@@ -392,8 +392,8 @@ async def query_gpt_json_async(prompt: str) -> dict:
     try:
         data = json.loads(text)
     except json.JSONDecodeError as exc:
-        logger.exception("Invalid JSON from GPT OSS API: %s", exc)
-        raise GPTClientJSONError("Invalid JSON response from GPT OSS API") from exc
+        logger.error("Invalid JSON from GPT OSS API: %s", exc)
+        return {"signal": "hold"}
     if not isinstance(data, dict):
         raise GPTClientResponseError("Unexpected response structure from GPT OSS API")
     required = {"signal", "tp_mult", "sl_mult"}

--- a/tests/test_gpt_integration.py
+++ b/tests/test_gpt_integration.py
@@ -1,6 +1,19 @@
+from collections import deque
+
 import pytest
 from bot import trading_bot
-from bot.gpt_client import GPTClientJSONError
+from bot.gpt_client import GPTClientError, GPTClientJSONError
+
+
+@pytest.fixture(autouse=True)
+def reset_gpt_state():
+    trading_bot.GPT_ADVICE = trading_bot.GPTAdviceModel()
+    trading_bot._GPT_ADVICE_ERROR_COUNT = 0
+    trading_bot._GPT_SAFE_MODE = False
+    yield
+    trading_bot.GPT_ADVICE = trading_bot.GPTAdviceModel()
+    trading_bot._GPT_ADVICE_ERROR_COUNT = 0
+    trading_bot._GPT_SAFE_MODE = False
 
 
 @pytest.mark.asyncio
@@ -36,3 +49,50 @@ async def test_refresh_gpt_advice_invalid_json(monkeypatch):
 
     await trading_bot.refresh_gpt_advice()
     assert alerts
+    assert trading_bot.GPT_ADVICE.signal == "hold"
+
+
+@pytest.mark.asyncio
+async def test_refresh_gpt_advice_safe_mode_after_retries(monkeypatch):
+    async def fake_features(symbol, price):
+        return [price, 0.0, price, 0.0, 50.0]
+
+    attempts = {"count": 0}
+
+    async def failing_query(prompt):
+        attempts["count"] += 1
+        raise GPTClientError("boom")
+
+    alerts: list[str] = []
+
+    async def fake_alert(msg: str) -> None:
+        alerts.append(msg)
+
+    toggles: list[bool] = []
+
+    async def fake_toggle(value: bool) -> None:
+        toggles.append(value)
+
+    monkeypatch.setattr(trading_bot, "build_feature_vector", fake_features)
+    monkeypatch.setattr(trading_bot, "SYMBOLS", ["BTCUSDT"])
+    monkeypatch.setattr(
+        trading_bot,
+        "_PRICE_HISTORY",
+        {"BTCUSDT": deque([1.0], maxlen=200)},
+    )
+    monkeypatch.setattr(trading_bot, "_load_env", lambda: {})
+    monkeypatch.setattr(trading_bot, "query_gpt_json_async", failing_query)
+    monkeypatch.setattr(trading_bot, "send_telegram_alert", fake_alert)
+    monkeypatch.setattr(trading_bot, "set_trading_enabled", fake_toggle)
+
+    for _ in range(trading_bot.GPT_ADVICE_MAX_ATTEMPTS):
+        await trading_bot.refresh_gpt_advice()
+
+    assert trading_bot.GPT_ADVICE.signal == "hold"
+    assert trading_bot._GPT_SAFE_MODE is True
+    assert toggles == [False]
+    assert any("safe mode" in msg.lower() for msg in alerts)
+
+    await trading_bot.refresh_gpt_advice()
+    assert attempts["count"] == trading_bot.GPT_ADVICE_MAX_ATTEMPTS
+    assert toggles == [False]


### PR DESCRIPTION
## Summary
- ensure GPT JSON decode failures in the client return a safe hold structure
- add GPT advice failure tracking with a safe-mode fallback that disables trading after repeated errors
- extend integration and client tests to cover the new graceful handling and safe-mode activation

## Testing
- `pytest tests/test_gpt_client.py`
- `pytest tests/test_gpt_integration.py`
- `pytest tests/test_trading_bot.py -k gpt`


------
https://chatgpt.com/codex/tasks/task_e_68c859449d70832db17a6ce31bfd4fbf