### PR TITLE
fix: pin release drafter action to a valid tag

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -19,7 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update release draft
-        uses: release-drafter/release-drafter@v6
+        # Release Drafter has no v7 tag yet; pin to the latest v6 release to avoid resolution errors.
+        uses: release-drafter/release-drafter@v6.1.0
         with:
           config-name: release-drafter.yml
         env:


### PR DESCRIPTION
## Summary
- pin the Release Drafter workflow to the existing v6.1.0 action tag
- document why the workflow sticks to the v6 series to avoid missing action failures

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c85fcc7ea0832da249c81129ebae2d