### PR TITLE
Fix CI environment handling and dependency imports

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -1,38 +1,36 @@
 """Main entry point for the trading bot."""
 
-from pydantic import BaseModel, ValidationError, ConfigDict
-from typing import Literal, Union
-
 import atexit
 import asyncio
 import json
+import logging
 import math
 import os
 import statistics
 import time
 from collections import defaultdict, deque
 from contextlib import suppress
-from typing import Awaitable, Callable, TypeVar
-import logging
-
-from model_builder_client import schedule_retrain, retrain
-from utils import retry, suppress_tf_logs
-from telegram_logger import TelegramLogger
+from typing import Awaitable, Callable, Literal, TypeVar, Union
 
 import httpx
-import logging
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from bot.config import BotConfig, OFFLINE_MODE
+from bot.dotenv_utils import load_dotenv
+from bot.gpt_client import GPTClientError, GPTClientJSONError, query_gpt_json_async
+from model_builder_client import retrain, schedule_retrain
+from telegram_logger import TelegramLogger
+from utils import retry, suppress_tf_logs
+
 try:  # pragma: no cover - optional dependency
     import ccxt  # type: ignore
 except Exception:  # noqa: BLE001 - broad to avoid test import errors
     ccxt = type("ccxt_stub", (), {})()
-from bot.gpt_client import GPTClientError, GPTClientJSONError, query_gpt_json_async
 
 BybitError = getattr(ccxt, "BaseError", Exception)
 NetworkError = getattr(ccxt, "NetworkError", BybitError)
 
 CFG = BotConfig()
-
-import logging
 
 logger = logging.getLogger("TradingBot")
 


### PR DESCRIPTION
## Summary
- ensure OFFLINE_MODE is derived from environment/.env and validate required variables with graceful offline fallback
- require gymnasium or gym to be installed and raise a clear error when missing instead of silently stubbing
- streamline trading bot imports and load dotenv helpers needed during startup

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c860c06d58832db633012e1cd4078f