### PR TITLE
Fix configuration and dependency handling

### DIFF
--- a/model_builder.py
+++ b/model_builder.py
@@ -74,17 +74,12 @@ def _create_gym_stub():
 
 
 if "gymnasium" in sys.modules and sys.modules["gymnasium"] is None:
-    gym, spaces = _create_gym_stub()
-else:
-    try:  # prefer gymnasium if available
-        import gymnasium as gym  # type: ignore
-        from gymnasium import spaces  # type: ignore
-    except ImportError:
-        try:
-            import gym  # type: ignore
-            from gym import spaces  # type: ignore
-        except ImportError:  # provide lightweight stubs for tests
-            gym, spaces = _create_gym_stub()
+    raise ImportError("gymnasium package is required for model_builder")
+try:  # prefer gymnasium if available
+    import gymnasium as gym  # type: ignore
+    from gymnasium import spaces  # type: ignore
+except ImportError as exc:
+    raise ImportError("gymnasium package is required for model_builder") from exc
 
 if os.getenv("TEST_MODE") == "1":
     import types

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -15,6 +15,8 @@ from contextlib import suppress
 from typing import Awaitable, Callable, TypeVar
 import logging
 
+from bot.config import BotConfig, OFFLINE_MODE
+from bot.dotenv_utils import load_dotenv
 from model_builder_client import schedule_retrain, retrain
 from utils import retry, suppress_tf_logs
 from telegram_logger import TelegramLogger


### PR DESCRIPTION
## Summary
- ensure configuration loading respects .env files, exposes OFFLINE_MODE, and reports missing variables gracefully
- import configuration helpers in the trading bot entry point to avoid runtime NameErrors
- raise a clear ImportError when gymnasium is missing and restore the Path import in the bot package init

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c85fc1ea00832d9af2b471df6474d3