### PR TITLE
Fix config loader environment handling and align CI dependencies

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -12,8 +12,8 @@ flask>=3.0.3,<4
 pydantic==2.11.7
 # gymnasium and scikit-learn are unavailable on some Python versions
 gymnasium==1.2.0; python_version<'3.12'
-# Pin older pandas to avoid incompatibilities with numpy
-pandas==2.1.4
+# Match the runtime dependency to keep compatibility with NumPy>=2 (required by OpenCV)
+pandas==2.3.2
 polars>=1.6.0
 pyarrow>=15.0.0
 python-dotenv>=1.0.0
@@ -21,15 +21,16 @@ psutil>=5.9.0
 werkzeug>=3.0.2,<4
 requests>=2.31.0
 httpx>=0.27.0
-# Newer scikit-learn releases pull in SciPy builds incompatible with our
-# pinned numpy; lock to a known working version.
+# Newer scikit-learn releases pull in SciPy builds incompatible with older
+# NumPy versions; lock to a known working combination used in production.
 scikit-learn==1.7.2; python_version<'3.12'
 joblib>=1.3
 setuptools>=70.0.0
 types-requests
 mypy==1.18.1
 hypothesis>=6.90.0
-numpy==1.26.4
+numpy==2.2.6
+scipy==1.16.1; python_version<'3.12'
 pip-audit==2.9.0
 pybit>=5.7.0
 

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -1,26 +1,25 @@
 """Main entry point for the trading bot."""
 
-from pydantic import BaseModel, ValidationError, ConfigDict
-from typing import Literal, Union
-
 import atexit
 import asyncio
 import json
+import logging
 import math
 import os
 import statistics
 import time
 from collections import defaultdict, deque
 from contextlib import suppress
-from typing import Awaitable, Callable, TypeVar
-import logging
-
-from model_builder_client import schedule_retrain, retrain
-from utils import retry, suppress_tf_logs
-from telegram_logger import TelegramLogger
+from typing import Awaitable, Callable, Literal, TypeVar, Union
 
 import httpx
-import logging
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from bot.config import BotConfig, OFFLINE_MODE
+from bot.dotenv_utils import load_dotenv
+from model_builder_client import schedule_retrain, retrain
+from telegram_logger import TelegramLogger
+from utils import retry, suppress_tf_logs
 try:  # pragma: no cover - optional dependency
     import ccxt  # type: ignore
 except Exception:  # noqa: BLE001 - broad to avoid test import errors


### PR DESCRIPTION
## Summary
- harden environment loading in `config.py`, including boolean parsing, `.env` support and safer default resolution for tests and offline mode
- require a real gymnasium install during model builder import while still supporting lightweight stubs in tests
- align CI requirements with runtime versions by bumping pandas/numpy and adding scipy to satisfy OpenCV
- ensure the trading bot imports configuration and dotenv helpers explicitly

## Testing
- `pytest -q --maxfail=1 --disable-warnings --cov=bot --cov-fail-under=0`
- `python -m flake8 .`
- `python -m bandit -r . -ll -x ./tests,./scripts,./gptoss_check` *(reports known B301 warning about pickle deserialisation)*

------
https://chatgpt.com/codex/tasks/task_e_68c85ffa1a38832d852fb02e9ad8328b