### PR TITLE
Grant permissions for Semgrep container pulls

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -21,6 +21,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   semgrep:
@@ -28,6 +29,7 @@ jobs:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+      packages: read # required to pull the Semgrep action container image from GHCR
     name: Scan
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- allow the Semgrep workflow to read GitHub Container Registry images by granting packages:read
- add a clarifying comment explaining why the permission is necessary

## Testing
- ~/.local/bin/semgrep ci --config p/ci

------
https://chatgpt.com/codex/tasks/task_e_68c863d9bdf4832da6e4b1b9f19349cd