### PR TITLE
Add module entry point for gptoss_check

### DIFF
--- a/gptoss_check/__main__.py
+++ b/gptoss_check/__main__.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from .main import main
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a __main__ module so `python -m gptoss_check` runs the existing CLI entry point

## Testing
- `python -m gptoss_check`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c8642b7e50832da6d92c4c31a04edf