### PR TITLE
fix: pin release drafter action to commit

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update release draft
-        # Release Drafter has no v7 tag yet; pin to the latest v6 release to avoid resolution errors.
-        uses: release-drafter/release-drafter@v6.1.0
+        # Release Drafter still has no v7 tag; pin directly to the v6.1.0 commit to avoid resolution errors.
+        uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         with:
           config-name: release-drafter.yml
         env:


### PR DESCRIPTION
## Summary
- pin the Release Drafter workflow to the v6.1.0 commit instead of the missing v7 tag
- document the reason in the workflow comment so future runs keep using an existing action version

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c863ceeda8832daaaeb87ead77971e