### PR TITLE
Fix OpenCV extra to avoid numpy 2 upgrade in CI

### DIFF
--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -1,2 +1,7 @@
 # Optional heavy dependencies
-opencv-python-headless==4.12.0.88
+# Pin OpenCV to a release that still supports NumPy<2.0 so that it remains
+# compatible with the pandas version used in CI (pandas 2.1.x only ships
+# wheels built against NumPy 1.26). Newer OpenCV wheels force an upgrade to
+# NumPy>=2, which breaks binary compatibility on Python 3.10 during the test
+# workflow.
+opencv-python-headless==4.10.0.84


### PR DESCRIPTION
## Summary
- pin opencv-python-headless in requirements-extras to a release compatible with NumPy<2.0
- document the reason for the pin to avoid breaking the CI test workflow

## Testing
- pytest -q --maxfail=1 --disable-warnings --cov=bot --cov-fail-under=0 (python 3.10)
- pytest -q --maxfail=1 --disable-warnings --cov=bot --cov-fail-under=0 (python 3.11)


------
https://chatgpt.com/codex/tasks/task_e_68c8646b9b80832db05d9062f32e1dc5