### PR TITLE
Ensure TradeManager loads dotenv before reading environment variables

### DIFF
--- a/bot/trade_manager/core.py
+++ b/bot/trade_manager/core.py
@@ -213,6 +213,11 @@ class TradeManager:
         chat_id,
         rl_agent=None,
     ):
+        # Ensure environment variables from optional .env file are available
+        # before we read Telegram-related settings. ``load_dotenv`` is a no-op
+        # when python-dotenv isn't installed, so calling it is safe in tests.
+        load_dotenv()
+
         self.config = config
         self.data_handler = data_handler
         self.model_builder = model_builder


### PR DESCRIPTION
## Summary
- load optional .env values at the start of `TradeManager.__init__` to keep Telegram configuration in sync with other entry points

## Testing
- python -m ruff check bot tests
- python -m mypy bot
- python -m bandit -r bot -x tests -ll
- python -m flake8 .
- pytest -m "not integration" -o cache_dir=/mnt/pytest_cache
- pytest -m integration -o cache_dir=/mnt/pytest_cache

------
https://chatgpt.com/codex/tasks/task_e_68c86b6d264c832da4ccf65099ddeb46