### PR TITLE
Simplify CI test run to remove pytest-cov dependency

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,4 +42,4 @@ jobs:
         run: bandit -r . -ll -x ./tests,./scripts,./gptoss_check
         continue-on-error: true
       - name: Run tests (pytest)
-        run: pytest -q --maxfail=1 --disable-warnings --cov=bot --cov-fail-under=0
+        run: pytest -q --maxfail=1 --disable-warnings

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -5,7 +5,6 @@ flake8==7.3.0
 bandit==1.8.6
 pytest==8.4.2
 pytest-asyncio==1.1.0
-pytest-cov==7.0.0
 fastapi==0.116.1
 fastapi-csrf-protect==1.0.6
 flask>=3.0.3,<4


### PR DESCRIPTION
## Summary
- drop pytest coverage flags from the Tests workflow
- remove pytest-cov from the CI requirements so the job no longer depends on the plugin

## Testing
- pytest -q --maxfail=1 --disable-warnings (python 3.10)
- pytest -q --maxfail=1 --disable-warnings (python 3.11)


------
https://chatgpt.com/codex/tasks/task_e_68c86a64a0f8832dadfda636f3451631