### PR TITLE
Fix GPT client insecure fallback when DNS fails

### DIFF
--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -174,6 +174,21 @@ async def test_allow_insecure_url(monkeypatch, func, client_cls):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("func, client_cls", QUERIES)
+async def test_insecure_url_dns_failure(monkeypatch, func, client_cls):
+    monkeypatch.setenv("GPT_OSS_API", "http://example.com")
+    monkeypatch.setenv("TEST_MODE", "1")
+
+    def fail_resolution(*args, **kwargs):
+        raise socket.gaierror("resolution failed")
+
+    monkeypatch.setattr(socket, "getaddrinfo", fail_resolution)
+
+    with pytest.raises(GPTClientError):
+        await run_query(func, "hi")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("func, client_cls", QUERIES)
 async def test_localhost_allowed(monkeypatch, func, client_cls):
     monkeypatch.setenv("GPT_OSS_API", "http://localhost")
 


### PR DESCRIPTION
## Summary
- prevent `_validate_api_url` from silently allowing HTTP endpoints when DNS resolution fails
- add a helper to detect local hostnames and reuse it during validation
- extend `tests/test_gpt_client.py` with coverage for DNS failures in test mode

## Testing
- TEST_MODE=1 CSRF_SECRET=testsecret pytest -ra
- python -m mypy --exclude venv .
- python -m flake8 --exclude venv .
- TEST_MODE=1 CSRF_SECRET=testsecret pytest -ra (Python 3.11.12)
- python -m mypy --exclude venv . (Python 3.11.12)
- python -m flake8 --exclude venv . (Python 3.11.12)


------
https://chatgpt.com/codex/tasks/task_e_68c86acd992c832d913fb94b1028633e