### PR TITLE
Fix CI lint setup and formatting

### DIFF
--- a/bot/trade_manager/core.py
+++ b/bot/trade_manager/core.py
@@ -279,7 +279,9 @@ class TradeManager:
                 names=["symbol", "timestamp"],
             ),
         )
-        self.returns_by_symbol: dict[str, list[tuple[float, float]]] = {symbol: [] for symbol in data_handler.usdt_pairs}
+        self.returns_by_symbol: dict[str, list[tuple[float, float]]] = {
+            symbol: [] for symbol in data_handler.usdt_pairs
+        }
         self.position_lock = asyncio.Lock()
         self.returns_lock = asyncio.Lock()
         self.tasks: list[asyncio.Task] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,3 +45,11 @@ py-modules = [
   "test_stubs",
   "utils"
 ]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 120
+
+[tool.ruff.lint]
+select = ["E", "F"]
+per-file-ignores = {"tests/*" = ["E402"]}

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -3,6 +3,7 @@ aiohttp>=3.9.4
 bcrypt>=4.1.2
 flake8==7.3.0
 bandit==1.8.6
+ruff==0.6.9
 pytest==8.4.2
 pytest-asyncio==1.1.0
 fastapi==0.116.1

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -107,7 +107,12 @@ class DummyDataHandler:
 async def test_simulator_trailing_stop(trade_manager_classes, tmp_path):
     TradeManager, HistoricalSimulator = trade_manager_classes
     dh = DummyDataHandler(str(tmp_path))
-    cfg = BotConfig(cache_dir=str(tmp_path), trailing_stop_percentage=1.0, trailing_stop_coeff=0.0, trailing_stop_multiplier=1.0)
+    cfg = BotConfig(
+        cache_dir=str(tmp_path),
+        trailing_stop_percentage=1.0,
+        trailing_stop_coeff=0.0,
+        trailing_stop_multiplier=1.0,
+    )
     tm = TradeManager(cfg, dh, None, None, None)
 
     first = {'n': 0}

--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -133,7 +133,17 @@ class DummyExchange:
         if self.fail:
             return {'retCode': 1}
         return {'id': '1'}
-    async def create_order_with_take_profit_and_stop_loss(self, symbol, type, side, amount, price, takeProfit, stopLoss, params):
+    async def create_order_with_take_profit_and_stop_loss(
+        self,
+        symbol,
+        type,
+        side,
+        amount,
+        price,
+        takeProfit,
+        stopLoss,
+        params,
+    ):
         self.orders.append({'method': 'create_order_with_tp_sl', 'symbol': symbol, 'type': type, 'side': side,
                              'amount': amount, 'price': price, 'tp': takeProfit, 'sl': stopLoss,
                              'params': params})

--- a/tests/test_trading_bot.py
+++ b/tests/test_trading_bot.py
@@ -299,8 +299,21 @@ async def test_monitor_positions_tp(monkeypatch):
     env = {'trade_manager_url': 'http://tm', 'data_handler_url': 'http://dh'}
     class DummyResp:
         status_code = 200
+
         def json(self):
-            return {'positions': [{'id': '1', 'symbol': 'BTCUSDT', 'side': 'buy', 'tp': 100, 'sl': 90, 'trailing_stop': None, 'entry_price': 95}]}
+            return {
+                'positions': [
+                    {
+                        'id': '1',
+                        'symbol': 'BTCUSDT',
+                        'side': 'buy',
+                        'tp': 100,
+                        'sl': 90,
+                        'trailing_stop': None,
+                        'entry_price': 95,
+                    }
+                ]
+            }
     called = {}
     class DummyClient:
         async def __aenter__(self):
@@ -334,8 +347,21 @@ async def test_monitor_positions_sl(monkeypatch):
     env = {'trade_manager_url': 'http://tm', 'data_handler_url': 'http://dh'}
     class DummyResp:
         status_code = 200
+
         def json(self):
-            return {'positions': [{'id': '2', 'symbol': 'BTCUSDT', 'side': 'buy', 'tp': None, 'sl': 90, 'trailing_stop': None, 'entry_price': 100}]}
+            return {
+                'positions': [
+                    {
+                        'id': '2',
+                        'symbol': 'BTCUSDT',
+                        'side': 'buy',
+                        'tp': None,
+                        'sl': 90,
+                        'trailing_stop': None,
+                        'entry_price': 100,
+                    }
+                ]
+            }
     called = {}
     class DummyClient:
         async def __aenter__(self):
@@ -369,8 +395,21 @@ async def test_monitor_positions_trailing_stop(monkeypatch):
     env = {'trade_manager_url': 'http://tm', 'data_handler_url': 'http://dh'}
     class DummyResp:
         status_code = 200
+
         def json(self):
-            return {'positions': [{'id': '3', 'symbol': 'BTCUSDT', 'side': 'buy', 'tp': None, 'sl': None, 'trailing_stop': 1, 'entry_price': 100}]}
+            return {
+                'positions': [
+                    {
+                        'id': '3',
+                        'symbol': 'BTCUSDT',
+                        'side': 'buy',
+                        'tp': None,
+                        'sl': None,
+                        'trailing_stop': 1,
+                        'entry_price': 100,
+                    }
+                ]
+            }
     called = {}
     class DummyClient:
         async def __aenter__(self):


### PR DESCRIPTION
## Summary
- add Ruff to the CI dependencies and configure linting defaults
- adjust formatting in core logic and tests to satisfy the tighter lint checks

## Testing
- python -m ruff check bot tests
- python -m mypy bot
- python -m bandit -r bot -x tests -ll
- python -m flake8 .
- pytest -m "not integration"
- pytest -m integration

------
https://chatgpt.com/codex/tasks/task_e_68c90a367c8c832dbc030b63c149b935