### PR TITLE
Fix GPT-OSS script import resolution

### DIFF
--- a/gptoss_check/main.py
+++ b/gptoss_check/main.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from pathlib import Path
-import os
+import importlib
 import logging
-
+import os
+import sys
+from pathlib import Path
 from typing import Optional
 
 
@@ -44,7 +45,12 @@ def main(config_path: Optional[Path] = None) -> None:
     try:
         from . import check_code  # package execution
     except ImportError:  # script execution
-        import check_code  # type: ignore
+        module_dir = Path(__file__).resolve().parent
+        package_name = module_dir.name
+        parent_dir = module_dir.parent
+        if str(parent_dir) not in sys.path:
+            sys.path.insert(0, str(parent_dir))
+        check_code = importlib.import_module(f"{package_name}.check_code")
     logger.info("Running GPT-OSS check...")
     check_code.run()
     logger.info("GPT-OSS check completed")


### PR DESCRIPTION
## Summary
- ensure the GPT-OSS check runner imports its module correctly when executed as a script
- add the parent directory to `sys.path` and import the package via `importlib`
- keep logging-based behaviour unchanged while supporting both package and script execution paths

## Testing
- `pytest tests/test_gptoss_check.py -q`
- `flake8 gptoss_check/main.py`
- `mypy gptoss_check/main.py`
- `TEST_MODE=1 GPT_OSS_API=http://127.0.0.1:9999 GPT_OSS_WAIT_TIMEOUT=1 python gptoss_check/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68c90a418f98832db2d91e07bf2a3a03