### PR TITLE
Add gymnasium stub fallback for tests

### DIFF
--- a/tests/test_model_builder_import.py
+++ b/tests/test_model_builder_import.py
@@ -24,6 +24,7 @@ def test_model_builder_requires_gymnasium(monkeypatch):
         monkeypatch.setitem(sys.modules, 'torch.utils', utils_stub)
         monkeypatch.setitem(sys.modules, 'torch.utils.data', data_stub)
     monkeypatch.setitem(sys.modules, 'gymnasium', None)
+    monkeypatch.setenv('ALLOW_GYM_STUB', '0')
     with pytest.raises(ImportError, match='gymnasium package is required'):
         importlib.import_module('model_builder')
 


### PR DESCRIPTION
## Summary
- add a lightweight gymnasium/stable-baselines stub that activates automatically in TEST_MODE when the real package is unavailable
- allow disabling the stub with an ALLOW_GYM_STUB flag so production imports still error when gymnasium is missing
- adjust the import test to disable the stub when verifying that an ImportError is raised

## Testing
- pytest -q --maxfail=1 --disable-warnings
- (.venv310) pytest -q --maxfail=1 --disable-warnings

------
https://chatgpt.com/codex/tasks/task_e_68c90a755d28832d8b1021713ed26a91