### PR TITLE
Fix jq payload construction in GPT-OSS review workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -106,7 +106,7 @@ jobs:
           payload=$(jq -n \
             --arg diff "$(cat diff.patch)" \
             --arg model "$model" \
-            '{model:$model, messages:[{role:"user", content:"Review the following diff and provide feedback:\n" + $diff}]}' )
+            '{model:$model, messages:[{role:"user", content:("Review the following diff and provide feedback:\n" + $diff)}]}' )
           resp=$(curl -sSf -H "Content-Type: application/json" -d "$payload" \
             http://127.0.0.1:8000/v1/chat/completions)
           review=$(echo "$resp" | jq -r '.choices[0].message.content // empty')


### PR DESCRIPTION
## Summary
- обернул конкатенацию строки в выражении jq, чтобы LLM review формировал корректный JSON-пейлоад без синтаксической ошибки

## Testing
- curl -sSf -H 'Content-Type: application/json' -d "$payload" http://127.0.0.1:8000/v1/chat/completions | jq '.choices[0].message.content'

------
https://chatgpt.com/codex/tasks/task_e_68c9417ea290832dadce4b6672a67835