### PR TITLE
Align numpy version across build configurations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "fastapi>=0.116.1",
     "aiohttp>=3.12.15",
     "pandas>=2.3.2",
-    "numpy>=2.3.3",
+    "numpy>=2.2.6",
     "pydantic>=2.11.7",
 ]
 

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -12,7 +12,7 @@ flask>=3.0.3,<4
 pydantic==2.11.9
 # gymnasium and scikit-learn are unavailable on some Python versions
 gymnasium==1.2.0; python_version<'3.12'
-# Pin older pandas to avoid incompatibilities with numpy
+# Pin pandas to stay compatible with the numpy version used across builds
 pandas==2.3.2
 polars>=1.6.0
 pyarrow>=15.0.0
@@ -22,14 +22,15 @@ werkzeug>=3.0.2,<4
 requests>=2.31.0
 httpx>=0.27.0
 # Newer scikit-learn releases pull in SciPy builds incompatible with our
-# pinned numpy; lock to a known working version.
+# pinned numpy; keep everything aligned with the Docker images.
 scikit-learn==1.7.2; python_version<'3.12'
 joblib>=1.3
 setuptools>=70.0.0
 types-requests
 mypy==1.18.1
 hypothesis>=6.90.0
-numpy==1.26.4
+# Keep numpy aligned with requirements-core.txt and Docker builds
+numpy==2.2.6
 pip-audit==2.9.0
 pybit>=5.7.0
 

--- a/requirements-core.in
+++ b/requirements-core.in
@@ -1,4 +1,4 @@
-numpy>=1.26.4  # core numeric library
+numpy>=2.2.6  # core numeric library
 pandas>=2.2.2
 ccxt==4.5.3
 ccxtpro>=0.9.0


### PR DESCRIPTION
## Summary
- align the declared numpy dependency with the version used in Docker and compiled requirement sets
- update CI requirements and documentation comments to keep pandas/scikit-learn compatibility notes accurate

## Testing
- python -m flake8 --exclude venv .
- python -m mypy --exclude venv .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c941691810832d88d89c85c2486cf6