### PR TITLE
Refine GPT-OSS review workflow robustness

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -101,21 +101,11 @@ jobs:
         if: steps.generate_diff.outputs.has_diff == 'true'
         id: llm_review
         run: |
-          set -euo pipefail
-          model="${MODEL_NAME}"
-          payload=$(jq -n \
-            --arg diff "$(cat diff.patch)" \
-            --arg model "$model" \
-            '{model:$model, messages:[{role:"user", content:("Review the following diff and provide feedback:\n" + $diff)}]}' )
-          resp=$(curl -sSf -H "Content-Type: application/json" -d "$payload" \
-            http://127.0.0.1:8000/v1/chat/completions)
-          review=$(echo "$resp" | jq -r '.choices[0].message.content // empty')
-          if [ -z "$review" ]; then
-            echo "has_content=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          printf "%s" "$review" > review.md
-          echo "has_content=true" >> "$GITHUB_OUTPUT"
+          python scripts/run_gptoss_review.py \
+            --diff diff.patch \
+            --output review.md \
+            --model "${MODEL_NAME}" \
+            --api-url http://127.0.0.1:8000/v1/chat/completions
 
       - name: Upload review artifact
         if: steps.llm_review.outputs.has_content == 'true'

--- a/scripts/run_gptoss_review.py
+++ b/scripts/run_gptoss_review.py
@@ -1,0 +1,184 @@
+"""Utility script used by the GPT-OSS review GitHub workflow.
+
+The workflow previously relied on shell pipelines with ``jq`` and ``curl`` to
+prepare the request payload and parse responses from the mock GPT-OSS server.
+That approach was brittle – any quoting issue or transient HTTP failure caused
+the entire job to exit with a non-zero status.  This module replaces the shell
+logic with a small Python implementation that gracefully handles errors and
+reports the result back to GitHub Actions via ``GITHUB_OUTPUT``.
+
+The module is intentionally free of third-party dependencies so it can run in
+the minimal GitHub runner environment.  It can also be imported from unit tests
+to validate individual helper functions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib import error, request
+
+_PROMPT_PREFIX = "Review the following diff and provide feedback:\n"
+
+
+class EmptyDiffError(RuntimeError):
+    """Raised when the diff file is missing or contains no meaningful data."""
+
+
+@dataclass
+class ReviewResult:
+    """Container for the generated review text and control flags."""
+
+    review: str
+    has_content: bool
+
+
+def _read_diff(diff_path: Path) -> str:
+    """Return diff contents, normalising encoding issues."""
+
+    try:
+        data = diff_path.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError as exc:  # pragma: no cover - handled by caller
+        raise EmptyDiffError(f"Diff файл {diff_path} не найден") from exc
+    except OSError as exc:  # pragma: no cover - unexpected filesystem error
+        raise RuntimeError(f"Не удалось прочитать diff {diff_path}: {exc}") from exc
+
+    if not data.strip():
+        raise EmptyDiffError(f"Diff файл {diff_path} пустой")
+    return data
+
+
+def _build_payload(diff_text: str, model: str | None) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "messages": [
+            {
+                "role": "user",
+                "content": f"{_PROMPT_PREFIX}{diff_text}",
+            }
+        ]
+    }
+    if model:
+        payload["model"] = model
+    return payload
+
+
+def _send_request(api_url: str, payload: dict[str, Any], timeout: float) -> dict[str, Any]:
+    data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    req = request.Request(
+        api_url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read()
+    except error.URLError as exc:
+        raise RuntimeError(f"Не удалось подключиться к GPT-OSS ({api_url}): {exc}") from exc
+
+    try:
+        return json.loads(raw.decode("utf-8"))
+    except ValueError as exc:
+        raise RuntimeError("Сервер GPT-OSS вернул некорректный JSON") from exc
+
+
+def _extract_review(response: dict[str, Any]) -> str:
+    """Pull textual review content from OpenAI-compatible response payloads."""
+
+    choices = response.get("choices")
+    if not isinstance(choices, list):
+        return ""
+    for choice in choices:
+        if not isinstance(choice, dict):
+            continue
+        message = choice.get("message")
+        if isinstance(message, dict):
+            content = message.get("content")
+            if isinstance(content, str) and content.strip():
+                return content.strip()
+        text = choice.get("text")
+        if isinstance(text, str) and text.strip():
+            return text.strip()
+    return ""
+
+
+def generate_review(
+    diff_path: Path,
+    model: str | None,
+    api_url: str,
+    timeout: float = 30.0,
+) -> ReviewResult:
+    """Produce a review for the supplied diff file."""
+
+    diff_text = _read_diff(diff_path)
+    payload = _build_payload(diff_text, model)
+    response = _send_request(api_url, payload, timeout)
+    review = _extract_review(response)
+    if not review:
+        raise RuntimeError("GPT-OSS не вернул текст отзыва")
+    return ReviewResult(review=review, has_content=True)
+
+
+def _write_github_output(has_content: bool) -> None:
+    """Append workflow outputs to the special file if available."""
+
+    output_path = os.getenv("GITHUB_OUTPUT")
+    if not output_path:
+        return
+    try:
+        with open(output_path, "a", encoding="utf-8") as fh:
+            fh.write(f"has_content={'true' if has_content else 'false'}\n")
+    except OSError as exc:  # pragma: no cover - extremely rare on GH runners
+        print(f"::warning::Не удалось записать GITHUB_OUTPUT: {exc}", file=sys.stderr)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate GPT-OSS review")
+    parser.add_argument("--diff", default="diff.patch", help="Путь к diff-файлу")
+    parser.add_argument(
+        "--output", default="review.md", help="Файл, куда сохранить отзыв"
+    )
+    parser.add_argument("--model", default=os.getenv("MODEL_NAME"))
+    parser.add_argument(
+        "--api-url",
+        default="http://127.0.0.1:8000/v1/chat/completions",
+        help="Адрес GPT-OSS API",
+    )
+    parser.add_argument("--timeout", type=float, default=30.0)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    diff_path = Path(args.diff)
+    output_path = Path(args.output)
+
+    try:
+        result = generate_review(diff_path, args.model, args.api_url, args.timeout)
+    except EmptyDiffError as exc:
+        print(f"::notice::{exc}", file=sys.stderr)
+        _write_github_output(False)
+        return 0
+    except RuntimeError as exc:
+        print(f"::warning::{exc}", file=sys.stderr)
+        _write_github_output(False)
+        return 0
+
+    try:
+        output_path.write_text(result.review, encoding="utf-8")
+    except OSError as exc:
+        print(f"::warning::Не удалось записать отзыв: {exc}", file=sys.stderr)
+        _write_github_output(False)
+        return 0
+
+    _write_github_output(result.has_content)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    raise SystemExit(main())

--- a/tests/test_run_gptoss_review.py
+++ b/tests/test_run_gptoss_review.py
@@ -1,0 +1,116 @@
+import threading
+import time
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+from urllib import request as urllib_request
+
+import pytest
+
+from scripts import gptoss_mock_server
+from scripts import run_gptoss_review
+
+
+@pytest.fixture()
+def gptoss_server_port():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), gptoss_mock_server._RequestHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    port = server.server_address[1]
+
+    for _ in range(50):
+        try:
+            with urllib_request.urlopen(
+                f"http://127.0.0.1:{port}/v1/models", timeout=0.2
+            ):
+                break
+        except Exception:
+            time.sleep(0.05)
+    else:  # pragma: no cover - extremely unlikely when server starts correctly
+        server.shutdown()
+        thread.join(timeout=1)
+        server.server_close()
+        pytest.fail("mock GPT-OSS server did not start in time")
+
+    try:
+        yield port
+    finally:
+        server.shutdown()
+        thread.join(timeout=1)
+        server.server_close()
+
+
+def _write_diff(path: Path) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "diff --git a/test.py b/test.py",
+                "+++ b/test.py",
+                "@@",
+                "+print('debug')",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_generate_review_success(tmp_path: Path, gptoss_server_port: int) -> None:
+    diff_path = tmp_path / "diff.patch"
+    _write_diff(diff_path)
+    api_url = f"http://127.0.0.1:{gptoss_server_port}/v1/chat/completions"
+
+    result = run_gptoss_review.generate_review(diff_path, "dummy", api_url)
+
+    assert result.has_content
+    assert "Автоматический обзор" in result.review
+
+
+def test_main_writes_review_and_output(tmp_path: Path, gptoss_server_port: int, monkeypatch):
+    diff_path = tmp_path / "diff.patch"
+    review_path = tmp_path / "review.md"
+    github_output = tmp_path / "gh_output.txt"
+    _write_diff(diff_path)
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+
+    exit_code = run_gptoss_review.main(
+        [
+            "--diff",
+            str(diff_path),
+            "--output",
+            str(review_path),
+            "--model",
+            "dummy-model",
+            "--api-url",
+            f"http://127.0.0.1:{gptoss_server_port}/v1/chat/completions",
+        ]
+    )
+
+    assert exit_code == 0
+    assert review_path.read_text(encoding="utf-8")
+    assert "has_content=true" in github_output.read_text(encoding="utf-8")
+
+
+def test_main_handles_missing_diff(tmp_path: Path, monkeypatch) -> None:
+    diff_path = tmp_path / "missing.patch"
+    review_path = tmp_path / "review.md"
+    github_output = tmp_path / "gh_output.txt"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+
+    exit_code = run_gptoss_review.main(
+        [
+            "--diff",
+            str(diff_path),
+            "--output",
+            str(review_path),
+            "--api-url",
+            "http://127.0.0.1:9999/v1/chat/completions",
+        ]
+    )
+
+    assert exit_code == 0
+    assert not review_path.exists()
+    assert "has_content=false" in github_output.read_text(encoding="utf-8")
+
+
+def test_extract_review_fallback_to_text() -> None:
+    response = {"choices": [{"text": " result "}]}
+    assert run_gptoss_review._extract_review(response) == "result"


### PR DESCRIPTION
## Summary
- replace the GPT-OSS review workflow shell pipeline with a Python helper that tolerates failures and writes workflow outputs
- add `scripts/run_gptoss_review.py` to prepare requests, parse responses and record review files
- introduce unit tests that exercise the new helper against the mock GPT-OSS server

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c948fbf918832d9610fa8bab95a1e6