### PR TITLE
Fix Docker build failure when NVIDIA packages absent

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -28,7 +28,12 @@ RUN python3 -m venv $VIRTUAL_ENV && \
     mkdir -p "$RAY_JARS_DIR" && \
     rm -f "$RAY_JARS_DIR"/commons-lang3-*.jar && \
     curl -fsSL https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar -o "$RAY_JARS_DIR"/commons-lang3-3.18.0.jar && \
-    $VIRTUAL_ENV/bin/pip freeze | grep -i '^nvidia-' | cut -d= -f1 | xargs -r $VIRTUAL_ENV/bin/pip uninstall -y && \
+    nvidia_packages="$($VIRTUAL_ENV/bin/pip freeze | grep -i '^nvidia-' || true)" && \
+    if [ -n "$nvidia_packages" ]; then \
+        printf '%s\n' "$nvidia_packages" | cut -d= -f1 | xargs -r $VIRTUAL_ENV/bin/pip uninstall -y; \
+    else \
+        echo "No NVIDIA packages detected in the virtual environment"; \
+    fi && \
     find $VIRTUAL_ENV -type d -name '__pycache__' -exec rm -rf {} + && \
     find $VIRTUAL_ENV -type f -name '*.pyc' -delete
 


### PR DESCRIPTION
## Summary
- guard the Dockerfile.cpu NVIDIA package removal step so builds succeed even when no GPU wheels are installed

## Testing
- not run (Dockerfile-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c95a1df810832d8bc33e594b37cb1a