### PR TITLE
Handle malformed GPT-OSS responses

### DIFF
--- a/scripts/run_gptoss_review.py
+++ b/scripts/run_gptoss_review.py
@@ -87,8 +87,11 @@ def _send_request(api_url: str, payload: dict[str, Any], timeout: float) -> dict
         raise RuntimeError("Сервер GPT-OSS вернул некорректный JSON") from exc
 
 
-def _extract_review(response: dict[str, Any]) -> str:
+def _extract_review(response: dict[str, Any] | Any) -> str:
     """Pull textual review content from OpenAI-compatible response payloads."""
+
+    if not isinstance(response, dict):
+        return ""
 
     choices = response.get("choices")
     if not isinstance(choices, list):
@@ -166,6 +169,13 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     except RuntimeError as exc:
         print(f"::warning::{exc}", file=sys.stderr)
+        _write_github_output(False)
+        return 0
+    except Exception as exc:  # pragma: no cover - defensive guard
+        print(
+            f"::error::Неожиданная ошибка при генерации обзора: {exc}",
+            file=sys.stderr,
+        )
         _write_github_output(False)
         return 0
 


### PR DESCRIPTION
## Summary
- guard the GPT-OSS review helper against malformed API payloads so unexpected shapes return empty feedback instead of crashing
- ensure the CLI logs and suppresses unforeseen exceptions while keeping workflow outputs consistent
- extend the GPT-OSS review tests to cover malformed payloads and unexpected exceptions

## Testing
- pytest tests/test_run_gptoss_review.py

------
https://chatgpt.com/codex/tasks/task_e_68c95a6fdcc0832dbd30bc2b953646c0