### PR TITLE
Handle missing GPT-OSS helper script in workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -101,6 +101,14 @@ jobs:
         if: steps.generate_diff.outputs.has_diff == 'true'
         id: llm_review
         run: |
+          if [ ! -f scripts/run_gptoss_review.py ]; then
+            echo "::notice::Скрипт scripts/run_gptoss_review.py не найден, пропускаю генерацию обзора"
+            if [ -n "${GITHUB_OUTPUT:-}" ]; then
+              echo "has_content=false" >> "${GITHUB_OUTPUT}"
+            fi
+            exit 0
+          fi
+
           python scripts/run_gptoss_review.py \
             --diff diff.patch \
             --output review.md \


### PR DESCRIPTION
## Summary
- skip the GPT-OSS review step gracefully when the helper script is absent
- keep GitHub step outputs consistent so downstream steps remain skipped

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c96195c288832dba086e20f74cbff5