### PR TITLE
chore: harden release drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -14,13 +14,27 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  RELEASE_DRAFTER_COMMIT: b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
+
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
+      - name: Validate Release Drafter reference
+        env:
+          RELEASE_DRAFTER_COMMIT: ${{ env.RELEASE_DRAFTER_COMMIT }}
+        run: |
+          set -euo pipefail
+          ref_url="https://api.github.com/repos/release-drafter/release-drafter/git/commits/${RELEASE_DRAFTER_COMMIT}"
+          if ! curl -sSfL -H 'Accept: application/vnd.github.v3+json' "$ref_url" >/dev/null; then
+            echo "Failed to resolve Release Drafter commit ${RELEASE_DRAFTER_COMMIT}." >&2
+            echo "Ensure the workflow pins a valid Release Drafter ref before re-running." >&2
+            exit 1
+          fi
       - name: Update release draft
         # Pin to the latest v6 release (v6.1.0). Release Drafter does not publish a v7 tag yet.
-        uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
+        uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5
         with:
           config-name: release-drafter.yml
         env:


### PR DESCRIPTION
## Summary
- fail the Release Drafter workflow early when the pinned action commit cannot be resolved
- document the pinned release-drafter commit through a shared environment variable for easier updates

## Testing
- actionlint .github/workflows/release-drafter.yml

------
https://chatgpt.com/codex/tasks/task_e_68c961a1b224832da14f93f6f030eca1