### PR TITLE
Validate HOST port parsing

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -245,3 +245,16 @@ def test_validate_host_invalid_port(monkeypatch):
     monkeypatch.setenv('HOST', '127.0.0.1:notaport')
     with pytest.raises(ValueError):
         utils.validate_host()
+
+
+def test_validate_host_port_out_of_range(monkeypatch):
+    monkeypatch.setenv('HOST', '127.0.0.1:70000')
+    with pytest.raises(ValueError):
+        utils.validate_host()
+
+
+@pytest.mark.parametrize('host', ['127.0.0.1:', '[::1]:'])
+def test_validate_host_missing_port_value(monkeypatch, host):
+    monkeypatch.setenv('HOST', host)
+    with pytest.raises(ValueError):
+        utils.validate_host()


### PR DESCRIPTION
## Summary
- ensure HOST validation requires explicit, in-range port numbers when a port suffix is provided
- extend utils tests to cover missing or out-of-range host port definitions

## Testing
- TEST_MODE=1 pytest -q --maxfail=1 --disable-warnings
- flake8 .
- bandit -r . -ll -x ./tests,./scripts,./gptoss_check

------
https://chatgpt.com/codex/tasks/task_e_68c961afbdcc832dbd795c1de05fff63