### PR TITLE
Handle CLI parsing errors in GPT-OSS review script

### DIFF
--- a/tests/test_run_gptoss_review.py
+++ b/tests/test_run_gptoss_review.py
@@ -121,6 +121,21 @@ def test_extract_review_handles_unexpected_payload() -> None:
     assert run_gptoss_review._extract_review({"choices": "invalid"}) == ""
 
 
+def test_parse_args_rejects_unknown_arguments() -> None:
+    with pytest.raises(ValueError):
+        run_gptoss_review._parse_args(["--unknown"])
+
+
+def test_main_handles_unknown_arguments(monkeypatch, tmp_path) -> None:
+    github_output = tmp_path / "gh_output.txt"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+
+    exit_code = run_gptoss_review.main(["--unknown"])  # type: ignore[arg-type]
+
+    assert exit_code == 0
+    assert "has_content=false" in github_output.read_text(encoding="utf-8")
+
+
 def test_main_handles_unexpected_exception(monkeypatch, tmp_path):
     diff_path = tmp_path / "diff.patch"
     diff_path.write_text("dummy", encoding="utf-8")


### PR DESCRIPTION
## Summary
- make the GPT-OSS review helper tolerate stray CLI flags so the workflow never exits with code 2
- emit informative warnings and set has_content=false when argument parsing fails
- extend the unit coverage to ensure unknown flags are handled gracefully

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c96c499730832db49da77287624b44