### PR TITLE
Harden release drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,7 +7,7 @@ on:
   pull_request_target:
     branches:
       - main
-    types: [opened, reopened, synchronize, labeled, unlabeled]
+    types: [opened, reopened, synchronize, labeled, unlabeled, edited]
   workflow_dispatch:
 
 permissions:
@@ -20,14 +20,31 @@ env:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    concurrency:
+      group: release-drafter-${{ github.ref }}
+      cancel-in-progress: false
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Validate Release Drafter reference
-        env:
-          RELEASE_DRAFTER_COMMIT: ${{ env.RELEASE_DRAFTER_COMMIT }}
         run: |
           set -euo pipefail
           ref_url="https://api.github.com/repos/release-drafter/release-drafter/git/commits/${RELEASE_DRAFTER_COMMIT}"
-          if ! curl -sSfL -H 'Accept: application/vnd.github.v3+json' "$ref_url" >/dev/null; then
+          curl_opts=(
+            --fail
+            --silent
+            --show-error
+            --location
+            --retry 5
+            --retry-delay 2
+            --retry-max-time 30
+            --connect-timeout 5
+          )
+          if ! curl "${curl_opts[@]}" \
+            -H 'Accept: application/vnd.github.v3+json' \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "$ref_url" >/dev/null; then
             echo "Failed to resolve Release Drafter commit ${RELEASE_DRAFTER_COMMIT}." >&2
             echo "Ensure the workflow pins a valid Release Drafter ref before re-running." >&2
             exit 1


### PR DESCRIPTION
## Summary
- add the pull_request_target edited event so title updates refresh the draft release
- serialize release drafter runs and authenticate commit validation to avoid transient API failures

## Testing
- python - <<'PY'
import yaml, sys
with open('.github/workflows/release-drafter.yml') as f:
    yaml.safe_load(f)
PY

------
https://chatgpt.com/codex/tasks/task_e_68c96c529854832db7bf04c3f624d86e