### PR TITLE
Trim whitespace when parsing HOST env values

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -241,6 +241,14 @@ def test_validate_host_ipv6_port(monkeypatch):
     assert utils.validate_host() == '::1'
 
 
+def test_validate_host_strips_whitespace_around_host_and_port(monkeypatch):
+    monkeypatch.setenv('HOST', ' 127.0.0.1 : 8080 ')
+    assert utils.validate_host() == '127.0.0.1'
+
+    monkeypatch.setenv('HOST', '[ ::1 ] : 9000')
+    assert utils.validate_host() == '::1'
+
+
 def test_validate_host_invalid_port(monkeypatch):
     monkeypatch.setenv('HOST', '127.0.0.1:notaport')
     with pytest.raises(ValueError):

--- a/utils.py
+++ b/utils.py
@@ -207,13 +207,15 @@ def validate_host() -> str:
         # IPv6 address, possibly in "[addr]:port" form
         end = host.find("]")
         if end != -1:
-            suffix = host[end + 1 :]
+            suffix = host[end + 1 :].strip()
             has_port = bool(suffix)
             port = suffix
-            host = host[1:end]
+            host = host[1:end].strip()
     else:
         if host.count(":") == 1:
-            host, port = host.split(":")
+            host_part, port_part = host.split(":", 1)
+            host = host_part.strip()
+            port = port_part
             has_port = True
 
     if port:


### PR DESCRIPTION
## Summary
- strip extraneous whitespace around HOST values before validating IPv4/IPv6 addresses and ports
- keep port validation strict while leaving loopback enforcement untouched
- add regression tests covering HOST values that include surrounding spaces

## Testing
- PYTHONHASHSEED=0 TEST_MODE=1 pytest -q --maxfail=1 --disable-warnings (Python 3.10.17)
- PYTHONHASHSEED=0 TEST_MODE=1 pytest -q --maxfail=1 --disable-warnings (Python 3.11.12)
- python -m flake8 .

------
https://chatgpt.com/codex/tasks/task_e_68c9a05e2ba4832db0b2bbc90ca080d3