### PR TITLE
ci: guard docker publish on non-release runs

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,6 +22,7 @@ jobs:
     env:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      PUBLISH_IMAGES: ${{ github.repository == 'averinaleks/bot' }}
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -110,13 +111,14 @@ jobs:
           df -h /mnt
 
       - name: Login to Docker Hub
-        if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ env.PUBLISH_IMAGES == 'true' && env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1  # v3
         with:
           username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ env.DOCKERHUB_TOKEN }}
 
       - name: Login to GHCR
+        if: ${{ env.PUBLISH_IMAGES == 'true' }}
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1  # v3
         with:
           registry: ghcr.io
@@ -130,9 +132,13 @@ jobs:
           OWNER: ${{ github.repository_owner }}
         run: |
           set -euo pipefail
-          tags="ghcr.io/${OWNER}/${MATRIX_IMAGE}:latest"
-          if [[ -n "${DOCKERHUB_USERNAME}" && -n "${DOCKERHUB_TOKEN}" ]]; then
-            tags="${tags}"$'\n'"docker.io/${DOCKERHUB_USERNAME}/${MATRIX_IMAGE}:latest"
+          if [[ "${PUBLISH_IMAGES}" == "true" ]]; then
+            tags="ghcr.io/${OWNER}/${MATRIX_IMAGE}:latest"
+            if [[ -n "${DOCKERHUB_USERNAME}" && -n "${DOCKERHUB_TOKEN}" ]]; then
+              tags="${tags}"$'\n'"docker.io/${DOCKERHUB_USERNAME}/${MATRIX_IMAGE}:latest"
+            fi
+          else
+            tags="local/${MATRIX_IMAGE}:ci-${GITHUB_RUN_ID}"
           fi
           {
             echo "list<<EOF"
@@ -145,13 +151,14 @@ jobs:
         with:
           context: .
           file: ${{ matrix.file }}
-          push: true
+          push: ${{ env.PUBLISH_IMAGES == 'true' }}
+          load: ${{ env.PUBLISH_IMAGES != 'true' }}
           tags: ${{ steps.tags.outputs.list }}
           cache-from: type=gha,scope=${{ matrix.image }}
           cache-to: type=gha,scope=${{ matrix.image }},mode=max
 
       - name: Cleanup before Trivy scan
-        if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ env.PUBLISH_IMAGES == 'true' && env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
         run: |
           sudo find /tmp -maxdepth 1 -name 'trivy-*' -exec rm -rf {} + || true
           sudo rm -rf /mnt/trivy-cache /mnt/trivy-tmp || true
@@ -159,12 +166,12 @@ jobs:
           sudo mkdir -p /mnt/trivy-cache
           sudo chown "$(id -u):$(id -g)" /mnt/trivy-cache
       - name: Prepare Trivy temp
-        if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ env.PUBLISH_IMAGES == 'true' && env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
         run: |
           sudo mkdir -p /mnt/trivy-tmp
           sudo chown "$(id -u):$(id -g)" /mnt/trivy-tmp
       - name: Run Trivy vulnerability scanner
-        if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ env.PUBLISH_IMAGES == 'true' && env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
         id: trivy
         uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8  # 0.33.1
         continue-on-error: true
@@ -178,11 +185,11 @@ jobs:
           output: ${{ matrix.artifact }}.txt
           scanners: vuln
       - name: Show Trivy scan results
-        if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' && steps.trivy.outcome == 'success' }}
+        if: ${{ env.PUBLISH_IMAGES == 'true' && env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' && steps.trivy.outcome == 'success' }}
         run: cat ${{ matrix.artifact }}.txt
 
       - name: Upload Trivy report artifact
-        if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' && steps.trivy.outcome == 'success' }}
+        if: ${{ env.PUBLISH_IMAGES == 'true' && env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' && steps.trivy.outcome == 'success' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: ${{ matrix.artifact }}


### PR DESCRIPTION
## Summary
- skip Docker Hub and GHCR logins and pushes when the workflow runs outside the main repository
- emit local tags and load images into the runner when publishing is disabled so builds still execute
- keep Trivy scanning gated behind both Docker Hub credentials and publish permission

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68c9a20a05bc832d9e6f1447754ee808