### PR TITLE
chore: bump vulnerable toolchain deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,8 @@ ENV VIRTUAL_ENV=/app/venv
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Устанавливаем зависимости (pip >=24.0 и устраняет CVE-2023-32681)
-RUN pip install --no-compile --no-cache-dir 'pip>=24.0' 'setuptools<81' wheel && \
+# Устанавливаем зависимости (pip >=24.0 устраняет CVE-2023-32681, setuptools>=78.1.1 закрывает свежие уязвимости)
+RUN pip install --no-compile --no-cache-dir 'pip>=24.0' 'setuptools>=78.1.1,<81' wheel && \
     pip install --no-compile --no-cache-dir -r requirements-core.txt -r requirements-gpu.txt && \
     RAY_JARS_DIR=$($VIRTUAL_ENV/bin/python -c "import os, ray; print(os.path.join(os.path.dirname(ray.__file__), 'jars'))") && \
     rm -f "$RAY_JARS_DIR"/commons-lang3-*.jar && \

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -21,8 +21,8 @@ COPY requirements-core.txt .
 
 ENV VIRTUAL_ENV=/app/venv
 RUN python3 -m venv $VIRTUAL_ENV && \
-    # pip >=24.0 устраняет CVE-2023-32681, setuptools>=70 нужен для сборки gymnasium
-    $VIRTUAL_ENV/bin/pip install --no-cache-dir 'pip>=24.0' 'setuptools>=70,<81' wheel && \
+    # pip >=24.0 устраняет CVE-2023-32681, setuptools>=78.1.1 закрывает актуальные уязвимости и подходит для сборки gymnasium
+    $VIRTUAL_ENV/bin/pip install --no-cache-dir 'pip>=24.0' 'setuptools>=78.1.1,<81' wheel && \
     $VIRTUAL_ENV/bin/pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -r requirements-core.txt && \
     RAY_JARS_DIR=$($VIRTUAL_ENV/bin/python -c "import os, ray; print(os.path.join(os.path.dirname(ray.__file__), 'jars'))") && \
     mkdir -p "$RAY_JARS_DIR" && \

--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -17,9 +17,9 @@ ENV PYTHONUNBUFFERED=1 HF_HOME=/workspace/hf-cache
 ENV VLLM_DEVICE=cpu VLLM_LOGGING_LEVEL=DEBUG
 
 RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch==2.3.1 \
+    && pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch==2.8.0+cpu \
     && pip install --no-cache-dir git+https://github.com/NICTA/pyairports \
-    && pip install --no-cache-dir vllm==0.6.3 \
+    && pip install --no-cache-dir vllm==0.10.2 \
     && pip install --no-cache-dir openai==1.99.1 \
     && rm -rf /root/.cache/pip
 

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -25,7 +25,7 @@ httpx>=0.27.0
 # pinned numpy; keep everything aligned with the Docker images.
 scikit-learn==1.7.2; python_version<'3.12'
 joblib>=1.3
-setuptools>=70.0.0
+setuptools>=78.1.1
 types-requests
 mypy==1.18.1
 hypothesis>=6.90.0


### PR DESCRIPTION
## Summary
- upgrade the GPT-OSS helper image to torch 2.8.0+cpu and vllm 0.10.2 to address reported CVEs
- require setuptools>=78.1.1 in the main and CPU Docker builds to keep patched toolchain versions
- align the CI requirements with the new setuptools floor

## Testing
- ⚠️ `pip-audit -r requirements-ci.txt` *(interrupted; building the isolated environment pulled heavyweight packages indefinitely)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a8078ce8832d8089581165bdfcc4