### PR TITLE
Handle GPT-OSS review CLI exit codes gracefully

### DIFF
--- a/scripts/run_gptoss_review.py
+++ b/scripts/run_gptoss_review.py
@@ -211,5 +211,28 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
+def cli(argv: list[str] | None = None) -> int:
+    """Wrapper around :func:`main` that shields CI from fatal exits."""
+
+    try:
+        return main(argv)
+    except SystemExit as exc:
+        code = exc.code  # ``code`` may be ``None`` or non-integer
+        if code not in (0, None):
+            print(
+                f"::warning::Скрипт завершился с кодом {code}. Возвращаю 0, чтобы не прерывать job.",
+                file=sys.stderr,
+            )
+            _write_github_output(False)
+        return 0
+    except BaseException as exc:  # pragma: no cover - defensive guard
+        print(
+            f"::error::Критическое исключение в CLI: {exc}",
+            file=sys.stderr,
+        )
+        _write_github_output(False)
+        return 0
+
+
 if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
-    raise SystemExit(main())
+    raise SystemExit(cli())

--- a/tests/test_run_gptoss_review.py
+++ b/tests/test_run_gptoss_review.py
@@ -151,3 +151,33 @@ def test_main_handles_unexpected_exception(monkeypatch, tmp_path):
 
     assert exit_code == 0
     assert "has_content=false" in github_output.read_text(encoding="utf-8")
+
+
+def test_cli_converts_system_exit(monkeypatch, tmp_path):
+    github_output = tmp_path / "gh_output.txt"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+
+    def _boom(_argv=None):
+        raise SystemExit(3)
+
+    monkeypatch.setattr(run_gptoss_review, "main", _boom)
+
+    exit_code = run_gptoss_review.cli([])
+
+    assert exit_code == 0
+    assert "has_content=false" in github_output.read_text(encoding="utf-8")
+
+
+def test_cli_handles_base_exception(monkeypatch, tmp_path):
+    github_output = tmp_path / "gh_output.txt"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+
+    def _boom(*_args, **_kwargs):
+        raise KeyboardInterrupt("stop")
+
+    monkeypatch.setattr(run_gptoss_review, "main", _boom)
+
+    exit_code = run_gptoss_review.cli([])
+
+    assert exit_code == 0
+    assert "has_content=false" in github_output.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- wrap the GPT-OSS review helper CLI with a safe entrypoint that converts non-zero SystemExit codes into workflow warnings
- extend the unit suite to cover the new CLI guard paths for SystemExit and BaseException scenarios

## Testing
- pytest tests/test_run_gptoss_review.py -q
- pytest tests/test_gptoss_mock_server.py -q

------
https://chatgpt.com/codex/tasks/task_e_68c9af185b34832d999c8542bda5e48a