### PR TITLE
Fix GPT-OSS mock service health endpoints

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -23,8 +23,10 @@ RUN pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir openai==1.99.1 \
     && rm -rf /root/.cache/pip
 
+COPY scripts/gptoss_mock_server.py /usr/local/bin/gptoss_mock_server.py
+
 EXPOSE 8000
 
-CMD ["python", "-m", "http.server", "8000"]
+CMD ["python", "/usr/local/bin/gptoss_mock_server.py", "--host", "0.0.0.0", "--port", "8000"]
 
 

--- a/scripts/gptoss_mock_server.py
+++ b/scripts/gptoss_mock_server.py
@@ -173,7 +173,10 @@ class _RequestHandler(BaseHTTPRequestHandler):
         self.wfile.write(data)
 
     def do_GET(self) -> None:  # noqa: N802 - required by BaseHTTPRequestHandler
-        if self.path.rstrip("/") == "/v1/models":
+        endpoint = self.path.rstrip("/") or "/"
+        if endpoint in {"/health", "/v1/health"}:
+            self._send_json({"status": "ok"})
+        elif endpoint == "/v1/models":
             self._send_json({"data": [{"id": _MODEL_NAME}]})
         else:
             self.send_error(HTTPStatus.NOT_FOUND)


### PR DESCRIPTION
## Summary
- run the dedicated mock GPT-OSS server inside the CI Docker image instead of the bare `http.server`
- add health endpoint handling so the mock service passes docker health checks

## Testing
- python -m flake8 --exclude venv,.venv .
- python -m mypy --exclude venv .
- pytest -ra

------
https://chatgpt.com/codex/tasks/task_e_68c9af323e0c832d8a07ef0abbdddc62