### PR TITLE
Handle unwritable model cache directories

### DIFF
--- a/tests/test_model_builder_cache.py
+++ b/tests/test_model_builder_cache.py
@@ -1,8 +1,12 @@
+import logging
 import sys
 import types
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
 import pytest
+
 from bot.config import BotConfig
 
 @pytest.fixture(autouse=True)
@@ -87,3 +91,58 @@ async def test_precompute_features_caches(monkeypatch, tmp_path):
     await mb.precompute_features("BTCUSDT")
     assert "BTCUSDT" in mb.feature_cache
     assert np.array_equal(mb.feature_cache["BTCUSDT"], feats)
+
+
+def test_model_builder_cache_fallback(monkeypatch, tmp_path):
+    from bot import model_builder
+
+    primary = tmp_path / "primary"
+    fallback_root = tmp_path / "fallback_root"
+    monkeypatch.setattr(model_builder.tempfile, "gettempdir", lambda: str(fallback_root))
+
+    calls: list[str] = []
+
+    class DummyCache:
+        def __init__(self, path: str) -> None:
+            self.cache_dir = path
+
+    def fake_cache(path: str) -> DummyCache:
+        calls.append(path)
+        if len(calls) == 1:
+            raise PermissionError("denied")
+        Path(path).mkdir(parents=True, exist_ok=True)
+        return DummyCache(path)
+
+    monkeypatch.setattr(model_builder, "HistoricalDataCache", fake_cache)
+
+    cfg = BotConfig(cache_dir=str(primary))
+    dh = DummyDH(make_df())
+    mb = model_builder.ModelBuilder(cfg, dh, DummyTM())
+
+    assert isinstance(mb.cache, DummyCache)
+    assert calls[0] == str(primary.resolve())
+    expected_fallback = (fallback_root / "model_builder_cache").resolve()
+    assert calls[1] == str(expected_fallback)
+    assert Path(mb.state_file).parent == expected_fallback
+    assert cfg["cache_dir"] == str(expected_fallback)
+
+
+def test_model_builder_cache_handles_total_failure(monkeypatch, tmp_path, caplog):
+    from bot import model_builder
+
+    monkeypatch.setattr(model_builder.tempfile, "gettempdir", lambda: str(tmp_path / "fallback"))
+
+    def boom(_path: str):
+        raise PermissionError("no access")
+
+    monkeypatch.setattr(model_builder, "HistoricalDataCache", boom)
+
+    cfg = BotConfig(cache_dir=str(tmp_path / "primary"))
+    dh = DummyDH(make_df())
+    with caplog.at_level(logging.WARNING):
+        mb = model_builder.ModelBuilder(cfg, dh, DummyTM())
+
+    assert mb.cache is None
+    expected_dir = (tmp_path / "fallback" / "model_builder_cache").resolve()
+    assert Path(mb.state_file).parent == expected_dir
+    assert expected_dir.exists()


### PR DESCRIPTION
## Summary
- initialise the ModelBuilder cache through a helper that falls back to a writable directory when the configured cache path cannot be used
- keep the ModelBuilder state file and configuration aligned with the resolved cache directory while logging any failures to prepare the cache
- extend the model builder cache test suite with scenarios covering permission errors and fallback behaviour

## Testing
- `PYTHONHASHSEED=0 TEST_MODE=1 pytest -q --maxfail=1 --disable-warnings`
- `flake8 .`
- `bandit -r . -ll -x ./tests,./scripts,./gptoss_check`


------
https://chatgpt.com/codex/tasks/task_e_68c9af8f4880832d8ae59b91d854f304