### PR TITLE
fix dependency graph workflow pip detector errors

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -30,4 +30,3 @@ jobs:
         uses: advanced-security/component-detection-dependency-submission-action@d433c2f467e149a8009c8fbce92cc708ed15ef7b # v0.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          detectorArgs: Pip=EnableIfDefaultOff


### PR DESCRIPTION
## Summary
- remove the optional pip detector from the dependency graph workflow so the job no longer logs certificate errors during scans

## Testing
- /tmp/component-detection scan --SourceDirectory /workspace/bot --LogLevel Information


------
https://chatgpt.com/codex/tasks/task_e_68c9afe2f188832d8d9a3bfad72a976c