### PR TITLE
Не запускать GPT-OSS review при событиях без PR

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -40,16 +40,30 @@ jobs:
       run:
         shell: bash
     env:
-      PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+      PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || '' }}
       MODEL_NAME: ${{ vars.LLM_MODEL || 'Qwen/Qwen2.5-Coder-0.5B-Instruct' }}
 
     steps:
+      - name: Проверка события
+        id: validate_event
+        run: |
+          set -euo pipefail
+          pr_number="${PR_NUMBER:-}"
+          if [ -z "$pr_number" ]; then
+            echo "::notice::Рабочий процесс запущен не для PR – пропускаю выполнение обзора."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+        if: steps.validate_event.outputs.skip != 'true'
         with:
           fetch-depth: 0
           ref: refs/pull/${{ env.PR_NUMBER }}/head
 
       - name: Choose free port for GPT-OSS mock
+        if: steps.validate_event.outputs.skip != 'true'
         id: choose_port
         run: |
           set -euo pipefail
@@ -65,9 +79,11 @@ PY
           echo "port=$port" >> "$GITHUB_OUTPUT"
 
       - name: Install jq
+        if: steps.validate_event.outputs.skip != 'true'
         run: sudo apt-get update && sudo apt-get install -y jq
 
       - name: Start mock GPT-OSS server
+        if: steps.validate_event.outputs.skip != 'true'
         run: |
           set -euo pipefail
           python scripts/gptoss_mock_server.py --host 127.0.0.1 --port "${LLM_PORT}" &
@@ -76,6 +92,7 @@ PY
           MODEL_NAME: ${{ env.MODEL_NAME }}
 
       - name: Wait for GPT-OSS server
+        if: steps.validate_event.outputs.skip != 'true'
         id: wait_llm
         run: |
           set -euo pipefail
@@ -92,7 +109,7 @@ PY
           exit 1
 
       - name: Generate diff
-        if: steps.wait_llm.conclusion == 'success'
+        if: steps.validate_event.outputs.skip != 'true' && steps.wait_llm.conclusion == 'success'
         id: generate_diff
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -113,7 +130,7 @@ PY
           echo "has_diff=true" >> "$GITHUB_OUTPUT"
 
       - name: LLM review
-        if: steps.generate_diff.outputs.has_diff == 'true'
+        if: steps.validate_event.outputs.skip != 'true' && steps.generate_diff.outputs.has_diff == 'true'
         id: llm_review
         run: |
           if [ ! -f scripts/run_gptoss_review.py ]; then
@@ -131,14 +148,14 @@ PY
             --api-url "http://127.0.0.1:${LLM_PORT}/v1/chat/completions"
 
       - name: Upload review artifact
-        if: steps.llm_review.outputs.has_content == 'true'
+        if: steps.validate_event.outputs.skip != 'true' && steps.llm_review.outputs.has_content == 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: gptoss-review-${{ env.PR_NUMBER }}
           path: review.md
 
       - name: Comment PR
-        if: steps.llm_review.outputs.has_content == 'true'
+        if: steps.validate_event.outputs.skip != 'true' && steps.llm_review.outputs.has_content == 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
         with:
           script: |


### PR DESCRIPTION
## Summary
- добавил проверку наличия номера PR перед запуском шагов GPT-OSS review
- прервал дальнейшие шаги, если проверка определяет неподдерживаемое событие
- защитил шаги артефактов и комментария условием skip

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c9bd2a1b18832da1359e3224e80040