### PR TITLE
Fix dependency graph workflow

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -25,7 +25,10 @@ jobs:
         with:
           python-version: '3.x'
       - name: Prepare requirements
-        run: sed -i '/^ccxtpro/d' requirements.out
+        run: |
+          if [ -f requirements.out ]; then
+            sed -i '/^ccxtpro/d' requirements.out
+          fi
       - name: Component detection
         uses: advanced-security/component-detection-dependency-submission-action@d433c2f467e149a8009c8fbce92cc708ed15ef7b # v0.1.0
         with:


### PR DESCRIPTION
## Summary
- prevent the dependency graph workflow from failing when requirements.out is missing by guarding the sed command

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9c9f759b0832d9b488175a34956cd