### PR TITLE
fix: trim release notes when exceeding size limit

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -18,3 +18,9 @@ change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 template: |
   ## Changes
   $CHANGES
+replacers:
+  - search: '/^([\s\S]{120000})([\s\S]+)/'
+    replace: |
+      $1
+
+      _Release notes truncated to satisfy GitHub's body size limit. Review the repository history for the complete list of merged pull requests._


### PR DESCRIPTION
## Summary
- add a release-drafter replacer that trims the generated notes to stay below GitHub's 125k character body limit and leave a truncation notice

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9ca654a34832dbc9fa8dcf1dde30d