### PR TITLE
Fix dependency graph workflow

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -25,8 +25,12 @@ jobs:
         with:
           python-version: '3.x'
       - name: Prepare requirements
-        run: sed -i '/^ccxtpro/d' requirements.out
+        run: |
+          if [ -f requirements.out ]; then
+            sed -i '/^ccxtpro/d' requirements.out
+          fi
       - name: Component detection
         uses: advanced-security/component-detection-dependency-submission-action@d433c2f467e149a8009c8fbce92cc708ed15ef7b # v0.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          detectorArgs: Pip=EnableIfDefaultOff


### PR DESCRIPTION
## Summary
- guard the optional requirements.out file before removing the ccxtpro entry
- enable the Pip detector when submitting dependencies to the GitHub dependency graph

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68c9ca4e920c832dbd4b8c04ae364a4e