### PR TITLE
Harden cache file handling and secrets

### DIFF
--- a/telegram_logger.py
+++ b/telegram_logger.py
@@ -123,8 +123,8 @@ class TelegramLogger(logging.Handler):
 
             parts = [message[i : i + 500] for i in range(0, len(message), 500)]
             for part in parts:
-                part_hash = hashlib.md5(
-                    part.encode("utf-8"), usedforsecurity=False
+                part_hash = hashlib.blake2s(
+                    part.encode("utf-8"), digest_size=16
                 ).hexdigest()
                 if part_hash == self.last_hash:
                     logger.debug("Повторное сообщение Telegram пропущено")

--- a/tests/test_telegram_logger.py
+++ b/tests/test_telegram_logger.py
@@ -176,7 +176,9 @@ async def test_hash_filter(monkeypatch):
     tl._queue.task_done()
 
     first_hash = tl.last_hash
-    expected_hash = hashlib.md5(message.encode("utf-8")).hexdigest()
+    expected_hash = hashlib.blake2s(
+        message.encode("utf-8"), digest_size=16
+    ).hexdigest()
     assert first_hash == expected_hash
 
     await tl.send_telegram_message(message, urgent=True)

--- a/utils.py
+++ b/utils.py
@@ -706,6 +706,17 @@ def sanitize_symbol(symbol: str) -> str:
     return re.sub(r'[^A-Za-z0-9._-]', '_', symbol)
 
 
+def sanitize_timeframe(timeframe: str) -> str:
+    """Validate that *timeframe* contains only safe characters."""
+
+    value = str(timeframe).strip()
+    if not value:
+        raise ValueError("Timeframe contains no valid characters")
+    if not re.fullmatch(r"[A-Za-z0-9_-]{1,32}", value):
+        raise ValueError(f"Invalid characters in timeframe: {timeframe!r}")
+    return value
+
+
 def filter_outliers_zscore(df, column="close", threshold=3.0):
     try:
         try:


### PR DESCRIPTION
## Summary
- sanitize timeframe inputs before persisting cache files and cover it with regression tests
- replace TelegramLogger deduplication hashes with BLAKE2s to avoid weak algorithms
- require a securely generated CSRF secret when the environment variable is missing and expose a reusable timeframe sanitizer

## Testing
- pytest tests/test_cache.py tests/test_data_handler_service_logging.py tests/test_data_handler_service_not_found.py tests/test_data_handler.py tests/test_simulation.py tests/test_telegram_logger.py tests/test_server_csrf_optional.py tests/test_server_csrf_unexpected.py

------
https://chatgpt.com/codex/tasks/task_e_68c9ca41d518832da3c5037877c5f983