### PR TITLE
Fix concurrency guard in GPT-OSS review workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -16,7 +16,11 @@ permissions:
 
 concurrency:
   group: >-
-    gptoss-review-${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+    gptoss-review-${{ github.workflow }}-${{
+      (github.event.pull_request && github.event.pull_request.number)
+        || (github.event.issue && github.event.issue.number)
+        || github.run_id
+    }}
   cancel-in-progress: true
 
 jobs:
@@ -40,7 +44,11 @@ jobs:
       run:
         shell: bash
     env:
-      PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || '' }}
+      PR_NUMBER: ${{
+        (github.event.pull_request && github.event.pull_request.number)
+          || (github.event.issue && github.event.issue.number)
+          || ''
+      }}
       MODEL_NAME: ${{ vars.LLM_MODEL || 'Qwen/Qwen2.5-Coder-0.5B-Instruct' }}
 
     steps:


### PR DESCRIPTION
## Summary
- guard the concurrency group expression so push events without pull request payload no longer fail immediately
- use the same defensive guard when computing the PR number environment variable

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c9c9c61e8c832d8a2cac2ea8569ec7