### PR TITLE
Handle structured GPT-OSS content

### DIFF
--- a/scripts/run_gptoss_review.py
+++ b/scripts/run_gptoss_review.py
@@ -104,6 +104,20 @@ def _extract_review(response: dict[str, Any] | Any) -> str:
             content = message.get("content")
             if isinstance(content, str) and content.strip():
                 return content.strip()
+            if isinstance(content, list):
+                pieces: list[str] = []
+                for part in content:
+                    if isinstance(part, str):
+                        if part:
+                            pieces.append(part)
+                        continue
+                    if isinstance(part, dict):
+                        text = part.get("text")
+                        if isinstance(text, str) and text:
+                            pieces.append(text)
+                combined = "".join(pieces).strip()
+                if combined:
+                    return combined
         text = choice.get("text")
         if isinstance(text, str) and text.strip():
             return text.strip()

--- a/tests/test_run_gptoss_review.py
+++ b/tests/test_run_gptoss_review.py
@@ -121,6 +121,23 @@ def test_extract_review_handles_unexpected_payload() -> None:
     assert run_gptoss_review._extract_review({"choices": "invalid"}) == ""
 
 
+def test_extract_review_supports_structured_content() -> None:
+    response = {
+        "choices": [
+            {
+                "message": {
+                    "content": [
+                        {"type": "text", "text": "Привет"},
+                        ", мир",
+                        {"type": "text", "text": "!"},
+                    ]
+                }
+            }
+        ]
+    }
+    assert run_gptoss_review._extract_review(response) == "Привет, мир!"
+
+
 def test_parse_args_rejects_unknown_arguments() -> None:
     with pytest.raises(ValueError):
         run_gptoss_review._parse_args(["--unknown"])


### PR DESCRIPTION
## Summary
- extend the GPT-OSS review parser to understand list-based chat message content
- add regression coverage for structured message payloads

## Testing
- pytest tests/test_run_gptoss_review.py -q
- pytest -k gptoss -q

------
https://chatgpt.com/codex/tasks/task_e_68c9d1ed9294832d99d585a34c48e20a