### PR TITLE
Add fallback job for unsupported GPT-OSS review events

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -24,6 +24,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  skip:
+    if: github.event_name != 'pull_request_target' && github.event_name != 'issue_comment'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip unsupported event
+        run: |
+          echo "Workflow triggered for ${{ github.event_name }} – no review required."
+
   review:
     if: >
       (


### PR DESCRIPTION
## Summary
- add a lightweight skip job so workflow runs triggered by non-PR events finish successfully

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca5a8faab4832da30f5734a15808a3