### PR TITLE
Fix Release Drafter validation script

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -27,24 +27,23 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Validate Release Drafter reference
+        env:
+          REF_URL: https://api.github.com/repos/release-drafter/release-drafter/git/commits/${{ env.RELEASE_DRAFTER_COMMIT }}
         run: |
           set -euo pipefail
-          ref_url="https://api.github.com/repos/release-drafter/release-drafter/git/commits/${RELEASE_DRAFTER_COMMIT}"
-          curl_opts=(
-            --fail
-            --silent
-            --show-error
-            --location
-            --retry 5
-            --retry-delay 2
-            --retry-max-time 30
-            --connect-timeout 5
-          )
-          if ! curl "${curl_opts[@]}" \
+          if ! curl \
+            --fail \
+            --silent \
+            --show-error \
+            --location \
+            --retry 5 \
+            --retry-delay 2 \
+            --retry-max-time 30 \
+            --connect-timeout 5 \
             -H 'Accept: application/vnd.github.v3+json' \
             -H "Authorization: Bearer ${GH_TOKEN}" \
             -H 'X-GitHub-Api-Version: 2022-11-28' \
-            "$ref_url" >/dev/null; then
+            "$REF_URL" >/dev/null; then
             echo "Failed to resolve Release Drafter commit ${RELEASE_DRAFTER_COMMIT}." >&2
             echo "Ensure the workflow pins a valid Release Drafter ref before re-running." >&2
             exit 1


### PR DESCRIPTION
## Summary
- simplify the Release Drafter validation step to avoid incorrect quoting
- construct the reference URL via an environment variable and pass curl options inline

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ca6c08330c832da55fd754a371bbdd