### PR TITLE
Ensure GPT-OSS review workflow starts reliably

### DIFF
--- a/scripts/gptoss_mock_server.py
+++ b/scripts/gptoss_mock_server.py
@@ -162,6 +162,13 @@ def _build_review(stats: DiffStats) -> str:
     return review
 
 
+class _Server(ThreadingHTTPServer):
+    """HTTP server with sane defaults for ephemeral port binding."""
+
+    allow_reuse_address = True
+    daemon_threads = True
+
+
 class _RequestHandler(BaseHTTPRequestHandler):
     server_version = "GptossMock/1.0"
 
@@ -276,7 +283,7 @@ def main() -> None:
     parser.add_argument("--port", type=int, default=8000)
     args = parser.parse_args()
 
-    server = ThreadingHTTPServer((args.host, args.port), _RequestHandler)
+    server = _Server((args.host, args.port), _RequestHandler)
     _install_signal_handlers(server)
     try:
         server.serve_forever()

--- a/tests/test_gptoss_mock_server.py
+++ b/tests/test_gptoss_mock_server.py
@@ -1,6 +1,5 @@
 import threading
 import time
-from http.server import ThreadingHTTPServer
 
 import httpx
 import pytest
@@ -10,7 +9,7 @@ from scripts import gptoss_mock_server
 
 @pytest.fixture()
 def mock_gptoss_server():
-    server = ThreadingHTTPServer(("127.0.0.1", 0), gptoss_mock_server._RequestHandler)
+    server = gptoss_mock_server._Server(("127.0.0.1", 0), gptoss_mock_server._RequestHandler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     port = server.server_address[1]

--- a/tests/test_run_gptoss_review.py
+++ b/tests/test_run_gptoss_review.py
@@ -1,18 +1,17 @@
 import threading
 import time
-from http.server import ThreadingHTTPServer
+from scripts import gptoss_mock_server
 from pathlib import Path
 from urllib import request as urllib_request
 
 import pytest
 
-from scripts import gptoss_mock_server
 from scripts import run_gptoss_review
 
 
 @pytest.fixture()
 def gptoss_server_port():
-    server = ThreadingHTTPServer(("127.0.0.1", 0), gptoss_mock_server._RequestHandler)
+    server = gptoss_mock_server._Server(("127.0.0.1", 0), gptoss_mock_server._RequestHandler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     port = server.server_address[1]


### PR DESCRIPTION
## Summary
- allow the mock GPT-OSS HTTP server to reuse recently bound ports and run handler threads as daemons
- update the GPT-OSS review tests to instantiate the new reusable server class

## Testing
- pytest tests/test_gptoss_mock_server.py tests/test_run_gptoss_review.py

------
https://chatgpt.com/codex/tasks/task_e_68ca6b812f14832d965e303f0fd38954