### PR TITLE
Simplify GPT-OSS mock Docker image for CPU CI

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -1,39 +1,19 @@
 FROM python:3.11-slim
-ARG DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libtbbmalloc2 libnuma1 curl git \
-    && apt-get install -y --no-install-recommends gnupg dirmngr \
-    && apt-get install -y --no-install-recommends --only-upgrade libpam0g libpam-modules \
-    && rm -rf /var/lib/apt/lists/* \
-    && gpg --version \
-    && dirmngr --version
-
-# Ensure curl is up to date
-RUN apt-get update && apt-get install -y --no-install-recommends --only-upgrade curl libpam0g libpam-modules \
-    && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONUNBUFFERED=1 HF_HOME=/workspace/hf-cache
 ENV VLLM_DEVICE=cpu VLLM_LOGGING_LEVEL=DEBUG
 
-RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch==2.8.0+cpu \
-    && pip install --no-cache-dir git+https://github.com/NICTA/pyairports \
-    && pip install --no-cache-dir vllm==0.10.2 \
-    && pip install --no-cache-dir openai==1.99.1 \
-    && rm -rf /root/.cache/pip
-
-COPY scripts/gptoss_mock_server.py /usr/local/bin/gptoss_mock_server.py
-
-EXPOSE 8000
-
-# Use a non-root user for running the mock server
-RUN groupadd --system bot && useradd --system --gid bot --home-dir /home/bot --shell /bin/bash bot \
+RUN groupadd --system bot \
+    && useradd --system --gid bot --home-dir /home/bot --shell /bin/bash bot \
     && mkdir -p /home/bot \
-    && chown bot:bot /usr/local/bin/gptoss_mock_server.py \
     && chown -R bot:bot /home/bot
 
+COPY scripts/gptoss_mock_server.py /usr/local/bin/gptoss_mock_server.py
+RUN chown bot:bot /usr/local/bin/gptoss_mock_server.py
+
 USER bot
+
+EXPOSE 8000
 
 CMD ["python", "/usr/local/bin/gptoss_mock_server.py", "--host", "0.0.0.0", "--port", "8000"]
 

--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -20,6 +20,18 @@ services:
     environment:
       VLLM_TARGET_DEVICE: cpu
 
+  data_handler:
+    profiles: ["gpu-required"]
+
+  model_builder:
+    profiles: ["gpu-required"]
+
+  trade_manager:
+    profiles: ["gpu-required"]
+
+  bot:
+    profiles: ["gpu-required"]
+
 networks:
   gptoss_net:
     name: gptoss_net


### PR DESCRIPTION
## Summary
- replace the GPT-OSS mock Docker image with a lightweight Python slim image that only copies the mock server script
- mark GPU-focused services with a dedicated profile in the CPU docker-compose override so they are skipped during CI

## Testing
- pytest
- python -m mypy --exclude venv .
- python -m flake8 --exclude venv .

------
https://chatgpt.com/codex/tasks/task_e_68ca6bfa8678832d94c56f236131b428