### PR TITLE
Fix CPU compose GPU requirements

### DIFF
--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -20,6 +20,18 @@ services:
     environment:
       VLLM_TARGET_DEVICE: cpu
 
+  model_builder:
+    deploy:
+      resources:
+        reservations:
+          devices: []
+
+  trade_manager:
+    deploy:
+      resources:
+        reservations:
+          devices: []
+
 networks:
   gptoss_net:
     name: gptoss_net


### PR DESCRIPTION
## Summary
- remove GPU device reservations from the CPU docker compose override so services can start on CPU-only runners

## Testing
- pytest -q --maxfail=1 --disable-warnings

------
https://chatgpt.com/codex/tasks/task_e_68ca6c172c18832db886b619ba27f22f