### PR TITLE
Handle GPT-OSS timeouts gracefully

### DIFF
--- a/scripts/run_gptoss_review.py
+++ b/scripts/run_gptoss_review.py
@@ -21,6 +21,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+import socket
 from urllib import error, request
 
 _PROMPT_PREFIX = "Review the following diff and provide feedback:\n"
@@ -78,7 +79,7 @@ def _send_request(api_url: str, payload: dict[str, Any], timeout: float) -> dict
     try:
         with request.urlopen(req, timeout=timeout) as resp:
             raw = resp.read()
-    except error.URLError as exc:
+    except (error.URLError, socket.timeout, TimeoutError) as exc:
         raise RuntimeError(f"Не удалось подключиться к GPT-OSS ({api_url}): {exc}") from exc
 
     try:

--- a/tests/test_run_gptoss_review.py
+++ b/tests/test_run_gptoss_review.py
@@ -110,6 +110,23 @@ def test_main_handles_missing_diff(tmp_path: Path, monkeypatch) -> None:
     assert "has_content=false" in github_output.read_text(encoding="utf-8")
 
 
+def test_main_handles_timeout(monkeypatch, tmp_path):
+    diff_path = tmp_path / "diff.patch"
+    diff_path.write_text("dummy", encoding="utf-8")
+    github_output = tmp_path / "gh_output.txt"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+
+    def _timeout(*_args, **_kwargs):
+        raise TimeoutError("boom")
+
+    monkeypatch.setattr(run_gptoss_review.request, "urlopen", _timeout)
+
+    exit_code = run_gptoss_review.main(["--diff", str(diff_path)])
+
+    assert exit_code == 0
+    assert "has_content=false" in github_output.read_text(encoding="utf-8")
+
+
 def test_extract_review_fallback_to_text() -> None:
     response = {"choices": [{"text": " result "}]}
     assert run_gptoss_review._extract_review(response) == "result"


### PR DESCRIPTION
## Summary
- extend the GPT-OSS review helper to treat socket- and TimeoutError failures as connection errors so the workflow reports a warning instead of an unexpected error
- add a regression test that simulates a timeout to ensure the CLI still reports `has_content=false`

## Testing
- pytest tests/test_run_gptoss_review.py
- pytest tests/test_gptoss_mock_server.py

------
https://chatgpt.com/codex/tasks/task_e_68cae6899dbc832da53cdfd03168570d