### PR TITLE
Fix GPT-OSS review workflow port selection

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -79,7 +79,7 @@ jobs:
         id: choose_port
         run: |
           set -euo pipefail
-            port=$(python -c "import socket; sock=socket.socket(); sock.bind(('127.0.0.1', 0)); print(sock.getsockname()[1]); sock.close()")
+          port=$(python -c "import socket; sock = socket.socket(); sock.bind(('127.0.0.1', 0)); print(sock.getsockname()[1]); sock.close()")
           echo "LLM_PORT=$port" >> "$GITHUB_ENV"
           echo "port=$port" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- fix the GPT-OSS review workflow port selection step so the Python command executes correctly

## Testing
- no tests were run (not needed for this change)

------
https://chatgpt.com/codex/tasks/task_e_68caed2ab9e8832d843cf38373989ffe