### PR TITLE
Install curl in GPT-OSS Docker image

### DIFF
--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -3,7 +3,10 @@ FROM python:3.11-slim
 ENV PYTHONUNBUFFERED=1 HF_HOME=/workspace/hf-cache
 ENV VLLM_DEVICE=cpu VLLM_LOGGING_LEVEL=DEBUG
 
-RUN groupadd --system bot \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --system bot \
     && useradd --system --gid bot --home-dir /home/bot --shell /bin/bash bot \
     && mkdir -p /home/bot \
     && chown -R bot:bot /home/bot


### PR DESCRIPTION
## Summary
- install curl into the GPT-OSS mock server image so container health checks succeed

## Testing
- python -m flake8
- python -m mypy --exclude venv .
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68caed8b9760832db00744efdc5bde69