### PR TITLE
Bump setuptools to address security advisories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=78.1.1", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/requirements-core.in
+++ b/requirements-core.in
@@ -35,4 +35,5 @@ openai==1.107.3
 jsonschema==4.25.1
 pytest-asyncio>=1.1
 backports-asyncio-runner==1.2.0; python_version < "3.11"
+setuptools>=78.1.1,<81
 

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -508,4 +508,5 @@ zipp==3.23.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools
+setuptools>=78.1.1,<81
+    # via -r requirements-core.in

--- a/requirements-gpu.in
+++ b/requirements-gpu.in
@@ -2,3 +2,4 @@ cupy-cuda12x>=13.5.1
 torch==2.8.0
 tensorflow==2.20.0
 jsonschema==4.25.1
+setuptools>=78.1.1,<81

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -136,4 +136,5 @@ wrapt==1.17.3
     # via tensorflow
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools
+setuptools>=78.1.1,<81
+    # via -r requirements-gpu.in

--- a/requirements.out
+++ b/requirements.out
@@ -699,4 +699,7 @@ zipp==3.23.0
     #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools
+setuptools>=78.1.1,<81
+    # via
+    #   -r requirements-core.in
+    #   -r requirements-gpu.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -627,4 +627,5 @@ zipp==3.23.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools
+setuptools>=78.1.1,<81
+    # via -r requirements-core.in

--- a/scripts/setup-tests.sh
+++ b/scripts/setup-tests.sh
@@ -2,4 +2,5 @@
 set -e
 # Install packages required for running the unit tests.
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+python -m pip install --upgrade 'pip>=24.0' 'setuptools>=78.1.1,<81' wheel
 python -m pip install -r "$REPO_ROOT/requirements.txt"


### PR DESCRIPTION
## Summary
- raise the build-system requirement to setuptools 78.1.1 to cover recent CVEs
- require the patched setuptools release across CPU/GPU requirements and test setup scripts so environments upgrade automatically

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68caf1dc19d4832d81a32cfe08bc46c0