### PR TITLE
Sanitize logging inputs for CodeQL compliance

### DIFF
--- a/http_client.py
+++ b/http_client.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, Generator, Tuple
 import httpx
 
 from bot.utils import retry
+from services.logging_utils import sanitize_log_value
 
 # Use system-level randomness for jitter to avoid predictable retry delays
 _RNG = random.SystemRandom()
@@ -26,7 +27,7 @@ try:
 except ValueError:
     logging.warning(
         "Invalid MODEL_DOWNLOAD_TIMEOUT '%s'; using default timeout 10s",
-        DEFAULT_TIMEOUT_STR,
+        sanitize_log_value(DEFAULT_TIMEOUT_STR),
     )
     DEFAULT_TIMEOUT = 10.0
 

--- a/services/offline.py
+++ b/services/offline.py
@@ -7,6 +7,7 @@ import os
 from collections.abc import Mapping
 
 from bot.config import OFFLINE_MODE
+from services.logging_utils import sanitize_log_value
 
 logger = logging.getLogger("TradingBot")
 
@@ -47,7 +48,7 @@ def ensure_offline_env(defaults: Mapping[str, str] | None = None) -> list[str]:
         applied.append(key)
         logger.warning(
             "OFFLINE_MODE=1: переменная %s не задана; используется фиктивное значение",
-            key,
+            sanitize_log_value(key),
         )
     return applied
 
@@ -101,7 +102,7 @@ class OfflineTelegram(logging.Handler):
         self.chat_id = kwargs.get("chat_id")
 
     async def send_telegram_message(self, message: str, urgent: bool = False) -> None:
-        logger.info("[OFFLINE TELEGRAM] %s", message)
+        logger.info("[OFFLINE TELEGRAM] %s", sanitize_log_value(message))
 
     def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - logging
         pass

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -20,6 +20,7 @@ from bot.dotenv_utils import load_dotenv
 from bot.gpt_client import GPTClientError, GPTClientJSONError, query_gpt_json_async
 from telegram_logger import TelegramLogger
 from utils import retry, suppress_tf_logs
+from services.logging_utils import sanitize_log_value
 
 try:  # pragma: no cover - optional dependency
     import ccxt  # type: ignore
@@ -68,17 +69,26 @@ def safe_number(env_var: str, default: T, cast: Callable[[str], T]) -> T:
         result = cast(value)
     except (TypeError, ValueError):
         logger.warning(
-            "Invalid %s value '%s', using default %s", env_var, value, default
+            "Invalid %s value '%s', using default %s",
+            sanitize_log_value(env_var),
+            sanitize_log_value(value),
+            default,
         )
         return default
     if isinstance(result, float) and not math.isfinite(result):
         logger.warning(
-            "Invalid %s value '%s', using default %s", env_var, value, default
+            "Invalid %s value '%s', using default %s",
+            sanitize_log_value(env_var),
+            sanitize_log_value(value),
+            default,
         )
         return default
     if result <= 0:
         logger.warning(
-            "Non-positive %s value '%s', using default %s", env_var, value, default
+            "Non-positive %s value '%s', using default %s",
+            sanitize_log_value(env_var),
+            sanitize_log_value(value),
+            default,
         )
         return default
     return result

--- a/utils.py
+++ b/utils.py
@@ -14,6 +14,8 @@ from typing import Callable, Dict, List, Optional, TypeVar
 
 import httpx
 
+from services.logging_utils import sanitize_log_value
+
 
 logger = logging.getLogger("TradingBot")
 
@@ -77,7 +79,10 @@ def configure_logging() -> None:
     try:
         logger.setLevel(level_name)
     except ValueError:
-        logger.warning("LOG_LEVEL '%s' недопустим, используется INFO", level_name)
+        logger.warning(
+            "LOG_LEVEL '%s' недопустим, используется INFO",
+            sanitize_log_value(level_name),
+        )
         logger.setLevel(logging.INFO)
 
     log_dir = os.getenv("LOG_DIR", "/app/logs")
@@ -245,11 +250,13 @@ def validate_host() -> str:
     except ValueError:
         if re.fullmatch(r"\d{1,3}(?:\.\d{1,3}){3}", host):
             raise ValueError(f"Некорректный IP: {host}")
-        logger.warning("HOST '%s' не локальный хост", host)
+        safe_host = sanitize_log_value(host)
+        logger.warning("HOST '%s' не локальный хост", safe_host)
         raise ValueError(f"HOST '{host}' не локальный хост")
     else:
         if not ip.is_loopback:
-            logger.warning("HOST '%s' не локальный хост", host)
+            safe_host = sanitize_log_value(host)
+            logger.warning("HOST '%s' не локальный хост", safe_host)
             raise ValueError(f"HOST '{host}' не локальный хост")
         return str(ip)
 
@@ -271,8 +278,8 @@ def safe_int(
             if env_var:
                 logger.warning(
                     "Non-positive %s value '%s', using default %s",
-                    env_var,
-                    value,
+                    sanitize_log_value(env_var),
+                    sanitize_log_value(value),
                     default,
                 )
             return default
@@ -281,8 +288,8 @@ def safe_int(
         if env_var:
             logger.warning(
                 "Invalid %s value '%s', using default %s",
-                env_var,
-                value,
+                sanitize_log_value(env_var),
+                sanitize_log_value(value),
                 default,
             )
         return default


### PR DESCRIPTION
## Summary
- sanitize environment-provided values before logging in utils, trading bot, server, and offline service code
- mask HTTP header data and request metadata logged by the FastAPI server
- ensure HTTP client timeout warnings escape control characters to prevent log injection

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68caf674aea8832d8052439ff6ba603d