### PR TITLE
Improve GPT-OSS review parsing

### DIFF
--- a/tests/test_run_gptoss_review.py
+++ b/tests/test_run_gptoss_review.py
@@ -154,6 +154,37 @@ def test_extract_review_supports_structured_content() -> None:
     assert run_gptoss_review._extract_review(response) == "Привет, мир!"
 
 
+def test_extract_review_supports_dict_content() -> None:
+    response = {
+        "choices": [
+            {
+                "message": {
+                    "content": {
+                        "text": "Привет",
+                        "content": [
+                            {"text": ", "},
+                            {"text": "мир"},
+                            {"content": [{"text": "!"}]},
+                        ],
+                    }
+                }
+            }
+        ]
+    }
+
+    assert run_gptoss_review._extract_review(response) == "Привет, мир!"
+
+
+def test_extract_review_handles_choice_level_content() -> None:
+    response = {
+        "choices": [
+            {"content": [{"text": "А"}, {"content": [{"text": "Б"}]}]},
+        ]
+    }
+
+    assert run_gptoss_review._extract_review(response) == "АБ"
+
+
 def test_parse_args_rejects_unknown_arguments() -> None:
     with pytest.raises(ValueError):
         run_gptoss_review._parse_args(["--unknown"])


### PR DESCRIPTION
## Summary
- make the GPT-OSS review parser resilient to nested content dictionaries and choice-level payloads
- cover the new response shapes with dedicated unit tests for the review script

## Testing
- pytest tests/test_run_gptoss_review.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68caf6890440832d93c85104483d5cf8