### PR TITLE
Install libgomp1 in CPU Docker image

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -44,6 +44,8 @@ RUN apt-get update && apt-get dist-upgrade -y \
     && apt-get install -y --no-install-recommends \
         libssl3t64 \
         python3.12-minimal \
+        # Библиотека OpenMP требуется бинарям scikit-learn и NumPy.
+        libgomp1 \
         curl \
         python3 \
         # Исключаем tar, чтобы избежать CVE-2025-45582


### PR DESCRIPTION
## Summary
- add libgomp1 to the CPU runtime image so OpenMP-enabled wheels (e.g. scikit-learn, NumPy) import correctly
- document why the extra runtime dependency is required

## Testing
- not run (Dockerfile-only change)

------
https://chatgpt.com/codex/tasks/task_e_68cb0a357a1c832d8daafbc3e908fb6b