### PR TITLE
Fix MLflow disable list typing

### DIFF
--- a/security.py
+++ b/security.py
@@ -29,7 +29,7 @@ def apply_ray_security_defaults(params: dict[str, Any]) -> dict[str, Any]:
     return hardened
 
 
-_MLFLOW_DISABLED_ATTRS: tuple[tuple[str, ...], str] = (
+_MLFLOW_DISABLED_ATTRS: tuple[tuple[tuple[str, ...], str], ...] = (
     (("pyfunc",), "load_model"),
     (("sklearn",), "load_model"),
     (("pytorch",), "load_model"),


### PR DESCRIPTION
## Summary
- correct the MLflow hardening constant type annotation so mypy handles the iteration

## Testing
- python -m ruff check bot tests
- python -m mypy bot
- python -m bandit -r bot -x tests -ll
- python -m flake8 .
- pytest -m "not integration"


------
https://chatgpt.com/codex/tasks/task_e_68cb0a3f1f98832da70a22fa4eb7bf89