### PR TITLE
Fix MLflow hardening typing for mypy

### DIFF
--- a/security.py
+++ b/security.py
@@ -29,7 +29,7 @@ def apply_ray_security_defaults(params: dict[str, Any]) -> dict[str, Any]:
     return hardened
 
 
-_MLFLOW_DISABLED_ATTRS: tuple[tuple[str, ...], str] = (
+_MLFLOW_DISABLED_ATTRS: tuple[tuple[tuple[str, ...], str], ...] = (
     (("pyfunc",), "load_model"),
     (("sklearn",), "load_model"),
     (("pytorch",), "load_model"),


### PR DESCRIPTION
## Summary
- correct the `_MLFLOW_DISABLED_ATTRS` annotation so mypy recognises the nested tuples

## Testing
- python -m flake8 --exclude venv .
- python -m mypy --exclude venv .
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cb0a48a6f0832da531227a601d8d37