### PR TITLE
Fix mypy typing for MLflow hardening

### DIFF
--- a/security.py
+++ b/security.py
@@ -29,7 +29,7 @@ def apply_ray_security_defaults(params: dict[str, Any]) -> dict[str, Any]:
     return hardened
 
 
-_MLFLOW_DISABLED_ATTRS: tuple[tuple[str, ...], str] = (
+_MLFLOW_DISABLED_ATTRS: tuple[tuple[tuple[str, ...], str], ...] = (
     (("pyfunc",), "load_model"),
     (("sklearn",), "load_model"),
     (("pytorch",), "load_model"),


### PR DESCRIPTION
## Summary
- fix the `_MLFLOW_DISABLED_ATTRS` type annotation so mypy understands the nested tuples

## Testing
- pytest
- mypy .

------
https://chatgpt.com/codex/tasks/task_e_68cb0a56888c832db784755de222b1f5