### PR TITLE
chore: refine dependency graph workflow pip detector

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -52,4 +52,4 @@ jobs:
         uses: advanced-security/component-detection-dependency-submission-action@d433c2f467e149a8009c8fbce92cc708ed15ef7b # v0.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          detectorArgs: Pip=EnableIfDefaultOff
+          detectorArgs: PipReport=EnableIfDefaultOff


### PR DESCRIPTION
## Summary
- switch the dependency graph submission workflow to enable the PipReport detector instead of the Pip detector to avoid SSL failures when scanning requirements

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cb0a635684832dbc903c2d51c75c2a