### PR TITLE
Handle unwritable model directories with safe fallbacks

### DIFF
--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -20,6 +20,7 @@ from flask import Flask, jsonify, request
 from numpy.typing import NDArray
 
 from bot.dotenv_utils import load_dotenv
+from bot.utils import ensure_writable_directory
 from utils import safe_int, validate_host
 from services.logging_utils import sanitize_log_value
 
@@ -91,8 +92,11 @@ NN_FRAMEWORK = os.getenv("NN_FRAMEWORK", _CFG.get("nn_framework", "sklearn")).lo
 if os.getenv("TEST_MODE") == "1" and "NN_FRAMEWORK" not in os.environ:
     NN_FRAMEWORK = "sklearn"
 MODEL_TYPE = _CFG.get("model_type", "transformer")
-MODEL_DIR = Path(os.getenv("MODEL_DIR", "."))
-MODEL_DIR.mkdir(parents=True, exist_ok=True)
+MODEL_DIR = ensure_writable_directory(
+    Path(os.getenv("MODEL_DIR", ".")),
+    description="моделей",
+    fallback_subdir="trading_bot_models",
+)
 
 _models: Dict[str, Any] = {}
 _scalers: Dict[str, Any] = {}

--- a/tests/test_model_builder_model_dir.py
+++ b/tests/test_model_builder_model_dir.py
@@ -1,0 +1,59 @@
+import importlib.util
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+def _load_model_builder(module_name: str) -> object:
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        Path(__file__).resolve().parents[1] / "model_builder.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(module_name, None)
+    return module
+
+
+def test_model_dir_fallback(monkeypatch, tmp_path):
+    monkeypatch.setenv("TEST_MODE", "1")
+    primary = tmp_path / "primary"
+    fallback_root = tmp_path / "fallback_root"
+    monkeypatch.setenv("MODEL_DIR", str(primary))
+    monkeypatch.setattr(tempfile, "gettempdir", lambda: str(fallback_root))
+
+    primary_resolved = primary.resolve()
+    original_mkdir = Path.mkdir
+
+    def fake_mkdir(self, mode=0o777, parents=False, exist_ok=False):
+        if self == primary_resolved:
+            raise PermissionError("denied")
+        return original_mkdir(self, mode=mode, parents=parents, exist_ok=exist_ok)
+
+    monkeypatch.setattr(Path, "mkdir", fake_mkdir)
+
+    module = _load_model_builder("model_builder_temp_fallback")
+    expected = (fallback_root / "trading_bot_models").resolve()
+
+    assert module.MODEL_DIR == expected
+    assert expected.exists()
+
+
+def test_model_dir_raises_when_all_candidates_fail(monkeypatch, tmp_path):
+    monkeypatch.setenv("TEST_MODE", "1")
+    monkeypatch.setenv("MODEL_DIR", str(tmp_path / "primary"))
+    monkeypatch.setattr(tempfile, "gettempdir", lambda: str(tmp_path / "fallback"))
+
+    def fail_mkdir(self, mode=0o777, parents=False, exist_ok=False):
+        raise PermissionError("no access")
+
+    monkeypatch.setattr(Path, "mkdir", fail_mkdir)
+
+    with pytest.raises(PermissionError):
+        _load_model_builder("model_builder_temp_failure")


### PR DESCRIPTION
## Summary
- add a shared helper to resolve writable directories with a tempfile fallback
- use the helper in model_builder and the model_builder_service to avoid unwritable MODEL_DIR failures
- cover the new behaviour with unit tests that simulate permission errors

## Testing
- pytest -q
- pytest tests/test_model_builder_model_dir.py -q
- flake8 .
- bandit -r . -ll -x ./tests,./scripts,./gptoss_check


------
https://chatgpt.com/codex/tasks/task_e_68cb0a95a918832d89cb782989ca7631