### PR TITLE
Fix dependency graph workflow ccxtpro sanitization

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "requirements*.txt"
       - "requirements*.in"
+      - "requirements*.out"
   workflow_dispatch:
 
 permissions:
@@ -29,7 +30,7 @@ jobs:
           python <<'PY'
           from pathlib import Path
 
-          patterns = ("requirements*.txt", "requirements*.in")
+          patterns = ("requirements*.txt", "requirements*.in", "requirements*.out")
           for pattern in patterns:
               for path in Path(".").glob(pattern):
                   original = path.read_text()


### PR DESCRIPTION
## Summary
- trigger the dependency submission workflow when requirements*.out files change
- filter ccxtpro entries from requirements*.out before dependency detection runs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb0aa1d740832d9b6766fb09d5adda