### PR TITLE
Mitigate setuptools CVEs in base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,15 @@ RUN set -eux; \
         tar \
         devscripts \
         equivs; \
-    python3 -m pip install --no-compile --no-cache-dir --break-system-packages 'pip>=24.0'; \
+    python3 -m pip install --no-compile --no-cache-dir --break-system-packages \
+        'pip>=24.0' \
+        'setuptools>=78.1.1,<81' \
+        wheel; \
+    if command -v python3.11 >/dev/null 2>&1; then \
+        python3.11 -m ensurepip --upgrade; \
+        python3.11 -m pip install --no-compile --no-cache-dir --break-system-packages \
+            'setuptools>=78.1.1,<81'; \
+    fi; \
     curl --netrc-file /dev/null -L https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz; \
     echo "${ZLIB_SHA256}  zlib.tar.gz" | sha256sum -c -; \
     (find /usr -type l -lname "*..*" -print 2>/dev/null || true); \
@@ -119,6 +127,10 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y --no-install
     libpam0g \
     libpam-modules \
     && dpkg -i /tmp/pam-fixed/*.deb \
+    && if command -v python3.11 >/dev/null 2>&1; then \
+        python3.11 -m ensurepip --upgrade; \
+        python3.11 -m pip install --no-cache-dir --break-system-packages 'setuptools>=78.1.1,<81'; \
+    fi \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/pam-fixed \
     && ldconfig \
     && /app/venv/bin/python --version \

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -13,6 +13,11 @@ RUN apt-get update && apt-get dist-upgrade -y \
         python3 python3-venv python3-dev \
         zlib1g-dev \
     && apt-get install -y --no-install-recommends --only-upgrade libpam0g libpam-modules \
+    && python3 -m ensurepip --upgrade \
+    && python3 -m pip install --no-cache-dir --break-system-packages \
+        'pip>=24.0' \
+        'setuptools>=78.1.1,<81' \
+        wheel \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 
@@ -49,6 +54,8 @@ RUN apt-get update && apt-get dist-upgrade -y \
         # Исключаем tar, чтобы избежать CVE-2025-45582
         coreutils libgcrypt20 login passwd \
     && apt-get install -y --no-install-recommends --only-upgrade libpam0g libpam-modules \
+    && python3 -m ensurepip --upgrade \
+    && python3 -m pip install --no-cache-dir --break-system-packages 'setuptools>=78.1.1,<81' \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && python3 --version
 


### PR DESCRIPTION
## Summary
- upgrade system-level Python tooling in CUDA builder stage to install patched setuptools when available
- ensure CUDA runtime stage refreshes Python 3.11 installations with the fixed setuptools release
- harden CPU Docker images by bootstrapping pip and installing setuptools 78.1.1+ in both build and runtime layers

## Testing
- pytest tests/test_stubs.py *(fails: missing optional test dependencies such as pytest_asyncio, numba, telegram)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0b05d748832da57e1a8c5fc6bd63