### PR TITLE
Fix MLflow hardening type hints

### DIFF
--- a/security.py
+++ b/security.py
@@ -29,7 +29,7 @@ def apply_ray_security_defaults(params: dict[str, Any]) -> dict[str, Any]:
     return hardened
 
 
-_MLFLOW_DISABLED_ATTRS: tuple[tuple[str, ...], str] = (
+_MLFLOW_DISABLED_ATTRS: tuple[tuple[tuple[str, ...], str], ...] = (
     (("pyfunc",), "load_model"),
     (("sklearn",), "load_model"),
     (("pytorch",), "load_model"),


### PR DESCRIPTION
## Summary
- correct the MLflow hardening constant type annotation to cover all disabled attributes
- unblock mypy by ensuring tuple unpacking is typed as intended

## Testing
- pytest
- mypy .

------
https://chatgpt.com/codex/tasks/task_e_68cb0b146aac832d8773c2e079e44ece