### PR TITLE
Handle missing diff script in GPT-OSS workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -116,6 +116,14 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          if [ ! -f scripts/prepare_gptoss_diff.py ]; then
+            echo "::notice::Скрипт scripts/prepare_gptoss_diff.py не найден, пропускаю подготовку diff"
+            if [ -n "${GITHUB_OUTPUT:-}" ]; then
+              echo "has_diff=false" >> "${GITHUB_OUTPUT}"
+            fi
+            exit 0
+          fi
+
           python scripts/prepare_gptoss_diff.py \
             --repo "${{ github.repository }}" \
             --pr-number "${PR_NUMBER}" \


### PR DESCRIPTION
## Summary
- skip diff generation gracefully when scripts/prepare_gptoss_diff.py is absent during the GPT-OSS review workflow
- emit a notice and explicitly mark has_diff=false so later steps are skipped cleanly

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68cc3e17d280832da2e82d8cf614ff91