### PR TITLE
Add PBKDF2 fallback for password hashing

### DIFF
--- a/tests/test_password_utils.py
+++ b/tests/test_password_utils.py
@@ -1,7 +1,9 @@
 import pytest
 
+import password_utils
 from password_utils import (
     MIN_PASSWORD_LENGTH,
+    PBKDF2_PREFIX,
     hash_password,
     verify_password,
 )
@@ -47,3 +49,36 @@ def test_verify_password_handles_incorrect_value(valid_password: str):
     hashed = hash_password(valid_password)
     assert verify_password(valid_password, hashed)
     assert not verify_password(valid_password + "x", hashed)
+
+
+def test_hash_password_uses_pbkdf2_when_bcrypt_missing(
+    valid_password: str, monkeypatch: pytest.MonkeyPatch
+):
+    """При отсутствии bcrypt используется PBKDF2 c корректной верификацией."""
+    monkeypatch.setattr(password_utils, "BCRYPT_AVAILABLE", False)
+    monkeypatch.setattr(password_utils, "bcrypt", None)
+
+    hashed = hash_password(valid_password)
+    assert hashed.startswith(f"{PBKDF2_PREFIX}$")
+    assert verify_password(valid_password, hashed)
+    assert not verify_password(valid_password + "z", hashed)
+
+
+def test_verify_password_rejects_corrupted_pbkdf2_hash(valid_password: str):
+    """Повреждённый PBKDF2-хэш приводит к ValueError."""
+    corrupted = f"{PBKDF2_PREFIX}$bad$ff"
+    with pytest.raises(ValueError, match="PBKDF2"):
+        verify_password(valid_password, corrupted)
+
+
+def test_verify_password_rejects_unknown_hash_format(valid_password: str):
+    """Неизвестный формат хэша приводит к ValueError с понятным сообщением."""
+    with pytest.raises(ValueError, match="Неизвестный формат"):
+        verify_password(valid_password, "not-a-valid-bcrypt-hash")
+
+
+def test_verify_password_rejects_malformed_bcrypt_hash(valid_password: str):
+    """Повреждённый bcrypt-хэш распознаётся и сообщает об ошибке."""
+    malformed = "$2b$12$short"
+    with pytest.raises(ValueError, match="bcrypt"):
+        verify_password(valid_password, malformed)


### PR DESCRIPTION
## Summary
- add a PBKDF2 fallback when bcrypt is unavailable and handle hash verification errors explicitly
- update password hashing and verification helpers to parse both bcrypt and PBKDF2 formats
- extend password utility tests to cover fallback hashing, corrupted data, and unknown formats

## Testing
- pytest tests/test_password_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68cc43c24588832d94764c36d62cfbb4