### PR TITLE
Make dotenv optional in server startup

### DIFF
--- a/server.py
+++ b/server.py
@@ -11,10 +11,13 @@ from contextlib import asynccontextmanager
 from bot.dotenv_utils import DOTENV_AVAILABLE, DOTENV_ERROR, load_dotenv
 from services.logging_utils import sanitize_log_value
 
+logger = logging.getLogger(__name__)
+
 if not DOTENV_AVAILABLE:
-    raise RuntimeError(
-        "python-dotenv is required. Install it with 'pip install python-dotenv'."
-    ) from DOTENV_ERROR
+    logger.warning(
+        "python-dotenv is not installed; continuing without loading .env files (%s)",
+        DOTENV_ERROR,
+    )
 
 from fastapi import FastAPI, HTTPException, Request, Response
 try:

--- a/tests/test_server_csrf_optional.py
+++ b/tests/test_server_csrf_optional.py
@@ -1,16 +1,12 @@
 import importlib
 import sys
-import types
 
 import pytest
 
 
 def test_server_requires_csrf(monkeypatch):
     monkeypatch.setitem(sys.modules, "fastapi_csrf_protect", None)
-    dotenv_stub = types.ModuleType("dotenv")
-    dotenv_stub.load_dotenv = lambda *a, **k: None
-    dotenv_stub.dotenv_values = lambda *a, **k: {}
-    monkeypatch.setitem(sys.modules, "dotenv", dotenv_stub)
+    monkeypatch.setitem(sys.modules, "dotenv", None)
     monkeypatch.delitem(sys.modules, "server", raising=False)
     with pytest.raises(RuntimeError):
         importlib.import_module("server")


### PR DESCRIPTION
## Summary
- log a warning instead of raising when python-dotenv is unavailable during server startup
- keep load_dotenv() invocation unconditional so .env loading becomes a no-op when the dependency is missing
- update the CSRF dependency test to simulate a missing python-dotenv module without custom stubs

## Testing
- pytest tests/test_server_csrf_optional.py

------
https://chatgpt.com/codex/tasks/task_e_68cc43c7c980832d970fec8d7103eb48