### PR TITLE
Handle invalid JSON payloads in trade manager service

### DIFF
--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -6,6 +6,7 @@ environment variables.
 """
 
 from flask import Flask, request, jsonify
+from werkzeug.exceptions import BadRequest
 from typing import Any
 from pathlib import Path
 import json
@@ -158,7 +159,10 @@ def _record(
 
 @app.route('/open_position', methods=['POST'])
 def open_position() -> ResponseReturnValue:
-    data = request.get_json(force=True)
+    try:
+        data = request.get_json(force=True)
+    except BadRequest:
+        return jsonify({'error': 'invalid json'}), 400
     symbol = data.get('symbol')
     side = str(data.get('side', 'buy')).lower()
     price = float(data.get('price', 0) or 0)
@@ -295,7 +299,10 @@ def open_position() -> ResponseReturnValue:
 
 @app.route('/close_position', methods=['POST'])
 def close_position() -> ResponseReturnValue:
-    data = request.get_json(force=True)
+    try:
+        data = request.get_json(force=True)
+    except BadRequest:
+        return jsonify({'error': 'invalid json'}), 400
     order_id = data.get('order_id')
     side = str(data.get('side', '')).lower()
     close_amount = data.get('close_amount')

--- a/tests/test_service_scripts.py
+++ b/tests/test_service_scripts.py
@@ -391,6 +391,22 @@ def test_trade_manager_service_fallback_failure(ctx):
 
 
 @pytest.mark.integration
+def test_trade_manager_service_invalid_json(ctx):
+    port = get_free_port()
+    p = ctx.Process(target=_run_tm, args=(port,))
+    with service_process(p, url=f'http://127.0.0.1:{port}/ping'):
+        resp = httpx.post(
+            f'http://127.0.0.1:{port}/open_position',
+            content='{',
+            timeout=5,
+            trust_env=False,
+            headers={**TOKEN_HEADERS, 'Content-Type': 'application/json'},
+        )
+        assert resp.status_code == 400
+        assert resp.json() == {'error': 'invalid json'}
+
+
+@pytest.mark.integration
 def test_trade_manager_ready_route(ctx):
     port = get_free_port()
     p = ctx.Process(target=_run_tm, args=(port,))


### PR DESCRIPTION
## Summary
- guard JSON parsing in trade manager open and close position endpoints
- return a 400 invalid json response when request body cannot be parsed
- add integration test that posts malformed JSON and expects a 400 error

## Testing
- pytest -m integration tests/test_service_scripts.py::test_trade_manager_service_invalid_json

------
https://chatgpt.com/codex/tasks/task_e_68cc5b235210832d90c96b911a9e308a