### PR TITLE
Require explicit CSRF secret

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -15,6 +15,9 @@ If both `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` environment variables are
 defined, a Telegram logger is automatically attached and forwards `ERROR`
 messages to the specified chat.
 
+For production deployments you **must** provide a strong random value in the `CSRF_SECRET` environment variable. Without it the
+FastAPI server refuses to start because CSRF protection cannot be configured safely.
+
 The GPT analysis service should return JSON with the following fields:
 `signal` ("buy"/"sell"/"hold"), `tp_mult` and `sl_mult` — multipliers applied
 to take‑profit and stop‑loss distances.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 
 **Disclaimer**: This project is provided for educational purposes only and does not constitute financial advice. Use at your own risk.
 
+В production‑окружении обязательно установите переменную окружения `CSRF_SECRET` в `.env` или системных настройках и используйте криптографически стойкое случайное значение. Без неё HTTP‑сервер с защитой от CSRF не запустится.
+
 ## Зависимости
 
 Основные пакеты устанавливаются из `requirements.txt` и включают, например,

--- a/tests/test_server_csrf_secret_required.py
+++ b/tests/test_server_csrf_secret_required.py
@@ -1,0 +1,26 @@
+import importlib
+import sys
+
+import pytest
+
+
+@pytest.mark.usefixtures("csrf_secret")
+def test_import_requires_csrf_secret(monkeypatch):
+    sys.modules.pop("server", None)
+    importlib.import_module("server")
+    monkeypatch.delenv("CSRF_SECRET", raising=False)
+    sys.modules.pop("server", None)
+    with pytest.raises(RuntimeError, match="CSRF_SECRET environment variable is required"):
+        importlib.import_module("server")
+    sys.modules.pop("server", None)
+
+
+def test_calling_resolve_without_secret_raises(monkeypatch):
+    monkeypatch.setenv("CSRF_SECRET", "static-test-secret")
+    sys.modules.pop("server", None)
+    server = importlib.import_module("server")
+    assert server._resolve_csrf_secret() == "static-test-secret"
+    monkeypatch.delenv("CSRF_SECRET", raising=False)
+    with pytest.raises(RuntimeError, match="CSRF_SECRET environment variable is required"):
+        server._resolve_csrf_secret()
+    sys.modules.pop("server", None)


### PR DESCRIPTION
## Summary
- fail fast during server startup when CSRF_SECRET is missing
- document the CSRF_SECRET requirement for production deployments
- add regression tests ensuring runtime errors when CSRF_SECRET is absent

## Testing
- pytest tests/test_server_csrf_secret_required.py tests/test_server_missing_api_keys.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cc5b3bd4e0832d956b6723de1201ef