### PR TITLE
Fix httpx stub typing and content handling

### DIFF
--- a/services/stubs.py
+++ b/services/stubs.py
@@ -101,7 +101,12 @@ def create_httpx_stub() -> SimpleNamespace:
                 content = str(data_payload).encode("utf-8")
             json_data = data_payload
         else:
-            content = content_payload if isinstance(content_payload, bytes) else None
+            if content_payload is None:
+                content = b""
+            elif isinstance(content_payload, bytes):
+                content = content_payload
+            else:
+                content = str(content_payload).encode("utf-8")
             json_data = None
         return Response(
             200,


### PR DESCRIPTION
## Summary
- ensure the offline httpx stub always produces byte content so mypy accepts the assignments
- introduce type-aware aliases for httpx classes so the module works in both runtime and type-checking environments
- tighten type annotations around async http client helpers to eliminate mypy errors

## Testing
- python -m flake8 --exclude venv .
- python -m mypy --exclude venv .
- pytest -ra


------
https://chatgpt.com/codex/tasks/task_e_68cc5bd9680c832da5dd1f8d35163a8b