### PR TITLE
Ensure runtime images upgrade setuptools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -121,6 +121,8 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y --no-install
     zlib1g \
     libpam0g \
     libpam-modules \
+    && python3 -m ensurepip --upgrade \
+    && python3 -m pip install --no-cache-dir --break-system-packages 'setuptools>=78.1.1,<81' \
     && dpkg -i /tmp/pam-fixed/*.deb \
     && if command -v python3.11 >/dev/null 2>&1; then \
         python3.11 -m ensurepip --upgrade; \

--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -5,6 +5,8 @@ ENV VLLM_DEVICE=cpu VLLM_LOGGING_LEVEL=DEBUG
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \
+    && python -m ensurepip --upgrade \
+    && python -m pip install --no-cache-dir 'pip>=24.0' 'setuptools>=78.1.1,<81' wheel \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd --system bot \
     && useradd --system --gid bot --home-dir /home/bot --shell /bin/bash bot \


### PR DESCRIPTION
## Summary
- install an updated setuptools build in the CUDA runtime stage so the final image no longer ships 65.5.1
- upgrade setuptools (and pip) inside the gptoss mock server image to remove the vulnerable version shipped with python:3.11-slim

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cc5fe6eed0832d8011a071d1143c33