### PR TITLE
Include ccxt in Dependabot test requirements

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -21,6 +21,10 @@ psutil>=5.9.0
 werkzeug>=3.0.2,<4
 requests>=2.31.0
 httpx>=0.27.0
+# ccxt is required for the trade_manager_service tests that run in the
+# Dependabot workflow. Keeping it in sync with requirements.txt avoids
+# inconsistencies between CI environments.
+ccxt==4.5.5
 # Newer scikit-learn releases pull in SciPy builds incompatible with our
 # pinned numpy; keep everything aligned with the Docker images.
 scikit-learn==1.7.2; python_version<'3.12'


### PR DESCRIPTION
## Summary
- add ccxt to the lightweight CI requirements used by the Dependabot workflow
- document why the dependency is necessary to keep TradeManager tests green during update checks

## Testing
- pytest
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_e_68cc604f1cac832d80df86ea62300831