### PR TITLE
Fix port selection script in GPT-OSS workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -79,7 +79,13 @@ jobs:
         id: choose_port
         run: |
           set -euo pipefail
-          port=$(python -c "import socket; sock = socket.socket(); sock.bind(('127.0.0.1', 0)); print(sock.getsockname()[1]); sock.close()")
+          port=$(python - <<'PY'
+import socket
+with socket.socket() as sock:
+    sock.bind(('127.0.0.1', 0))
+    print(sock.getsockname()[1])
+PY
+)
           echo "LLM_PORT=$port" >> "$GITHUB_ENV"
           echo "port=$port" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- fix the Python one-liner used to select a free port in the GPT-OSS review workflow
- replace the broken inline command with a here-document to avoid line wrapping issues

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc606bacac832da7191d5b1b1ea3d0