### PR TITLE
Handle missing httpx dependency in utils

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -14,7 +14,20 @@ from functools import wraps
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, TypeVar
 
-import httpx
+try:  # pragma: no cover - optional dependency for HTTP error handling
+    import httpx
+except Exception as exc:  # pragma: no cover - gracefully degrade when missing
+    class _HttpxStub:
+        class HTTPError(Exception):
+            """Fallback HTTPError used when httpx is unavailable."""
+
+            def __init__(self, *args, **kwargs) -> None:
+                super().__init__(*args)
+
+    httpx = _HttpxStub()  # type: ignore[assignment]
+    _HTTPX_IMPORT_ERROR: Exception | None = exc
+else:  # pragma: no cover - executed in environments with httpx installed
+    _HTTPX_IMPORT_ERROR = None
 
 from services.logging_utils import sanitize_log_value
 


### PR DESCRIPTION
## Summary
- allow importing bot.utils even when httpx is not installed by providing a lightweight stub for HTTPError
- ensure scripts that only rely on validate_host can run in minimal environments such as the docker health check job

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc61963f10832daa15d18c1a4a11ca