### PR TITLE
Handle missing pytest-asyncio plugin

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,15 @@ def _has_pytest_asyncio_plugin() -> bool:
     we only rely on ``pytest-asyncio`` when it is fully available.
     """
 
-    return importlib.util.find_spec("pytest_asyncio.plugin") is not None
+    try:
+        spec = importlib.util.find_spec("pytest_asyncio.plugin")
+    except ModuleNotFoundError:
+        # ``find_spec`` raises ``ModuleNotFoundError`` when the top-level
+        # ``pytest_asyncio`` package itself is unavailable.  Treat this the
+        # same as the plugin not being installed so the synchronous fallback
+        # below is used instead of crashing during test collection.
+        return False
+    return spec is not None
 
 
 if _has_pytest_asyncio_plugin():  # pragma: no cover - exercised in CI


### PR DESCRIPTION
## Summary
- avoid raising ModuleNotFoundError during pytest collection when pytest-asyncio is absent
- fall back to the synchronous loop fixtures that the test suite provides when the plugin cannot be imported

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc648741e0832d9ea5fcef95df0f39