### PR TITLE
chore: grant release drafter workflow actions permission

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,6 +11,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read # required for downloading the pinned Release Drafter action
   contents: write
   pull-requests: write
 


### PR DESCRIPTION
## Summary
- grant the Release Drafter workflow read access to the Actions API so the runner can download the pinned action revision

## Testing
- actionlint .github/workflows/release-drafter.yml

------
https://chatgpt.com/codex/tasks/task_e_68cc6244efa4832da887d86ef4872c99