### PR TITLE
chore: harden release drafter workflow version checks

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -39,6 +39,36 @@ jobs:
             auth_header=(-H "Authorization: Bearer ${GH_TOKEN}")
           fi
 
+          workflow_url="https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/.github/workflows/release-drafter.yml"
+          workflow_file="$(mktemp)"
+          trap 'rm -f "${workflow_file}"' EXIT
+
+          if ! curl \
+            --fail \
+            --silent \
+            --show-error \
+            --location \
+            --retry 5 \
+            --retry-delay 2 \
+            --retry-max-time 30 \
+            --connect-timeout 5 \
+            -H "Accept: text/plain" \
+            "${auth_header[@]}" \
+            "${workflow_url}" \
+            --output "${workflow_file}"; then
+            echo "Failed to download Release Drafter workflow definition at ${workflow_url}." >&2
+            echo "Ensure the workflow file is accessible before re-running." >&2
+            exit 1
+          fi
+
+          expected_ref="uses: release-drafter/release-drafter@${RELEASE_DRAFTER_COMMIT}"
+
+          if ! grep -F "${expected_ref}" "${workflow_file}" >/dev/null; then
+            echo "Release Drafter workflow must pin the action to ${RELEASE_DRAFTER_COMMIT}." >&2
+            echo "Update the 'uses' reference so it matches the RELEASE_DRAFTER_COMMIT environment value before re-running." >&2
+            exit 1
+          fi
+
           if ! curl \
             --fail \
             --silent \


### PR DESCRIPTION
## Summary
- download the release-drafter workflow definition during validation and ensure the action reference matches the pinned commit
- keep the existing curl-based commit validation while providing clearer errors when the workflow file or commit cannot be resolved

## Testing
- ./actionlint -no-color .github/workflows/release-drafter.yml

------
https://chatgpt.com/codex/tasks/task_e_68cc6e7eda28832daa611b7e9d4794f5