### PR TITLE
Fix dependency graph workflow permissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -13,12 +13,14 @@ on:
 permissions:
   contents: write
   id-token: write
+  dependency-graph: write
 
 jobs:
   submit:
     permissions:
       contents: write
       id-token: write
+      dependency-graph: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4


### PR DESCRIPTION
## Summary
- add the dependency-graph write permission to the dependency submission workflow
- ensure the component detection step comment stays on a single line

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cd9e8f0700832d85d12955ddc214c9