### PR TITLE
Fix dependency graph workflow comment formatting

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -50,7 +50,8 @@ jobs:
                       path.write_text(updated)
           PY
       - name: Component detection
-        uses: advanced-security/component-detection-dependency-submission-action@d433c2f467e149a8009c8fbce92cc708ed15ef7b # v0.1.0
+        # v0.1.0
+        uses: advanced-security/component-detection-dependency-submission-action@d433c2f467e149a8009c8fbce92cc708ed15ef7b
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           detectorArgs: Pip=EnableIfDefaultOff


### PR DESCRIPTION
## Summary
- clarify the pinned version comment for the component detection dependency submission action

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cd9ece5308832db1c0dccad0d14285