### PR TITLE
Update fastapi-csrf-protect requirement

### DIFF
--- a/requirements-core.in
+++ b/requirements-core.in
@@ -22,7 +22,7 @@ gymnasium>=0.29.1
 mlflow>=3.2.0
 pytorch-lightning>=2.5.2
 transformers==4.56.1
-fastapi-csrf-protect>=1.0.6
+fastapi-csrf-protect>=1.0.7
 flask>=3.0.2
 pybit>=5.11.0
 gunicorn>=23.0.0

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -91,7 +91,7 @@ farama-notifications==0.0.4
     # via gymnasium
 fastapi==0.116.1
     # via mlflow-skinny
-fastapi-csrf-protect==1.0.6
+fastapi-csrf-protect==1.0.7
     # via -r requirements-core.in
 filelock==3.19.1
     # via

--- a/requirements.out
+++ b/requirements.out
@@ -130,7 +130,7 @@ fastapi==0.116.1
     # via
     #   -r requirements.txt
     #   mlflow-skinny
-fastapi-csrf-protect==1.0.6
+fastapi-csrf-protect==1.0.7
     # via -r requirements.txt
 filelock==3.19.1
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -116,7 +116,7 @@ farama-notifications==0.0.4
     # via gymnasium
 fastapi==0.116.2
     # via mlflow-skinny
-fastapi-csrf-protect==1.0.6
+fastapi-csrf-protect==1.0.7
     # via -r requirements-core.in
 fastmcp==2.10.6
     # via mlflow


### PR DESCRIPTION
## Summary
- bump fastapi-csrf-protect to 1.0.7 across all pinned requirement files to pick up the latest security fixes
- keep the minimum core requirement in sync with the compiled requirement sets

## Testing
- python -m ruff check bot tests
- python -m mypy bot
- python -m flake8 .
- python -m bandit -r bot -x tests -ll
- python -m pip_audit --strict -f json -o /mnt/pip-audit.json
- pytest -m "not integration"
- pytest -m integration


------
https://chatgpt.com/codex/tasks/task_e_68cda0b9513c832db58fe520b3d71387