### PR TITLE
Improve Release Drafter workflow stability

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -22,10 +22,11 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     concurrency:
-      group: release-drafter-${{ github.ref }}
+      group: release-drafter-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: false
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      WORKFLOW_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
     steps:
       - name: Validate Release Drafter reference
         env:
@@ -39,7 +40,7 @@ jobs:
             auth_header=(-H "Authorization: Bearer ${GH_TOKEN}")
           fi
 
-          workflow_url="https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/.github/workflows/release-drafter.yml"
+          workflow_url="https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${WORKFLOW_REF}/.github/workflows/release-drafter.yml"
           workflow_file="$(mktemp)"
           trap 'rm -f "${workflow_file}"' EXIT
 


### PR DESCRIPTION
## Summary
- isolate Release Drafter concurrency per pull request to prevent cross-cancellation of runs
- download the workflow definition from the appropriate base commit when validating the pinned Release Drafter reference

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cda0ce4014832dab27abf87b4795d3