### PR TITLE
Ensure CI uses virtualenv interpreter for linting

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -84,3 +84,5 @@ runs:
           python -m pip install -r requirements-ci.txt -r requirements-cpu.txt
         fi
         echo "/mnt/venv/bin" >> $GITHUB_PATH
+        printf 'VIRTUAL_ENV=%s\n' "/mnt/venv" >> "$GITHUB_ENV"
+        printf 'PATH=%s:%s\n' "/mnt/venv/bin" "$PATH" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary
- export VIRTUAL_ENV and prepend /mnt/venv/bin to PATH inside the setup-env composite action
- guarantee that subsequent workflow steps run Python from the cached virtual environment

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cda0ec5764832d8c255c5d72e274fc