### PR TITLE
Fix Dependabot workflow failures on non-Dependabot runs

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -90,3 +90,15 @@ jobs:
         if: ${{ steps.enable_automerge.conclusion == 'failure' }}
         run: |
           echo "Auto-merge could not be enabled automatically. Check repository settings or branch protection rules." >> "$GITHUB_STEP_SUMMARY"
+
+  # GitHub still triggers this workflow on pushes to the default branch when the
+  # workflow file itself changes.  Those runs use the account that pushed the
+  # change (usually not Dependabot) as the actor, which means the primary job is
+  # skipped and GitHub marks the overall workflow as a failure.  Provide a tiny
+  # no-op job for those runs so the workflow reports success instead of red X's.
+  noop:
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip non-Dependabot runs
+        run: echo "Dependabot workflow is only relevant to Dependabot PRs; nothing to do for actor '${{ github.actor }}'."


### PR DESCRIPTION
## Summary
- add a fallback no-op job so pushes that modify the workflow complete successfully instead of failing
- keep the main Dependabot automation untouched for real Dependabot pull requests

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cda5278234832d885614f95913c5f2