### PR TITLE
Fix Dependabot workflow summary output quoting

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Report auto-merge failure
         if: ${{ steps.enable_automerge.conclusion == 'failure' }}
         run: |
-          echo "Auto-merge could not be enabled automatically. Check repository settings or branch protection rules." >> "$GITHUB_STEP_SUMMARY"
+          printf '%s\n' "Auto-merge could not be enabled automatically. Check repository settings or branch protection rules." >> "$GITHUB_STEP_SUMMARY"
 
   # GitHub still triggers this workflow on pushes to the default branch when the
   # workflow file itself changes.  Those runs use the account that pushed the


### PR DESCRIPTION
## Summary
- ensure the Dependabot workflow appends the failure message to `$GITHUB_STEP_SUMMARY` without relying on shell line wrapping

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cda76bd290832d8dd92e5d75c58315