### PR TITLE
Fix dependency graph workflow permissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -11,16 +11,16 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
   id-token: write
-  dependency-graph: write
+  security-events: write
 
 jobs:
   submit:
     permissions:
-      contents: write
+      contents: read
       id-token: write
-      dependency-graph: write
+      security-events: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4


### PR DESCRIPTION
## Summary
- adjust the dependency graph workflow permissions to match the Dependency Submission API requirements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cda775bdcc832d9669273ccd077639