### PR TITLE
Fix Dependabot workflow syntax

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -73,10 +73,7 @@ jobs:
 
       - name: Enable auto-merge for Dependabot PRs
         id: enable_automerge
-        if: ${{
-          steps.metadata.outputs['update-type'] != 'version-update:semver-major' &&
-          steps.auto_merge.outputs.allowed == 'true'
-        }}
+        if: ${{ steps.metadata.outputs['update-type'] != 'version-update:semver-major' && steps.auto_merge.outputs.allowed == 'true' }}
         # v3.0.0
         # yamllint disable-line rule:line-length
         uses: peter-evans/enable-pull-request-automerge@a59ea044f2aeabb1e63839cf06068655c1d70998


### PR DESCRIPTION
## Summary
- replace the multi-line `if` expression in the Dependabot workflow with a single-line expression so the YAML parses correctly

## Testing
- /root/.local/share/mise/installs/go/1.24.3/bin/actionlint .github/workflows/dependabot.yml


------
https://chatgpt.com/codex/tasks/task_e_68cda884f92c832d9e1d6810b7b585dd