### PR TITLE
Fix dependency snapshot workflow permissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -11,14 +11,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
   security-events: write
 
 jobs:
   submit:
     permissions:
-      contents: read
+      contents: write
       id-token: write
       security-events: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- grant write-level contents permissions required for dependency snapshot submissions at both workflow and job scopes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cdae7bc83c832d956c97cd993196b4