### PR TITLE
Add pandas dependency for healthcheck service

### DIFF
--- a/requirements-healthcheck.txt
+++ b/requirements-healthcheck.txt
@@ -3,3 +3,4 @@ flask==3.1.2
 ccxt==4.5.5
 python-dotenv==1.1.1
 requests==2.32.5
+pandas==2.3.2


### PR DESCRIPTION
## Summary
- add pandas to the healthcheck requirements so the data handler service can load historical data without warnings
- verify the lightweight healthcheck script runs successfully with TEST_MODE=1

## Testing
- TEST_MODE=1 python scripts/health_check.py

------
https://chatgpt.com/codex/tasks/task_e_68cdae9508c4832dbdcabb55e63ad852