### PR TITLE
Fix dependabot checkout for fork branches

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -34,7 +34,8 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
 
       # Set up a lightweight Python environment and install only the
       # dependencies required to run the unit tests.  This avoids the


### PR DESCRIPTION
## Summary
- update the Dependabot workflow checkout step to clone the pull request's head repository and branch

## Testing
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_e_68cdaeccd894832d857d5fb257d2ceb1