### PR TITLE
Fix dependency graph permissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -11,14 +11,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
   security-events: write
 
 jobs:
   submit:
     permissions:
-      contents: read
+      contents: write
       id-token: write
       security-events: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- grant write access to repository contents for the dependency snapshot workflow

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cdaee51a04832d857fd10062de6548