### PR TITLE
Clean up imports for GPT-OSS workflow

### DIFF
--- a/http_client.py
+++ b/http_client.py
@@ -11,6 +11,8 @@ from contextlib import asynccontextmanager, contextmanager
 from functools import wraps
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, Generator, Tuple
 
+from bot.utils import retry
+from services.logging_utils import sanitize_log_value
 from services.stubs import create_httpx_stub, is_offline_env
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type hints only
@@ -35,9 +37,6 @@ except Exception:  # noqa: BLE001 - guarantee stub availability
     httpx = create_httpx_stub()
 else:
     httpx = _httpx
-
-from bot.utils import retry
-from services.logging_utils import sanitize_log_value
 
 # Use system-level randomness for jitter to avoid predictable retry delays
 _RNG = random.SystemRandom()

--- a/model_builder.py
+++ b/model_builder.py
@@ -34,8 +34,12 @@ from bot.utils import (
     is_cuda_available,
     logger,
 )
-from services.logging_utils import sanitize_log_value
 from models.architectures import KERAS_FRAMEWORKS, create_model
+from security import (
+    verify_model_state_signature,
+    write_model_state_signature,
+)
+from services.logging_utils import sanitize_log_value
 
 MODEL_DIR = ensure_writable_directory(
     Path(os.getenv("MODEL_DIR", ".")),
@@ -287,11 +291,6 @@ except ImportError as e:  # pragma: no cover - optional dependency
     logger.warning("Не удалось импортировать mlflow: %s", e)
 else:
     harden_mlflow(mlflow)
-
-from security import (
-    verify_model_state_signature,
-    write_model_state_signature,
-)
 
 # Delay heavy SHAP import until needed to avoid CUDA warnings at startup
 shap = None

--- a/server.py
+++ b/server.py
@@ -1,11 +1,13 @@
 import os
-import sys
-import logging
 import asyncio
 import hmac
+import logging
 import re
-from typing import Any, List, Mapping
+import sys
 from contextlib import asynccontextmanager
+from typing import Any, List, Mapping
+
+from fastapi import FastAPI, HTTPException, Request, Response
 
 from bot.dotenv_utils import DOTENV_AVAILABLE, DOTENV_ERROR, load_dotenv
 from services.logging_utils import sanitize_log_value
@@ -17,8 +19,6 @@ if not DOTENV_AVAILABLE:
         "python-dotenv is not installed; continuing without loading .env files (%s)",
         DOTENV_ERROR,
     )
-
-from fastapi import FastAPI, HTTPException, Request, Response
 try:
     from pydantic import BaseModel, Field, ValidationError
 except ImportError as exc:  # pragma: no cover - dependency required

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -12,7 +12,13 @@ from collections import defaultdict, deque
 from contextlib import suppress
 from typing import Awaitable, Callable, TypeVar
 
+from bot.config import BotConfig, OFFLINE_MODE
+from bot.dotenv_utils import load_dotenv
+from bot.gpt_client import GPTClientError, GPTClientJSONError, query_gpt_json_async
+from services.logging_utils import sanitize_log_value
 from services.stubs import create_httpx_stub, create_pydantic_stub, is_offline_env
+from telegram_logger import TelegramLogger
+from utils import retry, suppress_tf_logs
 
 _OFFLINE_ENV = is_offline_env()
 
@@ -31,13 +37,6 @@ try:  # pragma: no cover - fallback executed in offline/testing scenarios
     from bot.pydantic_compat import BaseModel, ConfigDict, ValidationError
 except Exception:  # noqa: BLE001 - ensure stubs are used when dependencies missing
     BaseModel, ConfigDict, ValidationError = create_pydantic_stub()
-
-from bot.config import BotConfig, OFFLINE_MODE
-from bot.dotenv_utils import load_dotenv
-from bot.gpt_client import GPTClientError, GPTClientJSONError, query_gpt_json_async
-from telegram_logger import TelegramLogger
-from utils import retry, suppress_tf_logs
-from services.logging_utils import sanitize_log_value
 
 try:  # pragma: no cover - optional dependency
     import ccxt  # type: ignore

--- a/utils.py
+++ b/utils.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import inspect
-import ipaddress
 import logging
 import os
 import re
@@ -29,8 +28,11 @@ except Exception as exc:  # pragma: no cover - gracefully degrade when missing
 else:  # pragma: no cover - executed in environments with httpx installed
     _HTTPX_IMPORT_ERROR = None
 
+from bot.host_utils import validate_host as _validate_host
 from services.logging_utils import sanitize_log_value
-from bot.host_utils import validate_host
+
+
+validate_host = _validate_host
 
 
 logger = logging.getLogger("TradingBot")


### PR DESCRIPTION
## Summary
- move project imports to the top of the HTTP client, model builder, server, and trading bot modules to satisfy Ruff import-order rules
- expose `validate_host` via an alias and drop the unused `ipaddress` import so the utilities module stays lint-clean

## Testing
- ruff check
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cdaef34588832da2b6b3f36c94e621