### PR TITLE
Fix release drafter concurrency guard

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -22,7 +22,7 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     concurrency:
-      group: release-drafter-${{ github.event.pull_request.number || github.ref }}
+      group: release-drafter-${{ github.event_name == 'pull_request_target' && github.event.pull_request.number || github.ref }}
       cancel-in-progress: false
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- guard concurrency group against missing pull request payloads to prevent workflow failures

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cdaf0109d4832d848426b72f1fff9a