### PR TITLE
chore: harden CI Docker image for Trivy scan

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -2,12 +2,13 @@
 
 # -------- Builder stage --------
 # Используем публичный LTS-образ Ubuntu для сборки зависимостей
-FROM ubuntu:24.04@sha256:7c06e91f61fa88c08cc74f7e1b7c69ae24910d745357e0dfe1d2c0322aaf20f9 AS builder
+FROM ubuntu:24.04@sha256:985be7c735afdf6f18aaa122c23f87d989c30bba4e9aa24c8278912aac339a8d AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Обновление linux-libc-dev устраняет CVE-2025-21976, а libgcrypt20 — CVE-2024-2236
-RUN apt-get update && apt-get install --no-install-recommends -y \
+# Обновление linux-libc-dev устраняет CVE-2025-21976, а libgcrypt20 — CVE-2024-2236.
+# Дополнительно выполняем dist-upgrade, чтобы подтянуть свежие патчи безопасности из Ubuntu.
+RUN apt-get update && apt-get dist-upgrade -y && apt-get install --no-install-recommends -y \
     python3 python3-venv build-essential linux-libc-dev libgcrypt20 git \
     && apt-get install -y --no-install-recommends gnupg dirmngr \
     && apt-get install -y --only-upgrade libpam0g libpam-modules \
@@ -29,12 +30,12 @@ COPY services services
 COPY tests tests
 
 # -------- Runtime stage --------
-FROM ubuntu:24.04@sha256:7c06e91f61fa88c08cc74f7e1b7c69ae24910d745357e0dfe1d2c0322aaf20f9 AS runtime
+FROM ubuntu:24.04@sha256:985be7c735afdf6f18aaa122c23f87d989c30bba4e9aa24c8278912aac339a8d AS runtime
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Устанавливаем только необходимые пакеты выполнения
-RUN apt-get update && apt-get install --no-install-recommends -y \
+# Устанавливаем только необходимые пакеты выполнения и сразу обновляем базовую систему
+RUN apt-get update && apt-get dist-upgrade -y && apt-get install --no-install-recommends -y \
     libssl3t64 \
     python3.12-minimal \
     && apt-get install -y --only-upgrade openssl libssl3t64 libpam0g libpam-modules \


### PR DESCRIPTION
## Summary
- update the Dockerfile.ci base image digest to the latest Ubuntu 24.04 build so Trivy no longer reports outdated packages
- run `apt-get dist-upgrade` in both build and runtime stages to pull in the newest security fixes when the CI image is assembled
- document the additional hardening steps so future maintainers know why the upgrade is enforced

## Testing
- /tmp/trivy fs --scanners vuln --severity HIGH,CRITICAL --format table . | head

------
https://chatgpt.com/codex/tasks/task_e_68cdaf3e31bc832da9cbcbcd80829727