### PR TITLE
Fix dependency graph workflow script imports

### DIFF
--- a/scripts/submit_dependency_snapshot.py
+++ b/scripts/submit_dependency_snapshot.py
@@ -8,6 +8,11 @@ import sys
 from collections import OrderedDict
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Dict, Iterable, TypedDict
+
+from urllib.parse import urlparse
+
+import requests
 
 MANIFEST_PATTERNS = ("requirements*.txt", "requirements*.in", "requirements*.out")
 


### PR DESCRIPTION
## Summary
- add the missing typing, urllib, and requests imports for the dependency snapshot submission script

## Testing
- python -m compileall scripts/submit_dependency_snapshot.py

------
https://chatgpt.com/codex/tasks/task_e_68cdbd06b380832da6e4a0d917c821ab