### PR TITLE
Fix urllib usage in GPT-OSS scripts

### DIFF
--- a/scripts/run_gptoss_review.py
+++ b/scripts/run_gptoss_review.py
@@ -7,9 +7,9 @@ the entire job to exit with a non-zero status.  This module replaces the shell
 logic with a small Python implementation that gracefully handles errors and
 reports the result back to GitHub Actions via ``GITHUB_OUTPUT``.
 
-The module keeps dependencies minimal, relying only on the ubiquitous
-``requests`` package that is pre-installed on GitHub runners.  It can also be
-imported from unit tests to validate individual helper functions.
+The module keeps dependencies minimal by using only the standard-library
+``urllib`` helpers for HTTP access.  It can also be imported from unit tests to
+validate individual helper functions.
 """
 
 from __future__ import annotations
@@ -22,9 +22,8 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+from urllib import error, request
 from urllib.parse import urlparse
-
-import requests
 _PROMPT_PREFIX = "Review the following diff and provide feedback:\n"
 
 
@@ -82,20 +81,25 @@ def _send_request(api_url: str, payload: dict[str, Any], timeout: float) -> dict
             if host.lower() != "localhost":
                 raise RuntimeError("Небезопасный HTTP URL для GPT-OSS API")
 
+    data = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    req = request.Request(api_url, data=data, headers=headers)
+
     try:
-        response = requests.post(api_url, json=payload, timeout=timeout)
-    except requests.Timeout as exc:
+        with request.urlopen(req, timeout=timeout) as response:
+            body = response.read()
+    except TimeoutError as exc:
         raise RuntimeError(f"Не удалось подключиться к GPT-OSS ({api_url}): {exc}") from exc
-    except requests.RequestException as exc:
-        raise RuntimeError(f"Ошибка при обращении к GPT-OSS ({api_url}): {exc}") from exc
-
-    if response.status_code >= 400:
+    except error.HTTPError as exc:
         raise RuntimeError(
-            f"Сервер GPT-OSS вернул ошибку {response.status_code}: {response.reason}"
-        )
+            f"Сервер GPT-OSS вернул ошибку {exc.code}: {exc.reason}"
+        ) from exc
+    except error.URLError as exc:
+        reason = getattr(exc, "reason", exc)
+        raise RuntimeError(f"Ошибка при обращении к GPT-OSS ({api_url}): {reason}") from exc
 
     try:
-        return response.json()
+        return json.loads(body.decode("utf-8"))
     except ValueError as exc:
         raise RuntimeError("Сервер GPT-OSS вернул некорректный JSON") from exc
 


### PR DESCRIPTION
## Summary
- replace the GPT-OSS diff helper's HTTP client with urllib.request so tests can patch request.urlopen
- switch the review runner to urllib.request and adjust error handling while updating the module docstring

## Testing
- pytest tests/test_prepare_gptoss_diff.py tests/test_run_gptoss_review.py

------
https://chatgpt.com/codex/tasks/task_e_68cdc199f898832db766d549d9fae195