### PR TITLE
Run Semgrep workflow via CLI to avoid GHCR pull failures

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -36,11 +36,20 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           persist-credentials: false
-      - uses: returntocorp/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d # v1
+      - uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5
         with:
-          # Use the community "ci" ruleset which does not require an auth token
-          config: p/ci
-          generateSarif: true
+          python-version: "3.x"
+      - name: Install Semgrep CLI
+        env:
+          PIP_DISABLE_PIP_VERSION_CHECK: "1"
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "semgrep>=1.52.0"
+      - name: Run Semgrep
+        env:
+          SEMGREP_SEND_METRICS: "off"
+        run: |
+          semgrep --config p/ci --error --sarif --output semgrep.sarif
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
       - name: Check for SARIF results


### PR DESCRIPTION
## Summary
- replace the Semgrep GitHub Action with an explicit Python-based CLI execution
- install Semgrep from PyPI and run the scan with SARIF output to keep existing upload logic

## Testing
- `semgrep --config p/ci --error --sarif --output semgrep.sarif`


------
https://chatgpt.com/codex/tasks/task_e_68cdc2056364832d9463afcdebab622f