### PR TITLE
Use urllib for GPT-OSS scripts

### DIFF
--- a/scripts/run_gptoss_review.py
+++ b/scripts/run_gptoss_review.py
@@ -7,8 +7,8 @@ the entire job to exit with a non-zero status.  This module replaces the shell
 logic with a small Python implementation that gracefully handles errors and
 reports the result back to GitHub Actions via ``GITHUB_OUTPUT``.
 
-The module keeps dependencies minimal, relying only on the ubiquitous
-``requests`` package that is pre-installed on GitHub runners.  It can also be
+The module keeps dependencies minimal by using the standard library
+``urllib.request`` helpers that are available on GitHub runners.  It can also be
 imported from unit tests to validate individual helper functions.
 """
 
@@ -22,9 +22,8 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+from urllib import error, request
 from urllib.parse import urlparse
-
-import requests
 _PROMPT_PREFIX = "Review the following diff and provide feedback:\n"
 
 
@@ -82,20 +81,33 @@ def _send_request(api_url: str, payload: dict[str, Any], timeout: float) -> dict
             if host.lower() != "localhost":
                 raise RuntimeError("Небезопасный HTTP URL для GPT-OSS API")
 
+    data = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    req = request.Request(api_url, data=data, headers=headers, method="POST")
+
+    body: bytes
     try:
-        response = requests.post(api_url, json=payload, timeout=timeout)
-    except requests.Timeout as exc:
+        with request.urlopen(req, timeout=timeout) as response:
+            body = response.read()
+    except TimeoutError as exc:
         raise RuntimeError(f"Не удалось подключиться к GPT-OSS ({api_url}): {exc}") from exc
-    except requests.RequestException as exc:
-        raise RuntimeError(f"Ошибка при обращении к GPT-OSS ({api_url}): {exc}") from exc
-
-    if response.status_code >= 400:
+    except error.HTTPError as exc:
         raise RuntimeError(
-            f"Сервер GPT-OSS вернул ошибку {response.status_code}: {response.reason}"
-        )
+            f"Сервер GPT-OSS вернул ошибку {exc.code}: {exc.reason}"
+        ) from exc
+    except error.URLError as exc:
+        message = getattr(exc, "reason", exc)
+        raise RuntimeError(
+            f"Ошибка при обращении к GPT-OSS ({api_url}): {message}"
+        ) from exc
 
     try:
-        return response.json()
+        text = body.decode("utf-8")
+    except UnicodeDecodeError as exc:  # pragma: no cover - defensive guard
+        raise RuntimeError("Сервер GPT-OSS вернул данные в неизвестной кодировке") from exc
+
+    try:
+        return json.loads(text)
     except ValueError as exc:
         raise RuntimeError("Сервер GPT-OSS вернул некорректный JSON") from exc
 


### PR DESCRIPTION
## Summary
- switch the GPT-OSS diff preparation script to urllib so tests can patch urlopen and network errors are handled without requests
- update the GPT-OSS review runner to use urllib, keep error handling and documentation in sync

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdc210acd4832d9c0a02a6bd634ca1