### PR TITLE
Fix Trivy workflow failure handling

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -46,7 +46,7 @@ jobs:
           sarif_file: trivy-results.sarif
 
       - name: Upload Trivy report artifact
-        if: always()
+        if: ${{ steps.trivy.conclusion != 'skipped' && always() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         # v4
         with:
@@ -54,5 +54,5 @@ jobs:
           path: trivy-results.sarif
 
       - name: Fail if vulnerabilities found
-        if: ${{ steps.trivy.outcome == 'failure' }}
+        if: ${{ steps.trivy.conclusion == 'failure' }}
         run: exit 1


### PR DESCRIPTION
## Summary
- ensure the Trivy artifact upload only runs when the scan step finishes
- make the workflow fail when the Trivy scan reports vulnerabilities by relying on the step conclusion

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cdc21d9938832d95a67758b95715ee