### PR TITLE
Fix GitHub workflow helper network shims

### DIFF
--- a/scripts/run_gptoss_review.py
+++ b/scripts/run_gptoss_review.py
@@ -22,9 +22,16 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+from urllib import request as urllib_request
 from urllib.parse import urlparse
 
 import requests
+
+# ``tests`` expect to monkeypatch ``run_gptoss_review.request.urlopen`` in order
+# to simulate network failures.  Provide a module level alias to keep the public
+# API backwards compatible with the previous implementation that relied on
+# ``urllib.request``.
+request = urllib_request
 _PROMPT_PREFIX = "Review the following diff and provide feedback:\n"
 
 


### PR DESCRIPTION
## Summary
- expose urllib.request as request in the workflow helper scripts to allow existing monkeypatch-based tests to override urlopen
- reimplement the GitHub metadata fetcher with urllib so the unit tests can inject canned responses without real HTTP calls

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdc2357c38832dbbc363deb23e146e