### PR TITLE
Fix Release Drafter concurrency group for push events

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -22,7 +22,7 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     concurrency:
-      group: release-drafter-${{ replace(github.workflow, ' ', '-') }}-${{ github.event_name == 'pull_request_target' && github.event.pull_request.number || github.ref_name }}
+      group: release-drafter-${{ replace(github.workflow, ' ', '-') }}-${{ github.head_ref || github.ref_name }}
       cancel-in-progress: true
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- adjust the Release Drafter workflow concurrency key to use head or ref names so push events no longer error out

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cdc59400b0832d94223f0f42a51f3b