### PR TITLE
Fix release drafter validation reference

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -26,7 +26,7 @@ jobs:
       cancel-in-progress: true
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      WORKFLOW_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
+      WORKFLOW_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
     steps:
       - name: Validate Release Drafter reference
         env:


### PR DESCRIPTION
## Summary
- ensure the Release Drafter workflow validates the pull request's proposed workflow changes by fetching the PR head revision when running on pull_request_target events

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d014c3a65c832da5cd9b09cd1518aa