### PR TITLE
Fix Docker CPU image workflow failure

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -10,10 +10,9 @@ RUN apt-get update && apt-get dist-upgrade -y \
         python3.12-minimal \
         build-essential \
         curl \
-        python3 python3-venv python3-dev \
+        python3 python3-venv python3-dev python3-pip \
         zlib1g-dev \
     && apt-get install -y --no-install-recommends --only-upgrade libpam0g libpam-modules \
-    && python3 -m ensurepip --upgrade \
     && python3 -m pip install --no-cache-dir --break-system-packages \
         'pip>=24.0' \
         'setuptools>=78.1.1,<81' \
@@ -59,8 +58,9 @@ RUN set -eux; \
         # Исключаем tar, чтобы избежать CVE-2025-45582
         coreutils libgcrypt20 login passwd; \
     apt-get install -y --no-install-recommends --only-upgrade libpam0g libpam-modules; \
-    python3 -m ensurepip --upgrade; \
-    python3 -m pip install --no-cache-dir --break-system-packages 'setuptools>=78.1.1,<81'; \
+    # ``ensurepip`` отключён в системном Python Ubuntu, а рантайм использует
+    # виртуальное окружение из стадии сборки, поэтому дополнительные операции с pip
+    # не требуются.
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*; \
     python3 --version


### PR DESCRIPTION
## Summary
- stop invoking system ensurepip/pip in the runtime stage because Ubuntu disables ensurepip and we rely on the copied virtualenv instead
- install python3-pip in the builder stage so pip is available even when ensurepip is disabled before refreshing tooling

## Testing
- buildah build-using-dockerfile --isolation chroot -f Dockerfile.cpu -t bot-cpu-test *(fails due to time constraints in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d014d600e8832da5e555789d422bf0