### PR TITLE
Fix gptoss mock server module header

### DIFF
--- a/scripts/gptoss_mock_server.py
+++ b/scripts/gptoss_mock_server.py
@@ -1,4 +1,5 @@
-"""Mock GPT-OSS server used in CI to emulate chat completions.
+# -*- coding: utf-8 -*-
+"""Mock GPT-OSS server used by the GitHub Actions workflow.
 
 The implementation intentionally relies only on the Python standard library so
 that it can be executed in GitHub Actions without installing extra


### PR DESCRIPTION
## Summary
- restore a proper module docstring for the GPT-OSS mock server script
- declare UTF-8 encoding so non-ASCII characters in the documentation compile cleanly

## Testing
- python -m compileall scripts/gptoss_mock_server.py

------
https://chatgpt.com/codex/tasks/task_e_68d015083ca8832d8e64973b6ad8274b