### PR TITLE
Fix dependency graph permissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -14,6 +14,7 @@ permissions:
   contents: write
   id-token: write
   security-events: write
+  dependency-graph: write
 
 jobs:
   submit:
@@ -21,6 +22,7 @@ jobs:
       contents: write
       id-token: write
       security-events: write
+      dependency-graph: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4


### PR DESCRIPTION
## Summary
- grant the dependency graph workflow the required dependency-graph: write permission at both workflow and job scopes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d020ef4a3c832d9a32f58949b1dcc6