### PR TITLE
Harden HTTP requests in automation scripts

### DIFF
--- a/scripts/prepare_gptoss_diff.py
+++ b/scripts/prepare_gptoss_diff.py
@@ -25,7 +25,8 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Sequence
-from urllib import error, request
+import socket
+from http.client import HTTPSConnection
 from urllib.parse import urlparse
 
 
@@ -72,20 +73,31 @@ def _api_request(url: str, token: str | None, timeout: float = 10.0) -> dict:
     if token:
         headers["Authorization"] = f"token {token}"
 
-    req = request.Request(url, headers=headers)
-
+    host = parsed.hostname or ""
+    port = parsed.port or 443
+    target = parsed.path or "/"
+    if parsed.params:
+        target = f"{target};{parsed.params}"
+    if parsed.query:
+        target = f"{target}?{parsed.query}"
+    connection = HTTPSConnection(host, port=port, timeout=timeout)
     try:
-        with request.urlopen(req, timeout=timeout) as response:
-            payload = response.read()
-    except TimeoutError as exc:
+        connection.request("GET", target, headers=headers)
+        response = connection.getresponse()
+        status = int(response.status or 0)
+        reason_text = response.reason or ""
+        payload = response.read()
+    except (TimeoutError, socket.timeout) as exc:
         raise RuntimeError(f"HTTP запрос {url} завершился ошибкой: {exc}") from exc
-    except error.HTTPError as exc:
+    except OSError as exc:
+        raise RuntimeError(f"HTTP запрос {url} завершился ошибкой: {exc}") from exc
+    finally:
+        connection.close()
+
+    if status >= 400:
         raise RuntimeError(
-            f"HTTP запрос {url} завершился ошибкой: {exc.code} {exc.reason}"
-        ) from exc
-    except error.URLError as exc:
-        reason = getattr(exc, "reason", exc)
-        raise RuntimeError(f"HTTP запрос {url} завершился ошибкой: {reason}") from exc
+            f"HTTP запрос {url} завершился ошибкой: {status} {reason_text}"
+        )
 
     try:
         return json.loads(payload.decode("utf-8"))


### PR DESCRIPTION
## Summary
- replace the urllib.urlopen usage in automation scripts with explicit http.client connections and strict scheme validation
- tighten error handling around GPT-OSS and dependency snapshot calls so connections are closed and HTTP status codes are checked explicitly

## Testing
- /root/.pyenv/versions/3.11.12/bin/bandit -r . -ll -ii -x ./tests,./scripts,./gptoss_check -f sarif -o bandit.sarif
- /root/.pyenv/versions/3.11.12/bin/bandit -r scripts -ll -ii

------
https://chatgpt.com/codex/tasks/task_e_68d02127b82c832d85e1d7a79a7cfcff