### PR TITLE
Improve dependency snapshot submission reliability

### DIFF
--- a/tests/test_dependency_snapshot_parser.py
+++ b/tests/test_dependency_snapshot_parser.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from scripts.submit_dependency_snapshot import _parse_requirements
+from scripts.submit_dependency_snapshot import (
+    _auth_schemes,
+    _job_metadata,
+    _parse_requirements,
+)
 
 
 def _write_requirements(tmp_path: Path, contents: str) -> Path:
@@ -39,3 +43,21 @@ def test_parse_requirements_handles_hash_block(tmp_path: Path) -> None:
     parsed = _parse_requirements(path)
 
     assert list(parsed) == ["pkg:pypi/sample@0.1.0"]
+
+
+def test_auth_schemes_prefers_bearer_for_github_tokens(monkeypatch) -> None:
+    monkeypatch.delenv("DEPENDENCY_SNAPSHOT_AUTH_SCHEME", raising=False)
+    assert _auth_schemes("ghs_example") == ["Bearer", "token"]
+
+
+def test_auth_schemes_allows_override(monkeypatch) -> None:
+    monkeypatch.setenv("DEPENDENCY_SNAPSHOT_AUTH_SCHEME", "token")
+    assert _auth_schemes("anything") == ["token"]
+
+
+def test_job_metadata_adds_html_url_when_run_id_numeric(monkeypatch) -> None:
+    monkeypatch.setenv("GITHUB_SERVER_URL", "https://example.com")
+    job = _job_metadata("owner/repo", "12345", "corr")
+    assert job["html_url"] == "https://example.com/owner/repo/actions/runs/12345"
+    job_no_url = _job_metadata("owner/repo", "run-1", "corr")
+    assert "html_url" not in job_no_url


### PR DESCRIPTION
## Summary
- make dependency snapshot submissions more robust by adding auth scheme fallbacks, richer job metadata and scan timestamps
- add unit tests covering auth scheme selection and job metadata generation

## Testing
- pytest tests/test_dependency_snapshot_parser.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0241b29c4832db36d17e308ca877a