### PR TITLE
Fix dependency snapshot manifest keys

### DIFF
--- a/scripts/submit_dependency_snapshot.py
+++ b/scripts/submit_dependency_snapshot.py
@@ -102,7 +102,7 @@ def _parse_requirements(path: Path) -> Dict[str, ResolvedDependency]:
             name = name.split("[", 1)[0]
         package_name = _normalise_name(name)
         package_url = f"pkg:pypi/{package_name}@{version}"
-        resolved[package_url] = {
+        resolved[package_name] = {
             "package_url": package_url,
             "relationship": "direct",
             "scope": scope,

--- a/tests/test_dependency_snapshot_parser.py
+++ b/tests/test_dependency_snapshot_parser.py
@@ -26,8 +26,10 @@ def test_parse_requirements_strips_inline_comments(tmp_path: Path) -> None:
 
     parsed = _parse_requirements(path)
 
-    assert "pkg:pypi/package@1.2.3" in parsed
-    assert "pkg:pypi/other@4.5.6" in parsed
+    assert "package" in parsed
+    assert parsed["package"]["package_url"] == "pkg:pypi/package@1.2.3"
+    assert "other" in parsed
+    assert parsed["other"]["package_url"] == "pkg:pypi/other@4.5.6"
 
 
 def test_parse_requirements_handles_hash_block(tmp_path: Path) -> None:
@@ -42,7 +44,7 @@ def test_parse_requirements_handles_hash_block(tmp_path: Path) -> None:
 
     parsed = _parse_requirements(path)
 
-    assert list(parsed) == ["pkg:pypi/sample@0.1.0"]
+    assert list(parsed) == ["sample"]
 
 
 def test_auth_schemes_prefers_bearer_for_github_tokens(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- use normalized package names as keys in dependency snapshot manifests so GitHub accepts the payload
- extend the dependency snapshot parser tests to assert package URLs for each parsed requirement

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d02a72ed5c832d9c98eb436833b2b3