### PR TITLE
Limit release drafter on forked PRs

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   update_release_draft:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Update release draft


### PR DESCRIPTION
## Summary
- prevent the release drafter workflow from running on pull requests originating from forks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d02ce7a208832db0c69a11ef8a4be2