### PR TITLE
Handle unauthorized dependency snapshot submissions

### DIFF
--- a/scripts/submit_dependency_snapshot.py
+++ b/scripts/submit_dependency_snapshot.py
@@ -279,12 +279,19 @@ def submit_dependency_snapshot() -> None:
             break
 
     if last_error is not None:
-        if isinstance(last_error, DependencySubmissionError) and last_error.status_code in {403, 404}:
-            print(
-                "Dependency snapshot submission skipped из-за ограниченных прав доступа.",
-                file=sys.stderr,
-            )
-            return
+        if isinstance(last_error, DependencySubmissionError):
+            if last_error.status_code == 401:
+                print(
+                    "Dependency snapshot submission skipped из-за ошибки авторизации токена (HTTP 401).",
+                    file=sys.stderr,
+                )
+                return
+            if last_error.status_code in {403, 404}:
+                print(
+                    "Dependency snapshot submission skipped из-за ограниченных прав доступа.",
+                    file=sys.stderr,
+                )
+                return
         raise last_error
 
 

--- a/tests/test_dependency_snapshot_parser.py
+++ b/tests/test_dependency_snapshot_parser.py
@@ -61,3 +61,40 @@ def test_job_metadata_adds_html_url_when_run_id_numeric(monkeypatch) -> None:
     assert job["html_url"] == "https://example.com/owner/repo/actions/runs/12345"
     job_no_url = _job_metadata("owner/repo", "run-1", "corr")
     assert "html_url" not in job_no_url
+
+
+def test_submit_snapshot_skips_on_unauthorised_token(monkeypatch, capsys) -> None:
+    from scripts import submit_dependency_snapshot as module
+
+    manifests = {
+        "requirements.txt": {
+            "name": "requirements.txt",
+            "file": {"source_location": "requirements.txt"},
+            "resolved": {
+                "pkg:pypi/sample@1.0.0": {
+                    "package_url": "pkg:pypi/sample@1.0.0",
+                    "relationship": "direct",
+                    "scope": "runtime",
+                    "dependencies": [],
+                }
+            },
+        }
+    }
+
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+    monkeypatch.setenv("GITHUB_TOKEN", "ghs_dummy")
+    monkeypatch.setenv("GITHUB_SHA", "deadbeef")
+    monkeypatch.setenv("GITHUB_REF", "refs/heads/main")
+    monkeypatch.setenv("GITHUB_RUN_ID", "123")
+
+    monkeypatch.setattr(module, "_build_manifests", lambda root: manifests)
+
+    def _raise(*args, **kwargs):
+        raise module.DependencySubmissionError(401, "bad credentials")
+
+    monkeypatch.setattr(module, "_submit_with_headers", _raise)
+
+    module.submit_dependency_snapshot()
+
+    captured = capsys.readouterr()
+    assert "ошибки авторизации" in captured.err


### PR DESCRIPTION
## Summary
- treat HTTP 401 responses from the dependency snapshot API as a non-fatal authentication issue and keep the workflow green
- add regression coverage ensuring the submission helper surfaces the new skip message for unauthorized tokens

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d02c67fd84832d99c1f31f44cb4ded