### PR TITLE
Fix CI import order failure in trade manager service

### DIFF
--- a/bot/trade_manager/service.py
+++ b/bot/trade_manager/service.py
@@ -14,10 +14,9 @@ from typing import Any
 
 import httpx
 import ray
-from security import ensure_minimum_ray_version
-ensure_minimum_ray_version(ray)
 from bot.dotenv_utils import load_dotenv
 from flask import Flask, jsonify, request, Response
+from security import ensure_minimum_ray_version
 
 from .core import (
     IS_TEST_MODE as CORE_TEST_MODE,
@@ -30,6 +29,9 @@ from .core import (
     setup_multiprocessing,
 )
 from bot.config import load_config
+
+
+ensure_minimum_ray_version(ray)
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- reorder imports in `bot/trade_manager/service.py` so all module imports precede runtime calls
- invoke `ensure_minimum_ray_version` after the import block to satisfy Ruff's E402 rule

## Testing
- `python -m ruff check bot tests`
- `python -m mypy bot`
- `python -m bandit -r bot -x tests -ll`
- `python -m flake8 .`
- `pytest -m "not integration"`
- `pytest -m integration`


------
https://chatgpt.com/codex/tasks/task_e_68d02c93b1c4832d9b49033bf749dd30