### PR TITLE
Harden script HTTP requests to satisfy bandit

### DIFF
--- a/tests/test_prepare_gptoss_diff.py
+++ b/tests/test_prepare_gptoss_diff.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import contextlib
-import io
 import json
 import subprocess
 from pathlib import Path
@@ -65,12 +63,12 @@ def test_prepare_diff_reads_remote_metadata(monkeypatch: pytest.MonkeyPatch, tem
         }
     }
 
-    def _fake_urlopen(req, timeout=10):  # type: ignore[override]
-        _ = timeout
+    def _fake_request(url, headers, timeout):
+        _ = (headers, timeout)
         payload = json.dumps(pull_payload).encode("utf-8")
-        return contextlib.closing(io.BytesIO(payload))
+        return 200, "OK", payload
 
-    with mock.patch.object(prepare_gptoss_diff.request, "urlopen", _fake_urlopen):
+    with mock.patch.object(prepare_gptoss_diff, "_perform_https_request", _fake_request):
         result = prepare_gptoss_diff.prepare_diff(
             "example/repo",
             "123",

--- a/tests/test_run_gptoss_review.py
+++ b/tests/test_run_gptoss_review.py
@@ -116,10 +116,11 @@ def test_main_handles_timeout(monkeypatch, tmp_path):
     github_output = tmp_path / "gh_output.txt"
     monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
 
-    def _timeout(*_args, **_kwargs):
+    def _timeout(parsed, data, headers, timeout):
+        _ = (parsed, data, headers, timeout)
         raise TimeoutError("boom")
 
-    monkeypatch.setattr(run_gptoss_review.request, "urlopen", _timeout)
+    monkeypatch.setattr(run_gptoss_review, "_perform_http_request", _timeout)
 
     exit_code = run_gptoss_review.main(["--diff", str(diff_path)])
 


### PR DESCRIPTION
## Summary
- replace urllib usage in prepare_gptoss_diff with an HTTPS-only http.client helper
- use validated HTTP(S) connections in run_gptoss_review to tighten request handling
- enforce HTTPS targets and resilient retries when submitting dependency snapshots, updating tests for new helpers

## Testing
- bandit -r . -ll -ii -x ./tests,./scripts,./gptoss_check
- pytest tests/test_prepare_gptoss_diff.py tests/test_run_gptoss_review.py tests/test_dependency_snapshot_parser.py

------
https://chatgpt.com/codex/tasks/task_e_68d02c79b1a4832db58b9ba5cbfc911a