### PR TITLE
Limit dependency submission to requirements txt manifests

### DIFF
--- a/scripts/submit_dependency_snapshot.py
+++ b/scripts/submit_dependency_snapshot.py
@@ -16,7 +16,7 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
-MANIFEST_PATTERNS = ("requirements*.txt", "requirements*.in", "requirements*.out")
+MANIFEST_PATTERNS = ("requirements*.txt",)
 _REQUIREMENT_RE = re.compile(r"^(?P<name>[A-Za-z0-9_.-]+)(?:\[[^\]]+\])?==(?P<version>[^\s]+)")
 _DEFAULT_API_VERSION = "2022-11-28"
 _RETRYABLE_STATUS_CODES = {500, 502, 503, 504}


### PR DESCRIPTION
## Summary
- exclude requirements `.in` and `.out` manifests when building the dependency snapshot
- keep the dependency count within GitHub's submission limits so dependency-graph workflow can succeed

## Testing
- GITHUB_REPOSITORY=averinaleks/bot GITHUB_TOKEN=ghs_dummy12345678901234567890 GITHUB_SHA=d34db33f GITHUB_REF=refs/heads/main GITHUB_API_URL=https://example.com python scripts/submit_dependency_snapshot.py

------
https://chatgpt.com/codex/tasks/task_e_68d02e0ca4d8832d976ce8331a78585b