### PR TITLE
Refine joblib deserialization safety

### DIFF
--- a/model_builder.py
+++ b/model_builder.py
@@ -12,7 +12,6 @@ import importlib.metadata
 import json
 import math
 import os
-import pickle
 import platform
 import random
 import re
@@ -37,6 +36,7 @@ from bot.utils import (
 )
 from models.architectures import KERAS_FRAMEWORKS, create_model
 from security import (
+    ArtifactDeserializationError,
     ensure_minimum_ray_version,
     harden_mlflow,
     safe_joblib_load,
@@ -1183,7 +1183,7 @@ class ModelBuilder:
                 return
             try:
                 state = safe_joblib_load(state_path)
-            except pickle.UnpicklingError:
+            except ArtifactDeserializationError:
                 logger.error(
                     "Отказ от загрузки состояния из %s: обнаружены недоверенные объекты",
                     sanitize_log_value(state_path),
@@ -2170,7 +2170,7 @@ def _load_model() -> None:
         return
     try:
         _model = safe_joblib_load(model_path)
-    except pickle.UnpicklingError:
+    except ArtifactDeserializationError:
         logger.error(
             "Отказ от загрузки модели %s: обнаружены недоверенные объекты",
             sanitize_log_value(model_path),

--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import pickle
 import sys
 from pathlib import Path
 import re
@@ -26,6 +25,7 @@ from bot.dotenv_utils import load_dotenv
 from bot.utils import ensure_writable_directory
 from services.logging_utils import sanitize_log_value
 from security import (
+    ArtifactDeserializationError,
     safe_joblib_load,
     verify_model_state_signature,
     write_model_state_signature,
@@ -349,7 +349,7 @@ else:  # scikit-learn fallback used by tests
             return
         try:
             data = safe_joblib_load(path)
-        except pickle.UnpicklingError:
+        except ArtifactDeserializationError:
             app.logger.warning(
                 "Refused to load model %s: содержит недоверенные объекты", path
             )


### PR DESCRIPTION
## Summary
- replace direct pickle imports with a dedicated `ArtifactDeserializationError` abstraction
- update the security helpers to raise the new error and translate unsafe joblib failures
- catch the safer exception when loading models in both the trainer and service

## Testing
- bandit -r .

------
https://chatgpt.com/codex/tasks/task_e_68d03303c8f4832d92c6f960652ca4df