### PR TITLE
Fix invalid Ruff noqa codes in cache imports

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -32,9 +32,9 @@ def _sanitize_timeframe(timeframe: str) -> str:
     """Sanitize timeframe string using utility helper."""
 
     try:  # pragma: no cover - import style depends on caller
-        from .utils import sanitize_timeframe  # type: ignore  # noqa: WPS433
+        from .utils import sanitize_timeframe  # type: ignore  # noqa: E402
     except ImportError:  # pragma: no cover
-        from utils import sanitize_timeframe  # type: ignore  # noqa: WPS433
+        from utils import sanitize_timeframe  # type: ignore  # noqa: E402
 
     return sanitize_timeframe(timeframe)
 


### PR DESCRIPTION
## Summary
- replace outdated `# noqa: WPS433` markers with the Ruff-compatible `# noqa: E402`
- keep the lazy imports used to avoid circular dependencies but ensure Ruff no longer reports invalid noqa codes

## Testing
- `pytest tests/test_gptoss_check.py tests/test_run_gptoss_review.py tests/test_prepare_gptoss_diff.py tests/test_gptoss_mock_server.py`
- `ruff check`


------
https://chatgpt.com/codex/tasks/task_e_68d032c39ea8832d9513bddb83c4f976