### PR TITLE
Fix Dependabot workflow summary append command

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -87,7 +87,9 @@ jobs:
       - name: Report auto-merge failure
         if: ${{ steps.enable_automerge.conclusion == 'failure' }}
         run: |
-          printf '%s\n' "Auto-merge could not be enabled automatically. Check repository settings or branch protection rules." >> "$GITHUB_STEP_SUMMARY"
+          printf '%s\n' \
+            "Auto-merge could not be enabled automatically. Check repository settings or branch protection rules." \
+            >> "$GITHUB_STEP_SUMMARY"
 
   # GitHub still triggers this workflow on pushes to the default branch when the
   # workflow file itself changes.  Those runs use the account that pushed the


### PR DESCRIPTION
## Summary
- adjust the Dependabot auto-merge workflow so the failure message append command no longer breaks when long lines are wrapped

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d032a64e08832d9def86b65d9e132f