### PR TITLE
Fix Trivy misconfigurations in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY docker/patches/linux-pam-CVE-2024-10963.patch /tmp/security/linux-pam-CVE-2
 COPY docker/scripts/update_pam_changelog.py /tmp/security/update_pam_changelog.py
 RUN set -eux; \
     apt-get update; \
-    apt-get dist-upgrade -y; \
+    apt-get upgrade -y; \
     apt-get install -y --no-install-recommends \
         tzdata \
         linux-libc-dev \
@@ -119,7 +119,7 @@ COPY --from=builder /app/venv /app/venv
 COPY --from=builder /tmp/pam-fixed /tmp/pam-fixed
 
 # Установка минимальных пакетов выполнения
-RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     python3 \
     libpython3.12-stdlib \
     coreutils \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -7,8 +7,8 @@ FROM ubuntu:24.04@sha256:985be7c735afdf6f18aaa122c23f87d989c30bba4e9aa24c8278912
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Обновление linux-libc-dev устраняет CVE-2025-21976, а libgcrypt20 — CVE-2024-2236.
-# Дополнительно выполняем dist-upgrade, чтобы подтянуть свежие патчи безопасности из Ubuntu.
-RUN apt-get update && apt-get dist-upgrade -y && apt-get install --no-install-recommends -y \
+# Дополнительно выполняем upgrade, чтобы подтянуть свежие патчи безопасности из Ubuntu.
+RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y \
     python3 python3-venv build-essential linux-libc-dev libgcrypt20 git \
     && apt-get install -y --no-install-recommends gnupg dirmngr \
     && apt-get install -y --only-upgrade libpam0g libpam-modules \
@@ -35,7 +35,7 @@ FROM ubuntu:24.04@sha256:985be7c735afdf6f18aaa122c23f87d989c30bba4e9aa24c8278912
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Устанавливаем только необходимые пакеты выполнения и сразу обновляем базовую систему
-RUN apt-get update && apt-get dist-upgrade -y && apt-get install --no-install-recommends -y \
+RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y \
     libssl3t64 \
     python3.12-minimal \
     && apt-get install -y --only-upgrade openssl libssl3t64 libpam0g libpam-modules \

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -3,7 +3,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Обновление linux-libc-dev устраняет CVE-2025-21976, а libgcrypt20 — CVE-2024-2236
 # Обновляем систему перед установкой зависимостей
-RUN apt-get update && apt-get dist-upgrade -y \
+RUN apt-get update && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
         linux-libc-dev \
         libssl3t64 \


### PR DESCRIPTION
## Summary
- replace apt-get dist-upgrade with apt-get upgrade in runtime and builder Docker stages so Trivy no longer flags misconfigurations
- adjust CI Dockerfile comment to reflect the updated package upgrade strategy

## Testing
- trivy fs --exit-code 1 --format sarif --output trivy-results.sarif --severity CRITICAL,HIGH --ignore-unfixed .

------
https://chatgpt.com/codex/tasks/task_e_68d032e4eeec832dbdf2496759519454