### PR TITLE
Harden CONFIG_PATH handling

### DIFF
--- a/tests/test_load_defaults_error.py
+++ b/tests/test_load_defaults_error.py
@@ -1,11 +1,19 @@
+from pathlib import Path
+
+import contextlib
 import pytest
 from bot import config
 
 
-def test_load_defaults_raises_config_load_error(monkeypatch, tmp_path):
-    bad = tmp_path / "bad.json"
+def test_load_defaults_raises_config_load_error(monkeypatch):
+    config_dir = Path(config.CONFIG_PATH).resolve().parent
+    bad = config_dir / "bad.json"
     bad.write_text("{invalid")
     monkeypatch.setattr(config, "CONFIG_PATH", str(bad))
     monkeypatch.setattr(config, "DEFAULTS", None)
-    with pytest.raises(config.ConfigLoadError):
-        config.load_defaults()
+    try:
+        with pytest.raises(config.ConfigLoadError):
+            config.load_defaults()
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            bad.unlink()


### PR DESCRIPTION
## Summary
- constrain CONFIG_PATH to the repository config directory and reject invalid/symlinked values
- apply the same CONFIG_PATH validation to the model_builder_service bootstrap configuration
- update the load_defaults error test to work with the tightened path restrictions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0331e0aac832d94c6007443dab357