### PR TITLE
Encode dependency snapshot versions safely

### DIFF
--- a/scripts/submit_dependency_snapshot.py
+++ b/scripts/submit_dependency_snapshot.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, Iterable, TypedDict
 
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 MANIFEST_PATTERNS = (
     "requirements*.txt",
@@ -74,6 +74,13 @@ class Manifest(TypedDict):
     resolved: Dict[str, ResolvedDependency]
 
 
+def _encode_version_for_purl(version: str) -> str:
+    """Return a dependency version encoded for use inside a purl."""
+
+    safe_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._-~"
+    return quote(version, safe=safe_chars)
+
+
 def _parse_requirements(path: Path) -> Dict[str, ResolvedDependency]:
     scope = _derive_scope(path.name)
     resolved: Dict[str, ResolvedDependency] = OrderedDict()
@@ -109,7 +116,7 @@ def _parse_requirements(path: Path) -> Dict[str, ResolvedDependency]:
         package_name = _normalise_name(name)
         if package_name in _SKIPPED_PACKAGES:
             continue
-        package_url = f"pkg:pypi/{package_name}@{version}"
+        package_url = f"pkg:pypi/{package_name}@{_encode_version_for_purl(version)}"
         resolved[package_name] = {
             "package_url": package_url,
             "relationship": "direct",

--- a/tests/test_dependency_snapshot.py
+++ b/tests/test_dependency_snapshot.py
@@ -41,3 +41,12 @@ def test_parse_requirements_skips_blocklisted_packages(tmp_path: Path) -> None:
     assert "ccxtpro" not in resolved
     assert "httpx" in resolved
     assert resolved["httpx"]["package_url"] == "pkg:pypi/httpx@0.27.2"
+
+
+def test_parse_requirements_encodes_versions_for_purl(tmp_path: Path) -> None:
+    requirement_file = tmp_path / "requirements.txt"
+    requirement_file.write_text("torch==2.8.0+cpu\n")
+
+    resolved = snapshot._parse_requirements(requirement_file)
+
+    assert resolved["torch"]["package_url"] == "pkg:pypi/torch@2.8.0%2Bcpu"


### PR DESCRIPTION
## Summary
- percent-encode dependency versions when constructing purls for the dependency snapshot script to satisfy the GitHub API
- add a regression test that covers versions containing a plus sign

## Testing
- pytest tests/test_dependency_snapshot.py

------
https://chatgpt.com/codex/tasks/task_e_68d033876e5c832daa948a643f59224d