### PR TITLE
Fix mypy typing for joblib unpickler wrappers

### DIFF
--- a/security.py
+++ b/security.py
@@ -14,7 +14,7 @@ import os
 import pickle
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Iterable, Tuple
+from typing import Any, Iterable, Tuple, cast
 
 from packaging.version import InvalidVersion, Version
 
@@ -112,8 +112,8 @@ def _restricted_joblib_unpicklers(allowed: Tuple[str, ...]):
             "joblib недоступен: установите зависимость для работы с артефактами"
         )
 
-    original_unpickler = _joblib_numpy_pickle.NumpyUnpickler
-    compat_unpickler = None
+    original_unpickler: type[Any] = _joblib_numpy_pickle.NumpyUnpickler
+    compat_unpickler: type[Any] | None = None
     if _joblib_numpy_pickle_compat is not None:
         compat_unpickler = getattr(
             _joblib_numpy_pickle_compat, "NumpyUnpickler", None
@@ -137,7 +137,9 @@ def _restricted_joblib_unpicklers(allowed: Tuple[str, ...]):
             return super().find_class(module, name)
 
     if compat_unpickler is not None:
-        class _RestrictedCompatUnpickler(compat_unpickler):  # type: ignore[misc]
+        compat_unpickler_cls = cast(type[Any], compat_unpickler)
+
+        class _RestrictedCompatUnpickler(compat_unpickler_cls):  # type: ignore[misc, valid-type]
             def __init__(self, *args, **kwargs):
                 self._allowed_modules = allowed
                 super().__init__(*args, **kwargs)


### PR DESCRIPTION
## Summary
- add precise typing for joblib unpickler wrappers to satisfy mypy validation
- cast optional compatibility unpickler before subclassing and extend ignore annotations accordingly

## Testing
- python -m flake8 --exclude venv .
- python -m mypy --exclude venv .
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d033fc6af8832d9b771b89248e2358