### PR TITLE
Fix dependency snapshot manifest keys

### DIFF
--- a/scripts/submit_dependency_snapshot.py
+++ b/scripts/submit_dependency_snapshot.py
@@ -117,7 +117,7 @@ def _parse_requirements(path: Path) -> Dict[str, ResolvedDependency]:
         if package_name in _SKIPPED_PACKAGES:
             continue
         package_url = f"pkg:pypi/{package_name}@{_encode_version_for_purl(version)}"
-        resolved[package_name] = {
+        resolved[package_url] = {
             "package_url": package_url,
             "relationship": "direct",
             "scope": scope,

--- a/tests/test_dependency_snapshot.py
+++ b/tests/test_dependency_snapshot.py
@@ -38,9 +38,12 @@ def test_parse_requirements_skips_blocklisted_packages(tmp_path: Path) -> None:
 
     resolved = snapshot._parse_requirements(requirement_file)
 
-    assert "ccxtpro" not in resolved
-    assert "httpx" in resolved
-    assert resolved["httpx"]["package_url"] == "pkg:pypi/httpx@0.27.2"
+    assert "pkg:pypi/ccxtpro@1.0.1" not in resolved
+    assert "pkg:pypi/httpx@0.27.2" in resolved
+    assert (
+        resolved["pkg:pypi/httpx@0.27.2"]["package_url"]
+        == "pkg:pypi/httpx@0.27.2"
+    )
 
 
 def test_parse_requirements_encodes_versions_for_purl(tmp_path: Path) -> None:
@@ -49,4 +52,7 @@ def test_parse_requirements_encodes_versions_for_purl(tmp_path: Path) -> None:
 
     resolved = snapshot._parse_requirements(requirement_file)
 
-    assert resolved["torch"]["package_url"] == "pkg:pypi/torch@2.8.0%2Bcpu"
+    assert (
+        resolved["pkg:pypi/torch@2.8.0%2Bcpu"]["package_url"]
+        == "pkg:pypi/torch@2.8.0%2Bcpu"
+    )

--- a/tests/test_dependency_snapshot_parser.py
+++ b/tests/test_dependency_snapshot_parser.py
@@ -27,10 +27,16 @@ def test_parse_requirements_strips_inline_comments(tmp_path: Path) -> None:
 
     parsed = _parse_requirements(path)
 
-    assert "package" in parsed
-    assert parsed["package"]["package_url"] == "pkg:pypi/package@1.2.3"
-    assert "other" in parsed
-    assert parsed["other"]["package_url"] == "pkg:pypi/other@4.5.6"
+    assert "pkg:pypi/package@1.2.3" in parsed
+    assert (
+        parsed["pkg:pypi/package@1.2.3"]["package_url"]
+        == "pkg:pypi/package@1.2.3"
+    )
+    assert "pkg:pypi/other@4.5.6" in parsed
+    assert (
+        parsed["pkg:pypi/other@4.5.6"]["package_url"]
+        == "pkg:pypi/other@4.5.6"
+    )
 
 
 def test_parse_requirements_handles_hash_block(tmp_path: Path) -> None:
@@ -45,7 +51,7 @@ def test_parse_requirements_handles_hash_block(tmp_path: Path) -> None:
 
     parsed = _parse_requirements(path)
 
-    assert list(parsed) == ["sample"]
+    assert list(parsed) == ["pkg:pypi/sample@0.1.0"]
 
 
 def test_auth_schemes_prefers_bearer_for_github_tokens(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- use package URLs as keys in dependency snapshot manifests to match the GitHub API format
- adjust dependency snapshot unit tests to assert against the package URL keyed structure

## Testing
- pytest tests/test_dependency_snapshot.py tests/test_dependency_snapshot_parser.py

------
https://chatgpt.com/codex/tasks/task_e_68d0361f3694832db539c5575e1c82f4