### PR TITLE
Fix dependency graph workflow permissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -14,7 +14,6 @@ permissions:
   contents: write
   id-token: write
   security-events: write
-  dependency-graph: write
 
 jobs:
   submit:
@@ -22,7 +21,6 @@ jobs:
       contents: write
       id-token: write
       security-events: write
-      dependency-graph: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4


### PR DESCRIPTION
## Summary
- remove the unsupported `dependency-graph` permission from the dependency submission workflow so the file parses correctly

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d03ce1aef8832d8b6d2251b8a96ced