### PR TITLE
Disable default CodeQL setup for custom workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,6 +15,8 @@ jobs:
       actions: read
       contents: read
       security-events: write
+    env:
+      CODEQL_ACTION_DISABLE_DEFAULT_SETUP: true
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- set CODEQL_ACTION_DISABLE_DEFAULT_SETUP to true for the CodeQL job to prevent conflicts with the repository's default setup

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d03d170940832da4e51f1b7485c715