### PR TITLE
Fix Dependabot workflow noop job execution

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -97,8 +97,11 @@ jobs:
   # skipped and GitHub marks the overall workflow as a failure.  Provide a tiny
   # no-op job for those runs so the workflow reports success instead of red X's.
   noop:
-    if: ${{ github.event_name != 'pull_request_target' || github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - name: Skip non-Dependabot runs
+        if: ${{ github.event_name != 'pull_request_target' || github.actor != 'dependabot[bot]' }}
         run: echo "Dependabot workflow is only relevant to Dependabot PRs; nothing to do for actor '${{ github.actor }}'."
+      - name: Confirm Dependabot execution
+        if: ${{ github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]' }}
+        run: echo "Primary Dependabot job handled this run; noop job completes successfully."


### PR DESCRIPTION
## Summary
- ensure the noop job in the Dependabot workflow always runs by moving the guard condition to the step level
- add a confirmation step so Dependabot-triggered runs also complete successfully

## Testing
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_e_68d03d2d01d0832d89011761c0d3369c