### PR TITLE
Normalize dependency snapshot manifest paths

### DIFF
--- a/scripts/submit_dependency_snapshot.py
+++ b/scripts/submit_dependency_snapshot.py
@@ -132,9 +132,21 @@ def _build_manifests(root: Path) -> Dict[str, Manifest]:
         resolved = _parse_requirements(manifest)
         if not resolved:
             continue
-        manifests[str(manifest)] = {
+        try:
+            relative_path = manifest.relative_to(root)
+        except ValueError:
+            # Fallback for unexpected paths outside of the provided root.
+            relative_path = manifest.name
+
+        relative_str = (
+            relative_path.as_posix()
+            if isinstance(relative_path, Path)
+            else str(relative_path)
+        )
+
+        manifests[relative_str] = {
             "name": manifest.name,
-            "file": {"source_location": str(manifest)},
+            "file": {"source_location": relative_str},
             "resolved": resolved,
         }
     return manifests

--- a/tests/test_dependency_snapshot.py
+++ b/tests/test_dependency_snapshot.py
@@ -21,14 +21,13 @@ def test_build_manifests_includes_supported_patterns(tmp_path: Path, filename: s
 
     manifests = snapshot._build_manifests(tmp_path)
 
-    # The manifests use string keys, which are absolute paths when a temporary
-    # directory is used. Normalize via Path for the comparison.
-    manifest_paths = {Path(key) for key in manifests.keys()}
+    assert set(manifests.keys()) == {filename}
 
-    assert requirement_file in manifest_paths
+    manifest_data = manifests[filename]
+    assert manifest_data["file"]["source_location"] == filename
     assert any(
         entry["package_url"] == "pkg:pypi/requests@2.32.3"
-        for entry in manifests[next(iter(manifests))]["resolved"].values()
+        for entry in manifest_data["resolved"].values()
     )
 
 

--- a/tests/test_dependency_snapshot_parser.py
+++ b/tests/test_dependency_snapshot_parser.py
@@ -77,10 +77,13 @@ def test_build_manifests_supports_multiple_patterns(tmp_path: Path) -> None:
     manifests = _build_manifests(tmp_path)
 
     assert set(manifests) == {
-        str(tmp_path / "requirements.txt"),
-        str(tmp_path / "requirements-dev.in"),
-        str(tmp_path / "requirements-full.out"),
+        "requirements.txt",
+        "requirements-dev.in",
+        "requirements-full.out",
     }
+
+    for name, manifest in manifests.items():
+        assert manifest["file"]["source_location"] == name
 
 
 def test_job_metadata_adds_html_url_when_run_id_numeric(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- ensure dependency snapshot manifests use repository-relative keys
- record the same normalized path in the manifest file metadata
- update snapshot tests to assert the normalized paths

## Testing
- pytest -q tests/test_dependency_snapshot.py tests/test_dependency_snapshot_parser.py
- pytest -q --maxfail=1 --disable-warnings

------
https://chatgpt.com/codex/tasks/task_e_68d03d55e214832daf99e745fcc3f0c2