### PR TITLE
Fix dependency graph workflow errors

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -14,6 +14,7 @@ permissions:
   contents: write
   id-token: write
   security-events: write
+  dependency-graph: write
 
 jobs:
   submit:
@@ -21,12 +22,13 @@ jobs:
       contents: write
       id-token: write
       security-events: write
+      dependency-graph: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.x'
+          python-version: '3.11'
       - name: Prepare requirements
         run: |
           python <<'PY'


### PR DESCRIPTION
## Summary
- grant the dependency graph write permission and pin Python 3.11 in the submission workflow
- make the dependency snapshot helper treat retryable server errors as non-fatal so the job does not fail on transient issues

## Testing
- python -m compileall scripts/submit_dependency_snapshot.py

------
https://chatgpt.com/codex/tasks/task_e_68d051162584832d8ccbdcd4708c6d21