### PR TITLE
Fix docker publish workflow for forks

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -152,7 +152,6 @@ jobs:
           context: .
           file: ${{ matrix.file }}
           push: ${{ env.PUBLISH_IMAGES == 'true' }}
-          load: ${{ env.PUBLISH_IMAGES != 'true' }}
           tags: ${{ steps.tags.outputs.list }}
           cache-from: type=gha,scope=${{ matrix.image }}
           cache-to: type=gha,scope=${{ matrix.image }},mode=max


### PR DESCRIPTION
## Summary
- avoid requesting a docker image load when publishing is disabled so the docker buildx action runs with its container driver

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d05d492450832d8bbd69304f202f4a