### PR TITLE
Generate offline credentials instead of hard-coding

### DIFF
--- a/bot/trade_manager/core.py
+++ b/bot/trade_manager/core.py
@@ -64,7 +64,10 @@ from bot.http_client import (  # noqa: E402
     get_async_http_client as get_http_client,
     close_async_http_client as close_http_client,
 )
-from services.offline import ensure_offline_env  # noqa: E402
+from services.offline import (  # noqa: E402
+    ensure_offline_env,
+    generate_placeholder_credential,
+)
 
 torch: Any
 try:  # pragma: no cover - optional dependency
@@ -224,8 +227,12 @@ class TradeManager:
         if OFFLINE_MODE:
             ensure_offline_env(
                 {
-                    "TELEGRAM_BOT_TOKEN": "offline-telegram-token",
-                    "TELEGRAM_CHAT_ID": "offline-chat-id",
+                    "TELEGRAM_BOT_TOKEN": lambda: generate_placeholder_credential(
+                        "telegram-token"
+                    ),
+                    "TELEGRAM_CHAT_ID": lambda: generate_placeholder_credential(
+                        "telegram-chat"
+                    ),
                 }
             )
 

--- a/tests/test_offline_env.py
+++ b/tests/test_offline_env.py
@@ -1,0 +1,51 @@
+"""Tests for offline environment helpers."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from services import offline
+
+
+@pytest.fixture(autouse=True)
+def restore_env():
+    """Ensure environment variables created during a test are removed afterwards."""
+
+    snapshot = dict(os.environ)
+    yield
+    for key in set(os.environ) - set(snapshot):
+        del os.environ[key]
+    for key, value in snapshot.items():
+        os.environ[key] = value
+
+
+def test_ensure_offline_env_supports_callable(monkeypatch):
+    monkeypatch.setattr(offline, "OFFLINE_MODE", True)
+    monkeypatch.delenv("OFFLINE_TEST_TOKEN", raising=False)
+
+    generated: list[str] = []
+
+    def _factory() -> str:
+        value = offline.generate_placeholder_credential("unit-test")
+        generated.append(value)
+        return value
+
+    applied = offline.ensure_offline_env({"OFFLINE_TEST_TOKEN": _factory})
+
+    assert applied == ["OFFLINE_TEST_TOKEN"]
+    assert os.environ["OFFLINE_TEST_TOKEN"] == generated[0]
+
+    second = offline.ensure_offline_env({"OFFLINE_TEST_TOKEN": lambda: "ignored"})
+    assert second == []
+    assert os.environ["OFFLINE_TEST_TOKEN"] == generated[0]
+
+
+def test_generate_placeholder_credential_entropy():
+    token_one = offline.generate_placeholder_credential("entropy-check")
+    token_two = offline.generate_placeholder_credential("entropy-check")
+
+    assert token_one != token_two
+    assert token_one.startswith("offline-entropy-check-")
+    assert token_two.startswith("offline-entropy-check-")


### PR DESCRIPTION
## Summary
- generate offline placeholder credentials on demand to avoid hard-coded secrets flagged by CodeQL
- allow `ensure_offline_env` to accept callables and add defensive error handling
- update Telegram fallback setup to use the new helper and add unit tests for offline helpers

## Testing
- `pytest tests/test_offline_env.py`


------
https://chatgpt.com/codex/tasks/task_e_68d05d7abc2c832d84dfcb88693732a0