### PR TITLE
Fix dependabot workflow checkout fallback

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -38,8 +38,8 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           fetch-depth: 0
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       # Set up a lightweight Python environment and install only the
       # dependencies required to run the unit tests.  This avoids the


### PR DESCRIPTION
## Summary
- ensure the Dependabot workflow can check out security update branches even when the head repository metadata is missing by falling back to the base repository
- switch the checkout ref to the pull request head commit to guarantee we test the intended revision

## Testing
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_e_68d05d8ab5cc832d85992b0c744f9038