### PR TITLE
Fix Release Drafter workflow condition

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   update_release_draft:
-    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    if: ${{ github.event_name != 'pull_request' || (github.event.pull_request && github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
     steps:
       - name: Update release draft


### PR DESCRIPTION
## Summary
- guard the Release Drafter workflow so it only references pull request data when available

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d05db81d80832db99d0deb4767e158