### PR TITLE
Fix dependency graph snapshot keys

### DIFF
--- a/scripts/submit_dependency_snapshot.py
+++ b/scripts/submit_dependency_snapshot.py
@@ -117,7 +117,7 @@ def _parse_requirements(path: Path) -> Dict[str, ResolvedDependency]:
         if package_name in _SKIPPED_PACKAGES:
             continue
         package_url = f"pkg:pypi/{package_name}@{_encode_version_for_purl(version)}"
-        resolved[package_url] = {
+        resolved[package_name] = {
             "package_url": package_url,
             "relationship": "direct",
             "scope": scope,

--- a/tests/test_dependency_snapshot.py
+++ b/tests/test_dependency_snapshot.py
@@ -25,10 +25,7 @@ def test_build_manifests_includes_supported_patterns(tmp_path: Path, filename: s
 
     manifest_data = manifests[filename]
     assert manifest_data["file"]["source_location"] == filename
-    assert any(
-        entry["package_url"] == "pkg:pypi/requests@2.32.3"
-        for entry in manifest_data["resolved"].values()
-    )
+    assert manifest_data["resolved"]["requests"]["package_url"] == "pkg:pypi/requests@2.32.3"
 
 
 def test_parse_requirements_skips_blocklisted_packages(tmp_path: Path) -> None:
@@ -37,12 +34,9 @@ def test_parse_requirements_skips_blocklisted_packages(tmp_path: Path) -> None:
 
     resolved = snapshot._parse_requirements(requirement_file)
 
-    assert "pkg:pypi/ccxtpro@1.0.1" not in resolved
-    assert "pkg:pypi/httpx@0.27.2" in resolved
-    assert (
-        resolved["pkg:pypi/httpx@0.27.2"]["package_url"]
-        == "pkg:pypi/httpx@0.27.2"
-    )
+    assert "ccxtpro" not in resolved
+    assert "httpx" in resolved
+    assert resolved["httpx"]["package_url"] == "pkg:pypi/httpx@0.27.2"
 
 
 def test_parse_requirements_encodes_versions_for_purl(tmp_path: Path) -> None:
@@ -51,7 +45,4 @@ def test_parse_requirements_encodes_versions_for_purl(tmp_path: Path) -> None:
 
     resolved = snapshot._parse_requirements(requirement_file)
 
-    assert (
-        resolved["pkg:pypi/torch@2.8.0%2Bcpu"]["package_url"]
-        == "pkg:pypi/torch@2.8.0%2Bcpu"
-    )
+    assert resolved["torch"]["package_url"] == "pkg:pypi/torch@2.8.0%2Bcpu"


### PR DESCRIPTION
## Summary
- use normalised package names as manifest keys when building dependency snapshots so the payload matches the GitHub schema
- adjust dependency snapshot tests to reflect the new resolved key structure

## Testing
- pytest tests/test_dependency_snapshot.py

------
https://chatgpt.com/codex/tasks/task_e_68d05cf26dc4832dbe4779d75979c6cd