### PR TITLE
Fix mypy config path optional handling

### DIFF
--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -128,14 +128,19 @@ def _is_within_directory(path: Path, directory: Path) -> bool:
 
 
 def _resolve_config_path(raw: str | os.PathLike[str] | None) -> Path:
-    if raw in (None, ""):
+    if raw is None:
         return _DEFAULT_CONFIG_PATH
 
     try:
-        candidate = Path(raw)
+        raw_path = os.fspath(raw)
     except TypeError:
         LOGGER.warning("Invalid CONFIG_PATH %r; using default", raw)
         return _DEFAULT_CONFIG_PATH
+
+    if raw_path == "":
+        return _DEFAULT_CONFIG_PATH
+
+    candidate = Path(raw_path)
 
     if not candidate.is_absolute():
         candidate = (_CONFIG_DIR / candidate).resolve(strict=False)


### PR DESCRIPTION
## Summary
- ensure CONFIG_PATH resolution only instantiates Path when a real filesystem string is available
- preserve the existing fallback logic while satisfying mypy's stricter type expectations

## Testing
- python -m ruff check services/model_builder_service.py
- python -m mypy bot
- python -m bandit -r bot -x tests -ll
- pytest -m "not integration"

------
https://chatgpt.com/codex/tasks/task_e_68d05d5844ec832dad0d8c7a69ea04ab