### PR TITLE
Исправление ошибок mypy в обработке путей конфигурации

### DIFF
--- a/config.py
+++ b/config.py
@@ -137,7 +137,7 @@ def _is_within_directory(path: Path, directory: Path) -> bool:
 def _resolve_config_path(raw: str | os.PathLike[str] | None) -> Path:
     """Return a config path confined to ``_CONFIG_DIR``."""
 
-    if raw in (None, ""):
+    if raw is None or raw == "":
         return _DEFAULT_CONFIG_PATH
 
     try:

--- a/scripts/submit_dependency_snapshot.py
+++ b/scripts/submit_dependency_snapshot.py
@@ -133,20 +133,14 @@ def _build_manifests(root: Path) -> Dict[str, Manifest]:
         if not resolved:
             continue
         try:
-            relative_path = manifest.relative_to(root)
+            relative_path = manifest.relative_to(root).as_posix()
         except ValueError:
             # Fallback for unexpected paths outside of the provided root.
             relative_path = manifest.name
 
-        relative_str = (
-            relative_path.as_posix()
-            if isinstance(relative_path, Path)
-            else str(relative_path)
-        )
-
-        manifests[relative_str] = {
+        manifests[relative_path] = {
             "name": manifest.name,
-            "file": {"source_location": relative_str},
+            "file": {"source_location": relative_path},
             "resolved": resolved,
         }
     return manifests

--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -128,7 +128,7 @@ def _is_within_directory(path: Path, directory: Path) -> bool:
 
 
 def _resolve_config_path(raw: str | os.PathLike[str] | None) -> Path:
-    if raw in (None, ""):
+    if raw is None or raw == "":
         return _DEFAULT_CONFIG_PATH
 
     try:


### PR DESCRIPTION
## Summary
- корректно обрабатываем пустые значения CONFIG_PATH и исключаем передачу None в Path
- нормализуем относительные пути манифестов в скрипте отправки dependency snapshot

## Testing
- python -m flake8 --exclude venv .
- python -m mypy --exclude venv .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d05d6ad2bc832d9b9d20b383f2165c