### PR TITLE
chore: stabilise dependabot by ignoring GPU stacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,30 @@ updates:
       - dependency-name: "torchvision"
       - dependency-name: "torchaudio"
       - dependency-name: "vllm"
+      # GPU-tuned runtimes and their support stack take several minutes to
+      # resolve and routinely trigger the 20 minute timeout in the
+      # dependabot/dependabot-updates workflow.  Exclude them from automated
+      # refreshes so the job completes successfully and we can batch these
+      # upgrades manually when GPU images are rebuilt.
+      - dependency-name: "cupy-cuda12x"
+      - dependency-name: "tensorflow"
+      - dependency-name: "keras"
+      - dependency-name: "tensorboard"
+      - dependency-name: "tensorboard-data-server"
+      - dependency-name: "ml-dtypes"
+      - dependency-name: "opt-einsum"
+      - dependency-name: "optree"
+      - dependency-name: "sympy"
+      # Reinforcement learning stacks also exceed Dependabot's solver
+      # thresholds; keep them frozen until we refresh the training images
+      # out-of-band.
+      - dependency-name: "stable-baselines3"
+      - dependency-name: "gymnasium"
+      - dependency-name: "ray"
+      # ccxtpro is a commercial package that often trips Dependabot's rate
+      # limits; it is safer to upgrade it manually together with the
+      # matching back-end services.
+      - dependency-name: "ccxtpro"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary
- extend the Dependabot ignore list with GPU-focused packages that repeatedly exhaust the workflow runtime
- document why reinforcement-learning and commercial exchange clients are skipped so updates can be batched manually

## Testing
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_e_68d05d97d5b4832daa52d9482846259a