### PR TITLE
Improve resilience of GPT-OSS review workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -101,8 +101,24 @@ jobs:
           python scripts/gptoss_mock_server.py \
             --host 127.0.0.1 \
             --port 0 \
-            --port-file mock_server.port &
+            --port-file mock_server.port \
+            >mock_server.log 2>&1 &
           echo $! > mock_server.pid
+
+          # Make sure the background process actually started before waiting
+          # for the ``mock_server.port`` file.  ``kill -0`` returns success when
+          # the PID is alive and avoids failing the step because of "set -e".
+          if ! kill -0 "$(cat mock_server.pid)" 2>/dev/null; then
+            echo "::warning::Mock GPT-OSS server exited immediately" >&2
+            if [ -s mock_server.log ]; then
+              sed 's/^/mock-server: /' mock_server.log >&2 || true
+            fi
+            rm -f mock_server.pid mock_server.port mock_server.log
+            if [ -n "${GITHUB_OUTPUT:-}" ]; then
+              echo "started=false" >> "$GITHUB_OUTPUT"
+            fi
+            exit 0
+          fi
 
           ready=0
           for _ in {1..50}; do
@@ -123,7 +139,10 @@ jobs:
               kill "$(cat mock_server.pid)" || true
               rm -f mock_server.pid
             fi
-            rm -f mock_server.port || true
+            if [ -s mock_server.log ]; then
+              sed 's/^/mock-server: /' mock_server.log >&2 || true
+            fi
+            rm -f mock_server.port mock_server.log || true
             if [ -n "${GITHUB_OUTPUT:-}" ]; then
               echo "started=false" >> "$GITHUB_OUTPUT"
             fi
@@ -247,4 +266,4 @@ jobs:
             kill "$(cat mock_server.pid)" || true
             rm -f mock_server.pid
           fi
-          rm -f mock_server.port
+          rm -f mock_server.port mock_server.log


### PR DESCRIPTION
## Summary
- verify that the mock GPT-OSS server actually starts and capture its logs when it fails to do so, preventing the workflow from erroring out
- clean up the temporary server log alongside the existing mock server artifacts

## Testing
- pytest tests/test_run_gptoss_review.py::test_generate_review_success -q

------
https://chatgpt.com/codex/tasks/task_e_68d05da736a8832d9f55d3067a25f93a