### PR TITLE
Align dependency snapshot payload with API expectations

### DIFF
--- a/scripts/submit_dependency_snapshot.py
+++ b/scripts/submit_dependency_snapshot.py
@@ -307,7 +307,7 @@ def submit_dependency_snapshot() -> None:
     job_name = os.getenv("GITHUB_JOB", "submit")
     run_id = os.getenv("GITHUB_RUN_ID", str(int(datetime.now(timezone.utc).timestamp())))
     run_attempt = _normalise_run_attempt(os.getenv("GITHUB_RUN_ATTEMPT"))
-    correlator = f"{workflow}-{job_name}"
+    correlator = f"{workflow}:{job_name}"
 
     payload = {
         "version": 0,
@@ -319,13 +319,11 @@ def submit_dependency_snapshot() -> None:
             "version": "1.0.0",
             "url": "https://github.com/averinaleks/bot",
         },
-        "metadata": {
-            "dependency_count": sum(len(entry["resolved"]) for entry in manifests.values()),
-            "run_attempt": run_attempt,
-        },
         "scanned": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "manifests": manifests,
     }
+
+    payload["job"]["correlator"] = f"{correlator}:attempt-{run_attempt}"
 
     base_url = _api_base_url()
     url = f"{base_url}/repos/{repository}/dependency-graph/snapshots"


### PR DESCRIPTION
## Summary
- remove the extra metadata block from the dependency snapshot payload so the request matches the documented schema
- adjust the job correlator format to follow GitHub's expectations while still making retries unique

## Testing
- GITHUB_REPOSITORY=averinaleks/bot GITHUB_SHA=deadbeef GITHUB_REF=refs/heads/main GITHUB_TOKEN=github_pat_dummy GITHUB_API_URL=https://example.com python scripts/submit_dependency_snapshot.py

------
https://chatgpt.com/codex/tasks/task_e_68d05fe875e4832db8bf046e8b34f2d7