### PR TITLE
Handle GitHub API errors in dependency snapshot workflow

### DIFF
--- a/scripts/submit_dependency_snapshot.py
+++ b/scripts/submit_dependency_snapshot.py
@@ -443,6 +443,19 @@ def submit_dependency_snapshot() -> None:
                     file=sys.stderr,
                 )
                 return
+            print(
+                "Dependency snapshot submission skipped из-за ошибки GitHub API.",
+                file=sys.stderr,
+            )
+            message = str(last_error) or ""
+            if status_code:
+                print(
+                    f"Получен код ответа HTTP {status_code}: {message}",
+                    file=sys.stderr,
+                )
+            else:
+                print(message, file=sys.stderr)
+            return
         raise last_error
 
 


### PR DESCRIPTION
## Summary
- treat unexpected GitHub API responses as non-fatal in the dependency snapshot submission script while logging the status and message
- add detailed logging for generic GitHub API errors to aid troubleshooting
- extend the dependency snapshot parser tests to cover the new behaviour

## Testing
- pytest tests/test_dependency_snapshot_parser.py
- pytest tests/test_dependency_snapshot.py

------
https://chatgpt.com/codex/tasks/task_e_68d06546bedc832da298d9f51a1a28b8