### PR TITLE
Fix dependency graph workflow permissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -14,7 +14,6 @@ permissions:
   contents: write
   id-token: write
   security-events: write
-  dependency-graph: write
 
 jobs:
   submit:
@@ -22,7 +21,6 @@ jobs:
       contents: write
       id-token: write
       security-events: write
-      dependency-graph: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4


### PR DESCRIPTION
## Summary
- remove the unsupported `dependency-graph` permission from the dependency submission workflow
- keep the required token permissions while leaving the workflow logic untouched

## Testing
- pytest tests/test_dependency_snapshot.py

------
https://chatgpt.com/codex/tasks/task_e_68d0eeadca04832da05153bedd2256f3