### PR TITLE
Fix CI typing and dependency snapshot metadata

### DIFF
--- a/bot/ray_compat.py
+++ b/bot/ray_compat.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import os
 import sys
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from typing import Any, Iterable
 
 from security import ensure_minimum_ray_version
@@ -19,7 +19,7 @@ from security import ensure_minimum_ray_version
 __all__ = ["ray", "IS_RAY_STUB"]
 
 
-def _create_stub() -> tuple[SimpleNamespace, bool]:
+def _create_stub() -> tuple[ModuleType, bool]:
     """Вернуть заглушку Ray с минимально необходимым API."""
 
     class _ObjectRef:
@@ -74,15 +74,18 @@ def _create_stub() -> tuple[SimpleNamespace, bool]:
     def _is_initialized() -> bool:
         return state["initialized"]
 
-    stub = SimpleNamespace(
-        __version__="0.0.0-stub",
-        __ray_stub__=True,
-        remote=_remote,
-        get=_unwrap,
-        init=_init,
-        shutdown=lambda **_k: _shutdown(),
-        is_initialized=_is_initialized,
-        ObjectRef=_ObjectRef,
+    stub = ModuleType("ray")
+    stub.__dict__.update(
+        {
+            "__version__": "0.0.0-stub",
+            "__ray_stub__": True,
+            "remote": _remote,
+            "get": _unwrap,
+            "init": _init,
+            "shutdown": lambda **_k: _shutdown(),
+            "is_initialized": _is_initialized,
+            "ObjectRef": _ObjectRef,
+        }
     )
     return stub, True
 

--- a/config.py
+++ b/config.py
@@ -137,7 +137,10 @@ def _is_within_directory(path: Path, directory: Path) -> bool:
 def _resolve_config_path(raw: str | os.PathLike[str] | None) -> Path:
     """Return a config path confined to ``_CONFIG_DIR``."""
 
-    if raw in (None, ""):
+    if raw is None:
+        return _DEFAULT_CONFIG_PATH
+
+    if raw == "":
         return _DEFAULT_CONFIG_PATH
 
     try:


### PR DESCRIPTION
## Summary
- ensure CONFIG_PATH resolution never passes None into Path
- build dependency snapshot payload without untyped mutation
- expose the Ray stub as a proper ModuleType to satisfy type checking

## Testing
- `python -m flake8 --exclude venv .`
- `python -m mypy --exclude venv .`
- `pytest -ra`


------
https://chatgpt.com/codex/tasks/task_e_68d0f40f1640832dafe800a8bce8774a