### PR TITLE
Reduce dependency graph workflow permissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -12,15 +12,9 @@ on:
 
 permissions:
   contents: write
-  id-token: write
-  security-events: write
 
 jobs:
   submit:
-    permissions:
-      contents: write
-      id-token: write
-      security-events: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4


### PR DESCRIPTION
## Summary
- drop unsupported `dependency-graph`-related permission grants from the dependency submission workflow
- rely on the repository-level contents: write scope for the submission job to avoid schema validation errors

## Testing
- actionlint .github/workflows/dependency-graph.yml

------
https://chatgpt.com/codex/tasks/task_e_68d0f424d004832dba77ba04a350fbe3