### PR TITLE
Harden prepare_gptoss_diff git usage for Bandit

### DIFF
--- a/tests/test_prepare_gptoss_diff.py
+++ b/tests/test_prepare_gptoss_diff.py
@@ -115,3 +115,27 @@ def test_main_handles_unknown_args(monkeypatch: pytest.MonkeyPatch) -> None:
     exit_code = prepare_gptoss_diff.main(["--unknown"])
     assert exit_code == 0
 
+
+def test_prepare_diff_rejects_invalid_sha(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(prepare_gptoss_diff, "_ensure_base_available", lambda ref: None)
+    with pytest.raises(RuntimeError):
+        prepare_gptoss_diff.prepare_diff(
+            "example/repo",
+            "123",
+            token=None,
+            base_sha="not-a-sha",
+            base_ref="main",
+        )
+
+
+def test_prepare_diff_rejects_invalid_ref(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(prepare_gptoss_diff, "_compute_diff", lambda sha, paths, truncate: None)
+    with pytest.raises(RuntimeError):
+        prepare_gptoss_diff.prepare_diff(
+            "example/repo",
+            "123",
+            token=None,
+            base_sha="a" * 40,
+            base_ref="bad ref",
+        )
+


### PR DESCRIPTION
## Summary
- validate Git refs, SHAs, and path arguments before invoking subprocesses in `prepare_gptoss_diff`
- tighten `_run_git` to allow only the expected commands and document the safe subprocess usage
- add regression tests that exercise the new validation logic

## Testing
- pytest tests/test_prepare_gptoss_diff.py
- bandit -r . -ll -ii -x ./tests,./scripts,./gptoss_check
- bandit -r scripts/prepare_gptoss_diff.py


------
https://chatgpt.com/codex/tasks/task_e_68d115fbb3f4832daf46973d577bf594