### PR TITLE
Remove unused import to satisfy Dependabot lint

### DIFF
--- a/optimizer.py
+++ b/optimizer.py
@@ -6,7 +6,6 @@ Sharpe ratio and supports an optional grid search refinement step.
 
 import asyncio
 import inspect
-import os
 import time
 from itertools import product
 import numpy as np


### PR DESCRIPTION
## Summary
- remove the unused `os` import from `optimizer.py` so the Dependabot workflow's lint step no longer fails

## Testing
- ruff check
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_e_68d1163f8b50832d8c1d99bb11a58813