### PR TITLE
Fix dependabot auto-merge condition

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Enable auto-merge for Dependabot PRs
         id: enable_automerge
-        if: ${{ steps.metadata.outputs['update-type'] != 'version-update:semver-major' && steps.auto_merge.outputs.allowed == 'true' }}
+        if: ${{ steps.auto_merge.outputs.allowed == 'true' && steps.metadata.outputs['update-type'] != 'version-update:semver-major' }}
         # v3.0.0
         # yamllint disable-line rule:line-length
         uses: peter-evans/enable-pull-request-automerge@a59ea044f2aeabb1e63839cf06068655c1d70998


### PR DESCRIPTION
## Summary
- ensure the auto-merge step in the Dependabot workflow short-circuits on the repository auto-merge flag so runs skip cleanly when auto-merge is disabled

## Testing
- pytest -m "not integration" -q


------
https://chatgpt.com/codex/tasks/task_e_68d1164943e0832da88cb198fbddd10d