### PR TITLE
Adjust dependency snapshot permissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -11,10 +11,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  dependency-graph: write
 
 jobs:
   submit:
+    permissions:
+      contents: read
+      dependency-graph: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4


### PR DESCRIPTION
## Summary
- grant the workflow only the minimum permissions required to submit dependency snapshots
- ensure the submit job inherits dependency-graph write access so the API call can succeed

## Testing
- pytest tests/test_dependency_snapshot*.py

------
https://chatgpt.com/codex/tasks/task_e_68d127bef86c832da3ce2c7c7309201b