### PR TITLE
Fix Dependabot auto-merge flag parsing

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -68,8 +68,10 @@ jobs:
 
       - name: Check auto-merge availability
         id: auto_merge
+        env:
+          ALLOW_AUTO_MERGE: ${{ github.event.repository.allow_auto_merge == true }}
         run: |
-          if [[ "${{ github.event.repository.allow_auto_merge || false }}" == 'true' ]]; then
+          if [[ "${ALLOW_AUTO_MERGE}" == 'true' ]]; then
             echo "allowed=true" >> "$GITHUB_OUTPUT"
           else
             echo "allowed=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- guard the auto-merge flag evaluation behind an explicit environment variable
to avoid GitHub expression parsing issues in the Dependabot workflow

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d12a846ef8832d88c731ea0bc71823