### PR TITLE
Add User-Agent header for GPT-OSS diff requests

### DIFF
--- a/scripts/prepare_gptoss_diff.py
+++ b/scripts/prepare_gptoss_diff.py
@@ -143,7 +143,10 @@ def _perform_https_request(
 def _api_request(url: str, token: str | None, timeout: float = 10.0) -> dict:
     """Perform a GitHub API request and return the decoded JSON payload."""
 
-    headers = {"Accept": "application/vnd.github+json"}
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "gptoss-review-workflow/1.0 (+https://github.com/averinaleks/bot)",
+    }
     if token:
         headers["Authorization"] = f"token {token}"
 

--- a/tests/test_prepare_gptoss_diff.py
+++ b/tests/test_prepare_gptoss_diff.py
@@ -80,6 +80,21 @@ def test_prepare_diff_reads_remote_metadata(monkeypatch: pytest.MonkeyPatch, tem
     assert "print('bye')" in result.content
 
 
+def test_api_request_adds_user_agent(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorded_headers: dict[str, str] = {}
+
+    def _fake_request(url: str, headers: dict[str, str], timeout: float) -> tuple[int, str, bytes]:
+        _ = (url, timeout)
+        recorded_headers.update(headers)
+        return 200, "OK", b"{}"
+
+    monkeypatch.setattr(prepare_gptoss_diff, "_perform_https_request", _fake_request)
+
+    prepare_gptoss_diff._api_request("https://api.github.com/repos/test/repo", token=None)
+
+    assert recorded_headers.get("User-Agent")
+
+
 def test_main_writes_outputs(monkeypatch: pytest.MonkeyPatch, temp_repo: Path, tmp_path: Path) -> None:
     monkeypatch.chdir(temp_repo)
     base_sha = (


### PR DESCRIPTION
## Summary
- add an explicit User-Agent header when prepare_gptoss_diff.py talks to the GitHub API
- cover the new behaviour with a regression test in tests/test_prepare_gptoss_diff.py

## Testing
- pytest tests/test_prepare_gptoss_diff.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d12a9af9a8832d9b43da51ae5a9d69