### PR TITLE
Improve dependency snapshot alias handling

### DIFF
--- a/tests/test_dependency_snapshot_parser.py
+++ b/tests/test_dependency_snapshot_parser.py
@@ -22,7 +22,7 @@ def test_parse_requirements_strips_inline_comments(tmp_path: Path) -> None:
     path = _write_requirements(
         tmp_path,
         """\
-        package==1.2.3  # pinned for compatibility
+        package[extra]==1.2.3  # pinned for compatibility
         other==4.5.6
         """,
     )
@@ -34,6 +34,10 @@ def test_parse_requirements_strips_inline_comments(tmp_path: Path) -> None:
         parsed["pkg:pypi/package@1.2.3"]["package_url"]
         == "pkg:pypi/package@1.2.3"
     )
+    # Aliases allow lookups by the original requirement including extras and
+    # by normalised variations such as uppercase names.
+    assert parsed["package[extra]"]["package_url"] == "pkg:pypi/package@1.2.3"
+    assert parsed["PACKAGE"]["package_url"] == "pkg:pypi/package@1.2.3"
     assert "pkg:pypi/other@4.5.6" in parsed
     assert (
         parsed["pkg:pypi/other@4.5.6"]["package_url"]


### PR DESCRIPTION
## Summary
- extend the dependency snapshot parser to record aliases for package extras and raw requirement names
- derive the raw requirement token before normalization so lookups by original spec succeed
- exercise the new alias behaviour in the dependency snapshot parser test

## Testing
- PYTHONHASHSEED=0 TEST_MODE=1 pytest -q --maxfail=1 --disable-warnings

------
https://chatgpt.com/codex/tasks/task_e_68d12ab02c50832da8cc9a5afd62a915