### PR TITLE
Improve Trivy workflow robustness

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,6 +28,9 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
+      - name: Setup CodeQL CLI
+        uses: github/codeql-action/setup@v3
+
       - name: Setup Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -68,8 +68,10 @@ jobs:
 
       - name: Check auto-merge availability
         id: auto_merge
+        env:
+          ALLOW_AUTO_MERGE: ${{ github.event.repository.allow_auto_merge == true }}
         run: |
-          if [[ "${{ github.event.repository.allow_auto_merge || false }}" == 'true' ]]; then
+          if [[ "${ALLOW_AUTO_MERGE}" == 'true' ]]; then
             echo "allowed=true" >> "$GITHUB_OUTPUT"
           else
             echo "allowed=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -11,10 +11,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  dependency-graph: write
 
 jobs:
   submit:
+    permissions:
+      contents: read
+      dependency-graph: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -38,21 +38,42 @@ jobs:
           # Fail workflow when vulnerabilities of specified severity are found
           exit-code: 1
 
+      - name: Parse Trivy results
+        id: parse_trivy
+        if: ${{ steps.trivy.conclusion != 'skipped' && always() }}
+        run: |
+          if [ ! -f trivy-results.sarif ]; then
+            echo "sarif_exists=false" >> "$GITHUB_OUTPUT"
+            echo "vulnerability_count=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          count=$(jq '[.runs[].results[]] | length' trivy-results.sarif)
+          echo "sarif_exists=true" >> "$GITHUB_OUTPUT"
+          echo "vulnerability_count=${count}" >> "$GITHUB_OUTPUT"
+
       - name: Upload Trivy scan results to GitHub Security tab
-        if: ${{ github.event_name != 'pull_request' && always() }}
+        if: ${{ steps.parse_trivy.outputs.sarif_exists == 'true' && github.event_name != 'pull_request' && always() }}
         uses: github/codeql-action/upload-sarif@192325c86100d080feab897ff886c34abd4c83a3
         # v3.30.3
         with:
           sarif_file: trivy-results.sarif
 
       - name: Upload Trivy report artifact
-        if: ${{ steps.trivy.conclusion != 'skipped' && always() }}
+        if: ${{ steps.parse_trivy.outputs.sarif_exists == 'true' && always() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         # v4
         with:
           name: trivy-results
           path: trivy-results.sarif
 
+      - name: Fail if Trivy scan failed unexpectedly
+        if: ${{ steps.trivy.conclusion == 'failure' && steps.parse_trivy.outputs.sarif_exists != 'true' }}
+        run: |
+          echo "::error::Trivy scan failed before producing a SARIF report."
+          exit 1
+
       - name: Fail if vulnerabilities found
-        if: ${{ steps.trivy.conclusion == 'failure' }}
-        run: exit 1
+        if: ${{ steps.parse_trivy.outputs.sarif_exists == 'true' && steps.parse_trivy.outputs.vulnerability_count != '0' }}
+        run: |
+          echo "::error::Trivy detected ${{ steps.parse_trivy.outputs.vulnerability_count }} high or critical vulnerabilities."
+          exit 1

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -25,11 +25,11 @@ WORKDIR /app
 COPY requirements-core.txt .
 
 ENV VIRTUAL_ENV=/app/venv
-RUN python3 -m venv $VIRTUAL_ENV && \
+RUN python3 -m venv "$VIRTUAL_ENV" && \
     # pip >=24.0 устраняет CVE-2023-32681, setuptools>=78.1.1 закрывает актуальные уязвимости и подходит для сборки gymnasium
-    $VIRTUAL_ENV/bin/pip install --no-cache-dir 'pip>=24.0' 'setuptools>=78.1.1,<81' wheel && \
-    $VIRTUAL_ENV/bin/pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -r requirements-core.txt && \
-    $VIRTUAL_ENV/bin/python - <<'PY'
+    "$VIRTUAL_ENV"/bin/pip install --no-cache-dir 'pip>=24.0' 'setuptools>=78.1.1,<81' wheel && \
+    "$VIRTUAL_ENV"/bin/pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -r requirements-core.txt && \
+    "$VIRTUAL_ENV"/bin/python - <<'PY'
 import textwrap
 
 exec(textwrap.dedent("""
@@ -51,14 +51,16 @@ exec(textwrap.dedent("""
         )
 """))
 PY
-    && nvidia_packages="$($VIRTUAL_ENV/bin/pip freeze | grep -i '^nvidia-' || true)" && \
+
+RUN set -eu; \
+    nvidia_packages="$($VIRTUAL_ENV/bin/pip freeze | grep -i '^nvidia-' || true)"; \
     if [ -n "$nvidia_packages" ]; then \
-        printf '%s\n' "$nvidia_packages" | cut -d= -f1 | xargs -r $VIRTUAL_ENV/bin/pip uninstall -y; \
+        printf '%s\n' "$nvidia_packages" | cut -d= -f1 | xargs -r "$VIRTUAL_ENV"/bin/pip uninstall -y; \
     else \
         echo "No NVIDIA packages detected in the virtual environment"; \
-    fi && \
-    find $VIRTUAL_ENV -type d -name '__pycache__' -exec rm -rf {} + && \
-    find $VIRTUAL_ENV -type f -name '*.pyc' -delete
+    fi; \
+    find "$VIRTUAL_ENV" -type d -name '__pycache__' -exec rm -rf {} +; \
+    find "$VIRTUAL_ENV" -type f -name '*.pyc' -delete
 
 FROM ubuntu:24.04
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Summary
- parse Trivy SARIF output to capture high/critical vulnerability counts for downstream logic
- skip SARIF uploads when the scan does not generate a report and surface unexpected scan failures explicitly
- fail the workflow only when verified high/critical issues are present

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68d12abcd858832d97a34003f9916352