### PR TITLE
Fix CodeQL workflow configuration

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,8 +15,6 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    env:
-      CODEQL_ACTION_DISABLE_DEFAULT_SETUP: true
     strategy:
       fail-fast: false
       matrix:
@@ -28,19 +26,13 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Setup CodeQL CLI
-        uses: github/codeql-action/setup@v3
-
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.11'
-
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
-          build-mode: none
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary
- rely on the default CodeQL init behaviour instead of disabling the setup
- add the autobuild step so the analyze phase always has a database to process

## Testing
- `./codeql/codeql database analyze codeql-db --format=sarifv2.1.0 --output=codeql-results.sarif codeql/python-queries`


------
https://chatgpt.com/codex/tasks/task_e_68d13d499110832da1e5ea6ad222d03b