### PR TITLE
Ensure dependency snapshot workflow finds nested manifests

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -31,8 +31,26 @@ jobs:
           from pathlib import Path
 
           patterns = ("requirements*.txt", "requirements*.in", "requirements*.out")
+          excluded = {
+              ".git",
+              ".hg",
+              ".nox",
+              ".tox",
+              ".venv",
+              "__pycache__",
+              "env",
+              "node_modules",
+              "site-packages",
+              "venv",
+          }
+
+          def is_excluded(target: Path) -> bool:
+              return any(part in excluded for part in target.parts)
+
           for pattern in patterns:
-              for path in Path(".").glob(pattern):
+              for path in Path(".").rglob(pattern):
+                  if is_excluded(path.parent):
+                      continue
                   original = path.read_text()
                   lines = original.splitlines()
                   filtered = []

--- a/tests/test_dependency_snapshot_parser.py
+++ b/tests/test_dependency_snapshot_parser.py
@@ -107,6 +107,15 @@ def test_build_manifests_supports_multiple_patterns(tmp_path: Path) -> None:
         assert manifest["file"]["source_location"] == name
 
 
+def test_build_manifests_discovers_nested_requirement_files(tmp_path: Path) -> None:
+    nested_dir = tmp_path / "nested" / "configs"
+    nested_dir.mkdir(parents=True)
+    (nested_dir / "requirements-extra.txt").write_text("pkg==1.0.0\n")
+
+    manifests = _build_manifests(tmp_path)
+
+    assert set(manifests) == {"nested/configs/requirements-extra.txt"}
+
 def test_job_metadata_adds_html_url_when_run_id_numeric(monkeypatch) -> None:
     monkeypatch.setenv("GITHUB_SERVER_URL", "https://example.com")
     job = _job_metadata("owner/repo", "12345", "corr")


### PR DESCRIPTION
## Summary
- walk the repository tree when collecting dependency manifests so nested requirement files are included in submitted snapshots
- skip common virtual environment and cache directories during the scan to avoid noisy files and keep ordering deterministic
- extend the dependency graph workflow pre-processing to mirror the new traversal logic and add coverage for nested manifests

## Testing
- pytest tests/test_dependency_snapshot.py tests/test_dependency_snapshot_parser.py

------
https://chatgpt.com/codex/tasks/task_e_68d150125264832dac1bee419cf42d44