### PR TITLE
chore: stabilize codeql workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,13 +26,20 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
 
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-ci.txt
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary
- configure the CodeQL job to use Python 3.11 and install the minimal CI dependencies
- replace the autobuild step with an explicit dependency installation so analysis can run reliably

## Testing
- not run (CI workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d151fa0f94832d970b65809de5b3e4