### PR TITLE
Fix Dockerfile cpu build stage syntax

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -5,21 +5,24 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Обновление linux-libc-dev устраняет CVE-2025-21976, а libgcrypt20 — CVE-2024-2236
 # Обновляем систему перед установкой зависимостей
-RUN apt-get update && apt-get upgrade -y \
-    && apt-get install -y --no-install-recommends \
+RUN set -eux; \
+    apt-get update; \
+    apt-get upgrade -y; \
+    apt-get install -y --no-install-recommends \
         linux-libc-dev \
         libssl3t64 \
         python3.12-minimal \
         build-essential \
         curl \
         python3 python3-venv python3-dev python3-pip \
-        zlib1g-dev \
-    && apt-get install -y --no-install-recommends --only-upgrade libpam0g libpam-modules \
-    && python3 -m pip install --no-cache-dir --break-system-packages \
+        zlib1g-dev; \
+    apt-get install -y --no-install-recommends --only-upgrade libpam0g libpam-modules; \
+    python3 -m pip install --no-cache-dir --break-system-packages \
         'pip>=24.0' \
         'setuptools>=78.1.1,<81' \
-        wheel \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+        wheel; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 
 COPY requirements-core.txt .


### PR DESCRIPTION
## Summary
- replace the initial builder RUN command in Dockerfile.cpu with a shell script style block that uses `set -eux`
- avoid leading `&&` continuations that BuildKit treats as invalid instructions during image builds
- keep all package installation and cleanup steps intact while ensuring the Dockerfile parses correctly

## Testing
- not run (logic change only)


------
https://chatgpt.com/codex/tasks/task_e_68d151a23b28832d80383e167803b729