### PR TITLE
Fix dependency snapshot workflow permissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -12,13 +12,13 @@ on:
 
 permissions:
   contents: read
-  dependency-graph: write
+  security-events: write
 
 jobs:
   submit:
     permissions:
       contents: read
-      dependency-graph: write
+      security-events: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4


### PR DESCRIPTION
## Summary
- replace the invalid `dependency-graph` permission entries in the dependency snapshot workflow with `security-events`
- keep the workflow functional while preserving the dependency snapshot submission steps

## Testing
- pytest tests/test_dependency_snapshot.py

------
https://chatgpt.com/codex/tasks/task_e_68d1561a4a78832d8b83f8783ccc62a5