### PR TITLE
Handle chat-style GPT responses

### DIFF
--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -66,6 +66,30 @@ def test_parse_gpt_response_success():
     assert _parse_gpt_response(content) == "ok"
 
 
+def test_parse_gpt_response_message_content():
+    content = json.dumps({"choices": [{"message": {"content": "ok"}}]}).encode()
+    assert _parse_gpt_response(content) == "ok"
+
+
+def test_parse_gpt_response_message_content_list():
+    content = json.dumps(
+        {
+            "choices": [
+                {
+                    "message": {
+                        "content": [
+                            {"text": "hello"},
+                            {"text": {"value": " world"}},
+                            {"value": "!"},
+                        ]
+                    }
+                }
+            ]
+        }
+    ).encode()
+    assert _parse_gpt_response(content) == "hello world!"
+
+
 def test_parse_gpt_response_invalid_json():
     with pytest.raises(GPTClientJSONError):
         _parse_gpt_response(b"not json")


### PR DESCRIPTION
## Summary
- update gpt_client._parse_gpt_response to understand chat-style and nested completion payloads
- ensure Mapping is imported so the parser can safely inspect dict-like values
- extend the GPT client tests with coverage for message-based responses

## Testing
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_e_68d151c41d2c832da704e4f9688b32a4