### PR TITLE
Fix dependency snapshot test line length for lint compliance

### DIFF
--- a/tests/test_dependency_snapshot.py
+++ b/tests/test_dependency_snapshot.py
@@ -48,7 +48,10 @@ def test_parse_requirements_encodes_versions_for_purl(tmp_path: Path) -> None:
     assert resolved["torch"]["package_url"] == "pkg:pypi/torch@2.8.0%2Bcpu"
 
 
-def test_submit_dependency_snapshot_skips_when_env_missing(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+def test_submit_dependency_snapshot_skips_when_env_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.delenv("GITHUB_SHA", raising=False)


### PR DESCRIPTION
## Summary
- wrap the dependency snapshot environment-missing test signature across multiple lines to comply with Ruff line-length checks

## Testing
- python -m ruff check bot tests
- python -m mypy bot
- python -m bandit -r bot -x tests -ll
- python -m flake8 .
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d1599744d4832da272e74001f1a262