### PR TITLE
Reduce dependency snapshot payload size

### DIFF
--- a/scripts/submit_dependency_snapshot.py
+++ b/scripts/submit_dependency_snapshot.py
@@ -48,6 +48,17 @@ _TOKEN_PREFIXES = ("ghp_", "gho_", "ghu_", "ghs_", "ghr_", "github_pat_")
 _SKIPPED_PACKAGES = {"ccxtpro"}
 
 
+def _should_skip_manifest(name: str, available: set[str]) -> bool:
+    """Return ``True`` when the manifest is redundant and can be dropped."""
+
+    path = Path(name)
+    if path.suffix == ".out":
+        candidate = path.with_suffix(".txt").as_posix()
+        if candidate in available:
+            return True
+    return False
+
+
 class MissingEnvironmentVariableError(RuntimeError):
     """Raised when a required GitHub environment variable is missing."""
 
@@ -255,6 +266,17 @@ def _build_manifests(root: Path) -> Dict[str, Manifest]:
             "file": {"source_location": relative_str},
             "resolved": resolved,
         }
+
+    if manifests:
+        available = set(manifests.keys())
+        manifests = OrderedDict(
+            (
+                name,
+                manifest,
+            )
+            for name, manifest in manifests.items()
+            if not _should_skip_manifest(name, available)
+        )
     return manifests
 
 

--- a/tests/test_dependency_snapshot.py
+++ b/tests/test_dependency_snapshot.py
@@ -12,7 +12,6 @@ from scripts import submit_dependency_snapshot as snapshot
     [
         "requirements.txt",
         "requirements.in",
-        "requirements.out",
     ],
 )
 def test_build_manifests_includes_supported_patterns(tmp_path: Path, filename: str) -> None:
@@ -123,3 +122,12 @@ def test_submit_dependency_snapshot_reports_submission_error(
     captured = capsys.readouterr()
     assert "Dependency snapshot submission skipped из-за ошибки GitHub API." in captured.err
     assert "HTTP 400" in captured.err
+
+
+def test_build_manifests_skips_out_files_when_txt_present(tmp_path: Path) -> None:
+    (tmp_path / "requirements.txt").write_text("httpx==0.27.2\n")
+    (tmp_path / "requirements.out").write_text("httpx==0.27.2\n")
+
+    manifests = snapshot._build_manifests(tmp_path)
+
+    assert set(manifests.keys()) == {"requirements.txt"}


### PR DESCRIPTION
## Summary
- skip redundant pip-compile ``*.out`` requirement manifests when building dependency snapshots
- add helper to detect redundant manifests and keep behaviour covered by tests
- update dependency snapshot tests to match the new manifest filtering

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d15fb4e88c832d8f097f015f04c161