### PR TITLE
Wrap dependency snapshot auth error message

### DIFF
--- a/scripts/submit_dependency_snapshot.py
+++ b/scripts/submit_dependency_snapshot.py
@@ -536,7 +536,10 @@ def submit_dependency_snapshot() -> None:
                 ):
                     next_scheme = schemes[index + 1]
                     print(
-                        f"Authentication with scheme '{scheme}' failed (HTTP {exc.status_code}). Trying '{next_scheme}'.",
+                        (
+                            f"Authentication with scheme '{scheme}' failed "
+                            f"(HTTP {exc.status_code}). Trying '{next_scheme}'."
+                        ),
                         file=sys.stderr,
                     )
                     last_error = exc


### PR DESCRIPTION
## Summary
- wrap the dependency snapshot authentication failure log message so it respects the Ruff line-length limit

## Testing
- pytest
- ruff check

------
https://chatgpt.com/codex/tasks/task_e_68d15fedb2ac832da78678be4655b6e4