### PR TITLE
Fix dependency graph workflow permissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -12,13 +12,13 @@ on:
 
 permissions:
   contents: read
-  security-events: write
+  dependency-graph: write
 
 jobs:
   submit:
     permissions:
       contents: read
-      security-events: write
+      dependency-graph: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4


### PR DESCRIPTION
## Summary
- request the `dependency-graph: write` permission in the dependency submission workflow so GitHub can accept snapshots again.

## Testing
- `pytest tests/test_dependency_snapshot.py tests/test_dependency_snapshot_parser.py`


------
https://chatgpt.com/codex/tasks/task_e_68d1967e72d0832d9e5dbbda45fef253