### PR TITLE
Fix docstring for GPT-OSS review script

### DIFF
--- a/scripts/run_gptoss_review.py
+++ b/scripts/run_gptoss_review.py
@@ -1,4 +1,4 @@
-"""Utility script used by the GPT-OSS review GitHub workflow.
+"""Utility helpers for generating GPT-OSS code review comments on CI.
 
 The workflow previously relied on shell pipelines with ``jq`` and ``curl`` to
 prepare the request payload and parse responses from the mock GPT-OSS server.


### PR DESCRIPTION
## Summary
- ensure the GPT-OSS review helper module has a proper module docstring
- keep the existing documentation while tightening the introductory text

## Testing
- pytest tests/test_run_gptoss_review.py

------
https://chatgpt.com/codex/tasks/task_e_68d19718ada8832db03b316c0ff4c779