### PR TITLE
Fix Release Drafter condition syntax

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   update_release_draft:
-    if: ${{ github.event_name != 'pull_request' || (github.event.pull_request && github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: github.event_name != 'pull_request' || (github.event.pull_request && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     steps:
       - name: Update release draft


### PR DESCRIPTION
## Summary
- correct the Release Drafter workflow condition syntax so the job evaluates properly for pull_request events

## Testing
- no tests were run (workflow update)


------
https://chatgpt.com/codex/tasks/task_e_68d197311d88832d9dc4d467a9f52450