### PR TITLE
Fix dependency graph workflow permissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -11,14 +11,11 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   dependency-graph: write
 
 jobs:
   submit:
-    permissions:
-      contents: read
-      dependency-graph: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4


### PR DESCRIPTION
## Summary
- grant write access to repository contents for the dependency snapshot workflow so GitHub accepts submissions
- rely on workflow-level permissions inheritance for the submit job

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d1999cebcc832d83fe3187854e3233