### PR TITLE
Fix Dockerfile continuation so buildx can parse

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -28,10 +28,16 @@ WORKDIR /app
 COPY requirements-core.txt .
 
 ENV VIRTUAL_ENV=/app/venv
+# pip >=24.0 устраняет CVE-2023-32681, setuptools>=78.1.1 закрывает актуальные уязвимости
+# и подходит для сборки gymnasium.
 RUN python3 -m venv "$VIRTUAL_ENV" && \
-    # pip >=24.0 устраняет CVE-2023-32681, setuptools>=78.1.1 закрывает актуальные уязвимости и подходит для сборки gymnasium
-    "$VIRTUAL_ENV"/bin/pip install --no-cache-dir 'pip>=24.0' 'setuptools>=78.1.1,<81' wheel && \
-    "$VIRTUAL_ENV"/bin/pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -r requirements-core.txt && \
+    "$VIRTUAL_ENV"/bin/pip install --no-cache-dir \
+        'pip>=24.0' \
+        'setuptools>=78.1.1,<81' \
+        wheel && \
+    "$VIRTUAL_ENV"/bin/pip install --no-cache-dir \
+        --extra-index-url https://download.pytorch.org/whl/cpu \
+        -r requirements-core.txt && \
     "$VIRTUAL_ENV"/bin/python - <<'PY'
 import textwrap
 


### PR DESCRIPTION
## Summary
- restructure the CPU Dockerfile virtualenv setup so multiline RUN commands use clear continuations
- add context comments above the RUN command without breaking Dockerfile parsing

## Testing
- not run (Dockerfile change only)


------
https://chatgpt.com/codex/tasks/task_e_68d196fe7048832d8fa246571e593ea8