### PR TITLE
Expand dependency snapshot alias support

### DIFF
--- a/scripts/submit_dependency_snapshot.py
+++ b/scripts/submit_dependency_snapshot.py
@@ -160,6 +160,8 @@ class ResolvedDependencies(OrderedDict[str, ResolvedDependency]):
         base_name: str,
         package_url: str,
         dependency: ResolvedDependency,
+        *,
+        extra_aliases: Iterable[str] = (),
     ) -> None:
         if not super().__contains__(package_url):
             super().__setitem__(package_url, dependency)
@@ -170,6 +172,7 @@ class ResolvedDependencies(OrderedDict[str, ResolvedDependency]):
             _normalise_name(original_name),
             _normalise_name(base_name),
         }
+        alias_candidates.update(extra_aliases)
         for alias in alias_candidates:
             if alias:
                 self._aliases[alias] = package_url
@@ -239,7 +242,13 @@ def _parse_requirements(path: Path) -> Dict[str, ResolvedDependency]:
             "scope": scope,
             "dependencies": [],
         }
-        resolved.add(raw_name, base_name, package_url, dependency)
+        resolved.add(
+            raw_name,
+            base_name,
+            package_url,
+            dependency,
+            extra_aliases=(requirement_part,),
+        )
     return resolved
 
 

--- a/tests/test_dependency_snapshot_parser.py
+++ b/tests/test_dependency_snapshot_parser.py
@@ -37,6 +37,7 @@ def test_parse_requirements_strips_inline_comments(tmp_path: Path) -> None:
     # Aliases allow lookups by the original requirement including extras and
     # by normalised variations such as uppercase names.
     assert parsed["package[extra]"]["package_url"] == "pkg:pypi/package@1.2.3"
+    assert parsed["package[extra]==1.2.3"]["package_url"] == "pkg:pypi/package@1.2.3"
     assert parsed["PACKAGE"]["package_url"] == "pkg:pypi/package@1.2.3"
     assert "pkg:pypi/other@4.5.6" in parsed
     assert (


### PR DESCRIPTION
## Summary
- allow dependency snapshot aliases to include the full requirement specifier (e.g. `package[extra]==1.2.3`)
- update parsing tests to cover lookups by the full requirement string in addition to existing alias checks

## Testing
- `pytest -q --maxfail=1 --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_68d1974bc284832d858d7b5dc0e2f659