### PR TITLE
Fix dependency submission workflow permissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -12,7 +12,6 @@ on:
 
 permissions:
   contents: write
-  dependency-graph: write
 
 jobs:
   submit:


### PR DESCRIPTION
## Summary
- remove the unsupported `dependency-graph` permission from the dependency submission workflow
- keep the workflow compatible with GitHub Actions by retaining the required `contents: write` scope

## Testing
- ./actionlint -no-color .github/workflows/dependency-graph.yml

------
https://chatgpt.com/codex/tasks/task_e_68d19b3c8360832db5758a8b6e27131f