### PR TITLE
Handle Dependabot security updates in workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -103,7 +103,11 @@ jobs:
 
           for dependency in dependencies:
               name = dependency.get("dependency-name")
-              version = dependency.get("new-version")
+              # Dependabot uses "new-version" for regular updates and
+              # "dependency-version" for security advisories.  Support both so
+              # the workflow always installs the proposed version before
+              # running the tests.
+              version = dependency.get("new-version") or dependency.get("dependency-version")
               if not name or not version:
                   print(f"Skipping entry without name/version: {dependency}")
                   continue


### PR DESCRIPTION
## Summary
- ensure the Dependabot workflow installs versions from security advisory updates by falling back to the dependency-version field

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68d19d2bc86c832db14077f3290235f4