### PR TITLE
Fix dependency snapshot workflow permissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -11,8 +11,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  dependency-graph: write
+  contents: read
+  security-events: write
 
 jobs:
   submit:


### PR DESCRIPTION
## Summary
- replace the invalid `dependency-graph` permission with the supported scopes required for dependency snapshots

## Testing
- pytest tests/test_dependency_snapshot.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d19d9df3dc832dbc4c4af66148d183