### PR TITLE
Adjust dependency snapshot permissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   security-events: write
 
 jobs:


### PR DESCRIPTION
## Summary
- grant the dependency snapshot workflow write access to repository contents so it can submit data successfully

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1a533c624832d91ccbe2d08276dad