### PR TITLE
Fix Ruff unused import warning in Telegram logger tests

### DIFF
--- a/tests/test_telegram_logger.py
+++ b/tests/test_telegram_logger.py
@@ -2,7 +2,6 @@ import asyncio
 import hashlib
 import logging
 import os
-from pathlib import Path
 import pytest
 import sys
 import threading


### PR DESCRIPTION
## Summary
- remove the unused Path import from tests/test_telegram_logger.py so Ruff passes

## Testing
- python -m ruff check bot tests
- python -m mypy bot
- python -m bandit -r bot -x tests -ll
- python -m flake8 .
- pytest -m "not integration"
- pytest -m integration

------
https://chatgpt.com/codex/tasks/task_e_68d1a585818c832d83cbf7b8a7c6c8f0