### PR TITLE
Fix Dependabot workflow skip logic

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -14,36 +14,39 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  IS_DEPENDABOT_PR: ${{ github.event_name == 'pull_request_target' && (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]') }}
+
 jobs:
-  dependabot:
+  skip-non-dependabot:
+    if: ${{ env.IS_DEPENDABOT_PR != 'true' }}
     runs-on: ubuntu-latest
-    env:
-      IS_DEPENDABOT_PR: ${{ github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]' }}
     steps:
-      - name: Skip non-Dependabot runs
-        if: ${{ env.IS_DEPENDABOT_PR != 'true' }}
+      - name: Report skipped run
         run: |
           printf '%s\n' \
-            "Dependabot workflow is only relevant to Dependabot pull_request_target events." \
+            "Dependabot automation runs only for Dependabot pull_request_target events." \
             "Actor '${{ github.actor }}' on event '${{ github.event_name }}' does not require action." \
             >> "$GITHUB_STEP_SUMMARY"
-          exit 0
+
+  dependabot:
+    if: ${{ env.IS_DEPENDABOT_PR == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
       - name: Dependabot metadata
-        if: ${{ env.IS_DEPENDABOT_PR == 'true' }}
         id: metadata
         # v2.5.0
         uses: dependabot/fetch-metadata@46cfd663b8c18cab02928a3fa963cf0e73994bb1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Auto approve
-        if: ${{ env.IS_DEPENDABOT_PR == 'true' && steps.metadata.outputs['update-type'] != 'version-update:semver-major' }}
+        if: ${{ steps.metadata.outputs['update-type'] != 'version-update:semver-major' }}
         # v4.0.0
         uses: hmarr/auto-approve-action@8f929096a962e83ccdfa8afcf855f39f12d4dac7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-number: ${{ github.event.pull_request.number }}
       - name: Checkout code
-        if: ${{ env.IS_DEPENDABOT_PR == 'true' }}
         # v5.0.0
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
@@ -56,14 +59,14 @@ jobs:
       # heavier setup used in the main CI workflow which was causing
       # Dependabot update checks to fail.
       - name: Setup Python
-        if: ${{ env.IS_DEPENDABOT_PR == 'true' && steps.metadata.outputs['package-ecosystem'] == 'pip' }}
+        if: ${{ steps.metadata.outputs['package-ecosystem'] == 'pip' }}
         # v6.0.0
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
         with:
           python-version: '3.11'
           cache: 'pip'
       - name: Install dependencies
-        if: ${{ env.IS_DEPENDABOT_PR == 'true' && steps.metadata.outputs['package-ecosystem'] == 'pip' }}
+        if: ${{ steps.metadata.outputs['package-ecosystem'] == 'pip' }}
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements-ci.txt
@@ -76,7 +79,7 @@ jobs:
       # resolving the entire environment from scratch, keeping the job fast
       # while still validating the new packages.
       - name: Install Dependabot updates
-        if: ${{ env.IS_DEPENDABOT_PR == 'true' && steps.metadata.outputs['package-ecosystem'] == 'pip' }}
+        if: ${{ steps.metadata.outputs['package-ecosystem'] == 'pip' }}
         env:
           DEPENDENCIES_JSON: ${{ steps.metadata.outputs['updated-dependencies-json'] }}
         run: |
@@ -125,11 +128,10 @@ jobs:
       # the main CI.  If any test fails this step will surface the
       # error and prevent automatic merging of the pull request.
       - name: Run unit tests
-        if: ${{ env.IS_DEPENDABOT_PR == 'true' && steps.metadata.outputs['package-ecosystem'] == 'pip' }}
+        if: ${{ steps.metadata.outputs['package-ecosystem'] == 'pip' }}
         run: pytest -m "not integration" -q
 
       - name: Check auto-merge availability
-        if: ${{ env.IS_DEPENDABOT_PR == 'true' }}
         id: auto_merge
         env:
           ALLOW_AUTO_MERGE: ${{ github.event.repository.allow_auto_merge == true }}
@@ -143,7 +145,7 @@ jobs:
 
       - name: Enable auto-merge for Dependabot PRs
         id: enable_automerge
-        if: ${{ env.IS_DEPENDABOT_PR == 'true' && steps.auto_merge.outputs.allowed == 'true' && steps.metadata.outputs['update-type'] != 'version-update:semver-major' }}
+        if: ${{ steps.auto_merge.outputs.allowed == 'true' && steps.metadata.outputs['update-type'] != 'version-update:semver-major' }}
         # v3.0.0
         # yamllint disable-line rule:line-length
         uses: peter-evans/enable-pull-request-automerge@a59ea044f2aeabb1e63839cf06068655c1d70998
@@ -154,7 +156,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Report auto-merge failure
-        if: ${{ env.IS_DEPENDABOT_PR == 'true' && steps.enable_automerge.conclusion == 'failure' }}
+        if: ${{ steps.enable_automerge.conclusion == 'failure' }}
         run: |
           printf '%s\n' \
             "Auto-merge could not be enabled automatically. Check repository settings or branch protection rules." \


### PR DESCRIPTION
## Summary
- gate the Dependabot workflow so it only runs on Dependabot pull_request_target events
- add an explicit skip job to report when the workflow is not relevant
- simplify step conditions now that the main job only executes for Dependabot PRs

## Testing
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_e_68d1a52924ec832db744eff94dcd047e