### PR TITLE
Handle missing GITHUB_ENV in GPT-OSS mock server startup

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -125,8 +125,12 @@ jobs:
             if [ -s mock_server.port ]; then
               port=$(cat mock_server.port)
               if [[ "$port" =~ ^[0-9]+$ ]]; then
-                echo "LLM_PORT=$port" >> "$GITHUB_ENV"
-                ready=1
+                if [ -n "${GITHUB_ENV:-}" ]; then
+                  echo "LLM_PORT=$port" >> "$GITHUB_ENV"
+                  ready=1
+                else
+                  echo "::warning::Переменная GITHUB_ENV не задана – не удалось экспортировать порт LLM" >&2
+                fi
                 break
               fi
             fi


### PR DESCRIPTION
## Summary
- guard the GPT-OSS review workflow against missing GITHUB_ENV when exporting the mock server port
- emit a warning instead of failing the job when the environment file is unavailable

## Testing
- pytest tests/test_run_gptoss_review.py

------
https://chatgpt.com/codex/tasks/task_e_68d1a545645c832db557560674eadf4c