### PR TITLE
Normalize dependency snapshot requirement aliases

### DIFF
--- a/scripts/submit_dependency_snapshot.py
+++ b/scripts/submit_dependency_snapshot.py
@@ -242,12 +242,17 @@ def _parse_requirements(path: Path) -> Dict[str, ResolvedDependency]:
             "scope": scope,
             "dependencies": [],
         }
+        normalised_requirement = requirement_part
+        if "==" in requirement_part:
+            name_part, version_part = requirement_part.split("==", 1)
+            normalised_requirement = f"{_normalise_name(name_part)}=={version_part}"
+
         resolved.add(
             raw_name,
             base_name,
             package_url,
             dependency,
-            extra_aliases=(requirement_part,),
+            extra_aliases=(requirement_part, normalised_requirement),
         )
     return resolved
 

--- a/tests/test_dependency_snapshot_parser.py
+++ b/tests/test_dependency_snapshot_parser.py
@@ -46,6 +46,15 @@ def test_parse_requirements_strips_inline_comments(tmp_path: Path) -> None:
     )
 
 
+def test_parse_requirements_adds_normalised_requirement_alias(tmp_path: Path) -> None:
+    path = _write_requirements(tmp_path, "PACKAGE[EXTRA]==1.2.3\n")
+
+    parsed = _parse_requirements(path)
+
+    assert parsed["PACKAGE[EXTRA]==1.2.3"]["package_url"] == "pkg:pypi/package@1.2.3"
+    assert parsed["package[extra]==1.2.3"]["package_url"] == "pkg:pypi/package@1.2.3"
+
+
 def test_parse_requirements_handles_hash_block(tmp_path: Path) -> None:
     path = _write_requirements(
         tmp_path,


### PR DESCRIPTION
## Summary
- ensure the dependency snapshot parser registers a normalised requirement alias alongside the raw specifier so lookups succeed regardless of requirement casing
- extend the dependency snapshot parser tests to cover uppercase requirement strings and their lower-case aliases

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1a4dcaf50832d8db16538c499e63f