### PR TITLE
Fix Dependabot workflow gating logic

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -14,12 +14,9 @@ permissions:
   contents: write
   pull-requests: write
 
-env:
-  IS_DEPENDABOT_PR: ${{ github.event_name == 'pull_request_target' && (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]') }}
-
 jobs:
   skip-non-dependabot:
-    if: ${{ env.IS_DEPENDABOT_PR != 'true' }}
+    if: ${{ !(github.event_name == 'pull_request_target' && (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Report skipped run
@@ -30,7 +27,7 @@ jobs:
             >> "$GITHUB_STEP_SUMMARY"
 
   dependabot:
-    if: ${{ env.IS_DEPENDABOT_PR == 'true' }}
+    if: ${{ github.event_name == 'pull_request_target' && (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]') }}
     runs-on: ubuntu-latest
     steps:
       - name: Dependabot metadata


### PR DESCRIPTION
## Summary
- ensure the Dependabot automation only executes for Dependabot pull_request_target events
- simplify the skip job by checking the actor/event combination directly

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d1a86b0b44832d84faa764893b973f