### PR TITLE
Include Docker requirements files in build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -34,6 +34,9 @@ venv/
 *.pkl.gz
 *.parquet
 !requirements.txt
+!requirements-core.txt
+!requirements-gpu.txt
+!requirements-healthcheck.txt
 !.env
 !Dockerfile
 !docker-compose.yml


### PR DESCRIPTION
## Summary
- ensure the Docker build context keeps the requirements files used by the docker-publish workflow so the CPU image build can copy them

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68d1a6a741c8832db62dec5d60752e20