### PR TITLE
Improve Trivy workflow resilience

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -24,11 +24,28 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Prepare Trivy cache directory
+        run: |
+          mkdir -p "$TRIVY_CACHE_DIR"
+        env:
+          TRIVY_CACHE_DIR: ${{ runner.temp }}/trivy-cache
+
+      - name: Restore Trivy vulnerability database
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        # v4.2.2
+        with:
+          path: ${{ runner.temp }}/trivy-cache
+          key: ${{ runner.os }}-trivy-db-${{ hashFiles('requirements*.txt', 'Dockerfile*') }}
+          restore-keys: |
+            ${{ runner.os }}-trivy-db-
+
       - id: trivy
         name: Run Trivy scan
         uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
         # 0.33.1
         continue-on-error: true
+        env:
+          TRIVY_CACHE_DIR: ${{ runner.temp }}/trivy-cache
         with:
           scan-type: fs
           format: sarif
@@ -50,14 +67,33 @@ jobs:
         id: parse_trivy
         if: ${{ steps.trivy.conclusion != 'skipped' && always() }}
         run: |
+          set -euo pipefail
           if [ ! -f trivy-results.sarif ]; then
             echo "sarif_exists=false" >> "$GITHUB_OUTPUT"
             echo "vulnerability_count=0" >> "$GITHUB_OUTPUT"
+            echo "parsing_failed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          count=$(jq '[.runs[]?.results[]?] | length' trivy-results.sarif)
+          if ! count=$(jq '[.runs[]?.results[]?] | length' trivy-results.sarif); then
+            echo "::error::Failed to parse trivy-results.sarif with jq." >&2
+            echo "sarif_exists=false" >> "$GITHUB_OUTPUT"
+            echo "vulnerability_count=0" >> "$GITHUB_OUTPUT"
+            echo "parsing_failed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           echo "sarif_exists=true" >> "$GITHUB_OUTPUT"
           echo "vulnerability_count=${count}" >> "$GITHUB_OUTPUT"
+          echo "parsing_failed=false" >> "$GITHUB_OUTPUT"
+
+      - name: Summarize Trivy scan
+        if: ${{ steps.trivy.conclusion != 'skipped' && always() }}
+        run: |
+          if [ "${{ steps.parse_trivy.outputs.sarif_exists }}" != 'true' ]; then
+            printf '### Trivy scan summary\n\n* No SARIF report was generated.\n' >> "$GITHUB_STEP_SUMMARY"
+          else
+            count="${{ steps.parse_trivy.outputs.vulnerability_count }}"
+            printf '### Trivy scan summary\n\n* High/Critical findings: `%s`\n' "$count" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: ${{ steps.parse_trivy.outputs.sarif_exists == 'true' && github.event_name != 'pull_request' && always() }}
@@ -78,6 +114,12 @@ jobs:
         if: ${{ steps.trivy.conclusion == 'failure' && steps.parse_trivy.outputs.sarif_exists != 'true' }}
         run: |
           echo "::error::Trivy scan failed before producing a SARIF report."
+          exit 1
+
+      - name: Fail if Trivy results parsing failed
+        if: ${{ steps.parse_trivy.outputs.parsing_failed == 'true' }}
+        run: |
+          echo "::error::Unable to parse Trivy SARIF output."
           exit 1
 
       - name: Fail if vulnerabilities found


### PR DESCRIPTION
## Summary
- cache the Trivy vulnerability database to reduce transient download failures
- harden SARIF parsing by handling jq availability and collect scan summaries
- surface parsing errors explicitly so the workflow only fails on actionable issues

## Testing
- `./actionlint -color`


------
https://chatgpt.com/codex/tasks/task_e_68d1a565c840832dac313122190cc6ca