### PR TITLE
Fix dependency graph change detection flag

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -63,7 +63,7 @@ jobs:
                   if any(fnmatch.fnmatch(file, pattern) for pattern in patterns)
               ]
 
-          changed_flag = "true" if diff_failed or changed else "false"
+          changed_flag = "true" if diff_failed or bool(changed) else "false"
           output_path = os.environ.get("GITHUB_OUTPUT")
           if not output_path:
               raise SystemExit("Missing GITHUB_OUTPUT")


### PR DESCRIPTION
## Summary
- ensure the dependency graph workflow correctly sets the change-detected output flag when manifests are modified

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68d1acb27900832d8d1f4ab3f8a8e5bf