### PR TITLE
Refine dependabot workflow gating

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -14,9 +14,12 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  IS_DEPENDABOT: ${{ github.event_name == 'pull_request_target' && (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]') }}
+
 jobs:
   skip-non-dependabot:
-    if: ${{ !(github.event_name == 'pull_request_target' && (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')) }}
+    if: ${{ env.IS_DEPENDABOT != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Report skipped run
@@ -27,7 +30,7 @@ jobs:
             >> "$GITHUB_STEP_SUMMARY"
 
   dependabot:
-    if: ${{ github.event_name == 'pull_request_target' && (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]') }}
+    if: ${{ env.IS_DEPENDABOT == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Dependabot metadata


### PR DESCRIPTION
## Summary
- reuse a shared expression to detect Dependabot actors at the workflow level
- gate the jobs on the shared flag so only the appropriate job runs

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d1acd41f88832da87314f1e595e2dd