### PR TITLE
Handle bcrypt panic and improve httpx test stub

### DIFF
--- a/password_utils.py
+++ b/password_utils.py
@@ -127,8 +127,12 @@ def verify_password(password: str, stored_hash: str) -> bool:
             )
         try:
             return bcrypt.checkpw(password.encode(), stored_hash.encode())
-        except ValueError as exc:
+        except Exception as exc:  # pragma: no cover - bcrypt may raise varied errors
             raise ValueError("Повреждён bcrypt-хэш пароля") from exc
+        except BaseException as exc:  # pragma: no cover - handle pyo3 panics
+            if exc.__class__.__module__ == "pyo3_runtime":
+                raise ValueError("Повреждён bcrypt-хэш пароля") from exc
+            raise
 
     raise ValueError("Неизвестный формат хэша пароля")
 

--- a/test_stubs.py
+++ b/test_stubs.py
@@ -12,7 +12,7 @@ import sys
 import types
 import logging
 from importlib.machinery import ModuleSpec
-from types import ModuleType
+from types import ModuleType, TracebackType
 from typing import Any, Protocol, cast
 
 
@@ -200,6 +200,11 @@ def apply() -> None:
             def text(self) -> str:
                 return self._text
 
+            def raise_for_status(self) -> None:  # pragma: no cover - simple helper
+                if 200 <= self.status_code < 400:
+                    return None
+                raise Exception(f"HTTP {self.status_code}")
+
             async def aread(self) -> bytes:
                 return self.content
 
@@ -256,6 +261,18 @@ def apply() -> None:
                 return _return_response()
 
             get = post = request
+
+            def __enter__(self) -> "_HTTPXClient":  # pragma: no cover - simple helper
+                return self
+
+            def __exit__(
+                self,
+                exc_type: type[BaseException] | None,
+                exc: BaseException | None,
+                tb: TracebackType | None,
+            ) -> bool:
+                self.close()
+                return False
 
             def close(self) -> None:  # pragma: no cover - simple no-op
                 return None


### PR DESCRIPTION
## Summary
- convert runtime panics from bcrypt into a ValueError so malformed hashes are handled consistently during verification
- extend the lightweight httpx stub used in tests to support `raise_for_status` and context manager usage when the real dependency is absent

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1ace25678832d97acca19bd6307c3