### PR TITLE
Fix Dockerfile syntax version for BuildKit

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1
+# syntax=docker/dockerfile:1.7
 
 FROM ubuntu:24.04 AS builder
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Summary
- bump the Dockerfile frontend version used by the CPU image to 1.7 so BuildKit can parse modern heredoc syntax

## Testing
- not run (Docker builds require Docker, which is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d1b0090928832d84ade42dc92212e4