### PR TITLE
Fix Dependabot workflow conditions

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -14,12 +14,9 @@ permissions:
   contents: write
   pull-requests: write
 
-env:
-  IS_DEPENDABOT: ${{ github.event_name == 'pull_request_target' && (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]') }}
-
 jobs:
   skip-non-dependabot:
-    if: ${{ env.IS_DEPENDABOT != 'true' }}
+    if: ${{ not (github.event_name == 'pull_request_target' && (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Report skipped run
@@ -30,7 +27,7 @@ jobs:
             >> "$GITHUB_STEP_SUMMARY"
 
   dependabot:
-    if: ${{ env.IS_DEPENDABOT == 'true' }}
+    if: ${{ github.event_name == 'pull_request_target' && (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]') }}
     runs-on: ubuntu-latest
     steps:
       - name: Dependabot metadata


### PR DESCRIPTION
## Summary
- remove the global IS_DEPENDABOT environment variable and inline the actor/event checks on each job
- ensure the skip job only runs for non-Dependabot events while the automation job stays limited to Dependabot PRs

## Testing
- `pytest -m "not integration" -q`


------
https://chatgpt.com/codex/tasks/task_e_68d27805f528832db96b11e727ed0620