### PR TITLE
Fix GitHub expression syntax in Dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   skip-non-dependabot:
-    if: ${{ not (github.event_name == 'pull_request_target' && (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')) }}
+    if: ${{ !(github.event_name == 'pull_request_target' && (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Report skipped run


### PR DESCRIPTION
## Summary
- fix the skip-non-dependabot gate to use valid GitHub Actions expression syntax

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d27d41148c832d90f841278052968a