### PR TITLE
Update Trivy cache action

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -31,8 +31,8 @@ jobs:
           TRIVY_CACHE_DIR: ${{ runner.temp }}/trivy-cache
 
       - name: Restore Trivy vulnerability database
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
-        # v4.2.2
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
+        # v4.2.4
         with:
           path: ${{ runner.temp }}/trivy-cache
           key: ${{ runner.os }}-trivy-db-${{ hashFiles('requirements*.txt', 'Dockerfile*') }}


### PR DESCRIPTION
## Summary
- update the Trivy workflow to use the supported actions/cache v4.2.4 commit

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d27b2f7b6c832d8531551400c776a0