### PR TITLE
Fix log sanitization for tab characters

### DIFF
--- a/services/logging_utils.py
+++ b/services/logging_utils.py
@@ -7,7 +7,7 @@ from typing import Any
 _CONTROL_MAP: dict[int, str] = {
     ord("\n"): "\\n",
     ord("\r"): "\\r",
-    ord("\t"): "\t",
+    ord("\t"): "\\t",
 }
 for _code_point in range(32):
     if _code_point in (10, 13, 9):  # already handled newlines, carriage return, tab

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,0 +1,12 @@
+"""Тесты для утилит очистки логов."""
+
+from services.logging_utils import sanitize_log_value
+
+
+def test_sanitize_log_value_replaces_control_characters() -> None:
+    """Невидимые символы управления заменяются безопасными эквивалентами."""
+
+    original = "start\nline\twith\x00controls\rend"
+    sanitized = sanitize_log_value(original)
+
+    assert sanitized == "start\\nline\\twith?controls\\rend"


### PR DESCRIPTION
## Summary
- escape tab characters when sanitizing log values to avoid hidden control characters
- add regression coverage ensuring sanitize_log_value replaces control characters predictably

## Testing
- flake8 .
- bandit -r . -ll -x ./tests,./scripts,./gptoss_check,./venv
- pytest -q --maxfail=1 --disable-warnings

------
https://chatgpt.com/codex/tasks/task_e_68d27b1aa844832d9b2cbbcca691b39f