### PR TITLE
Handle invalid manifest encodings for dependency graph

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   contents: write
-  security-events: write
+  dependency-graph: write
 
 jobs:
   submit:
@@ -110,7 +110,14 @@ jobs:
               for path in Path(".").rglob(pattern):
                   if is_excluded(path.parent):
                       continue
-                  original = path.read_text()
+                  try:
+                      original = path.read_text(encoding="utf-8")
+                  except UnicodeDecodeError as exc:
+                      print(
+                          f"Skipping {path} due to encoding error: {exc}",
+                          flush=True,
+                      )
+                      continue
                   lines = original.splitlines(keepends=True)
                   filtered: list[str] = []
                   for line in lines:
@@ -122,7 +129,7 @@ jobs:
                       filtered.append(line)
                   if filtered != lines:
                       updated = "".join(filtered)
-                      path.write_text(updated)
+                      path.write_text(updated, encoding="utf-8")
           PY
       - name: Submit dependency snapshot
         if: steps.detect.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'

--- a/tests/test_dependency_snapshot.py
+++ b/tests/test_dependency_snapshot.py
@@ -47,6 +47,21 @@ def test_parse_requirements_encodes_versions_for_purl(tmp_path: Path) -> None:
     assert resolved["torch"]["package_url"] == "pkg:pypi/torch@2.8.0%2Bcpu"
 
 
+def test_parse_requirements_handles_decode_errors(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    manifest = tmp_path / "requirements.txt"
+    manifest.write_bytes(b"\xff\xfeinvalid")
+
+    resolved = snapshot._parse_requirements(manifest)
+
+    assert not resolved
+
+    captured = capsys.readouterr()
+    assert "encoding error" in captured.err
+    assert "requirements.txt" in captured.err
+
+
 def test_submit_dependency_snapshot_skips_when_env_missing(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],


### PR DESCRIPTION
## Summary
- skip dependency manifest processing when requirement files contain invalid UTF-8 and explain the issue in logs
- extend the dependency submission workflow to read/write requirement files with UTF-8 encoding and log decoding problems
- ensure the workflow requests dependency-graph write permissions required for snapshot submission and add regression coverage

## Testing
- pytest tests/test_dependency_snapshot.py
- pytest tests/test_dependency_snapshot_parser.py

------
https://chatgpt.com/codex/tasks/task_e_68d27ad73eb8832d8b243ff2feee1784