### PR TITLE
fix: use dockerfile syntax 1.6 for cpu image

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1.6
 
 FROM ubuntu:24.04 AS builder
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Summary
- downgrade the Dockerfile.cpu frontend syntax to 1.6 so the GitHub Actions build step can parse it without errors

## Testing
- not run (Dockerfile change only)


------
https://chatgpt.com/codex/tasks/task_e_68d27e2808bc832d800d2c160c3a687e