### PR TITLE
Restore security events permission for dependency graph workflow

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: write
   dependency-graph: write
+  security-events: write
 
 jobs:
   submit:


### PR DESCRIPTION
## Summary
- restore the security-events write permission in the dependency-graph workflow so dependency snapshots can be submitted successfully

## Testing
- pytest tests/test_dependency_snapshot.py

------
https://chatgpt.com/codex/tasks/task_e_68d28452d820832dbfe552ce69ce8a4e