### PR TITLE
Fix dependency graph workflow permissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: write
-  dependency-graph: write
   security-events: write
 
 jobs:


### PR DESCRIPTION
## Summary
- remove the unsupported `dependency-graph` permission from the dependency submission workflow to allow it to load

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d28c3513ac832d94fa68d3e3e5844b