### PR TITLE
Fix pip invocation in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           device: ${{ matrix.device }}
       - name: Install development requirements
-        run: pip install -r requirements-ci.txt
+        run: python -m pip install -r requirements-ci.txt
       - run: python -m ruff check bot tests --output-format=github
       - run: python -m mypy bot
       - run: python -m bandit -r bot -x tests -ll
@@ -96,7 +96,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           device: ${{ matrix.device }}
       - name: Install development requirements
-        run: pip install -r requirements-ci.txt
+        run: python -m pip install -r requirements-ci.txt
       - name: Remove test caches
         if: always()
         uses: ./.github/actions/clear-test-caches


### PR DESCRIPTION
## Summary
- call pip via `python -m pip` in the CI workflow to avoid missing command failures on cached runners

## Testing
- TEST_MODE=1 pytest -m "not integration"

------
https://chatgpt.com/codex/tasks/task_e_68d28c409998832db0cc401c18dc5467