### PR TITLE
Improve GPT-OSS check robustness without external httpx install

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,7 +165,7 @@ services:
         hard: 65536
   gptoss_check:
     image: python:3.11-slim
-    command: sh -c "pip install --no-cache-dir httpx && python3 gptoss_check/main.py"
+    command: python3 gptoss_check/main.py
     working_dir: /workspace
     volumes:
       - .:/workspace


### PR DESCRIPTION
## Summary
- implement a standard-library HTTP client fallback in gptoss_check so the GPT-OSS review can run without third-party packages
- update error handling to rely on the shared HTTPError alias and keep retry/Telegram logic intact
- simplify the gptoss_check docker-compose command by removing the on-the-fly httpx installation

## Testing
- pytest
- python -m flake8 --exclude venv .
- python -m mypy gptoss_check

------
https://chatgpt.com/codex/tasks/task_e_68d28c4a854c832d9bd29c5762f671ce