### PR TITLE
Improve Dependabot actor checks

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -14,9 +14,12 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  DEPENDABOT_ACTORS_JSON: '["dependabot[bot]","dependabot-preview[bot]"]'
+
 jobs:
   skip-non-dependabot:
-    if: ${{ !(github.event_name == 'pull_request_target' && (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')) }}
+    if: ${{ !(github.event_name == 'pull_request_target' && contains(fromJSON(env.DEPENDABOT_ACTORS_JSON), github.actor)) }}
     runs-on: ubuntu-latest
     steps:
       - name: Report skipped run
@@ -27,7 +30,7 @@ jobs:
             >> "$GITHUB_STEP_SUMMARY"
 
   dependabot:
-    if: ${{ github.event_name == 'pull_request_target' && (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]') }}
+    if: ${{ github.event_name == 'pull_request_target' && contains(fromJSON(env.DEPENDABOT_ACTORS_JSON), github.actor) }}
     runs-on: ubuntu-latest
     steps:
       - name: Dependabot metadata


### PR DESCRIPTION
## Summary
- centralize the Dependabot actor list for the workflow checks
- rely on supported GitHub Actions expressions to guard skip and Dependabot jobs

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d2a5e2d9e4832d8368a285b8f93fed