### PR TITLE
Fix dependabot workflow expressions for non-PR events

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -42,14 +42,14 @@ jobs:
         uses: hmarr/auto-approve-action@8f929096a962e83ccdfa8afcf855f39f12d4dac7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          pull-request-number: ${{ github.event.pull_request.number }}
+          pull-request-number: ${{ (github.event.pull_request && github.event.pull_request.number) || '' }}
       - name: Checkout code
         # v5.0.0
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           fetch-depth: 0
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ (github.event.pull_request && github.event.pull_request.head.repo.full_name) || github.repository }}
+          ref: ${{ (github.event.pull_request && github.event.pull_request.head.sha) || github.sha }}
 
       # Set up a lightweight Python environment and install only the
       # dependencies required to run the unit tests.  This avoids the
@@ -147,7 +147,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ (github.event.pull_request && github.event.pull_request.number) || '' }}
         shell: bash
         run: |
           set -uo pipefail


### PR DESCRIPTION
## Summary
- guard Dependabot workflow expressions that access `github.event.pull_request` so push events no longer fail during evaluation
- ensure the checkout step falls back to the repository and SHA from the triggering event when no pull request payload is present

## Testing
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_e_68d2a5e66bf8832dad7d603cf349e6a3