### PR TITLE
Guard dependency snapshot workflow on main branch

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -6,13 +6,21 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: write
-  security-events: write
-
 jobs:
-  submit:
+  guard:
+    if: github.ref != 'refs/heads/main' && github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
+    steps:
+      - name: Skip dependency snapshot for non-main push
+        run: |
+          echo "Dependency snapshot submission runs only on 'main' or when manually dispatched."
+
+  submit:
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      security-events: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:


### PR DESCRIPTION
## Summary
- add a guard job so branch pushes report a friendly skip instead of failing
- restrict the dependency snapshot job to main or manual dispatch runs
- scope elevated permissions to the submission job only

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d2a5f32a10832d80c99ed987b4283f