### PR TITLE
Add regression test guarding python3 usage in GPT-OSS workflow

### DIFF
--- a/tests/test_gptoss_workflow_python3.py
+++ b/tests/test_gptoss_workflow_python3.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+WORKFLOW_PATH = Path('.github/workflows/gptoss_review.yml')
+
+
+def test_gptoss_workflow_uses_python3() -> None:
+    workflow_text = WORKFLOW_PATH.read_text(encoding='utf-8')
+
+    assert 'python3 scripts/gptoss_mock_server.py' in workflow_text
+    assert 'python3 scripts/prepare_gptoss_diff.py' in workflow_text
+    assert 'python3 scripts/run_gptoss_review.py' in workflow_text
+    assert 'python scripts/gptoss_mock_server.py' not in workflow_text
+    assert 'python scripts/prepare_gptoss_diff.py' not in workflow_text
+    assert 'python scripts/run_gptoss_review.py' not in workflow_text


### PR DESCRIPTION
## Summary
- add a regression test that inspects `.github/workflows/gptoss_review.yml`
- ensure the GPT-OSS review workflow always invokes helper scripts via `python3`

## Testing
- pytest tests/test_gptoss_workflow_python3.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2a602fc20832d9813bb8cfbb4690c