### PR TITLE
Fix Release Drafter workflow permissions

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
     branches:
       - main
     types: [opened, reopened, synchronize, labeled, unlabeled, edited]
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   update_release_draft:
-    if: github.event_name != 'pull_request' || (github.event.pull_request && github.event.pull_request.head.repo.full_name == github.repository)
+    if: github.event_name != 'pull_request_target' || (github.event.pull_request && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     steps:
       - name: Update release draft


### PR DESCRIPTION
## Summary
- switch Release Drafter workflow to pull_request_target for PR-triggered updates
- adjust workflow guard to match new event name so forked contributions stay skipped

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d2a60d51b4832d9ab041abe8c65543