### PR TITLE
Fix Trivy workflow artifact permissions

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -12,7 +12,7 @@ on:
 permissions:
   contents: read
   security-events: write
-  actions: read  # required for github/codeql-action/upload-sarif
+  actions: write  # required for uploading artifacts such as SARIF reports
 
 jobs:
   scan:


### PR DESCRIPTION
## Summary
- grant the Trivy workflow the write-level Actions permission so artifact uploads succeed reliably

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d2a628be74832db351a7ba9da1ed58