### PR TITLE
Fix Dependabot workflow summary handling

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -24,17 +24,20 @@ jobs:
     steps:
       - name: Report skipped run
         run: |
-          if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-            {
-              printf '%s\n' \
-                "Dependabot automation runs only for Dependabot pull_request_target events." \
-                "Actor '${{ github.actor }}' on event '${{ github.event_name }}' does not require action."
-            } >>"$GITHUB_STEP_SUMMARY"
-          else
-            printf '%s\n' \
-              "Dependabot automation runs only for Dependabot pull_request_target events." \
-              "Actor '${{ github.actor }}' on event '${{ github.event_name }}' does not require action."
-          fi
+          write_summary() {
+            local message
+            message=$1
+
+            if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+              mkdir -p "$(dirname "$GITHUB_STEP_SUMMARY")"
+              printf '%s\n' "${message}" >>"$GITHUB_STEP_SUMMARY"
+            else
+              printf '%s\n' "${message}"
+            fi
+          }
+
+          write_summary "Dependabot automation runs only for Dependabot pull_request_target events."
+          write_summary "Actor '${{ github.actor }}' on event '${{ github.event_name }}' does not require action."
 
   dependabot:
     if: ${{ github.event_name == 'pull_request_target' && contains(fromJSON(env.DEPENDABOT_ACTORS_JSON), github.actor) }}
@@ -143,15 +146,20 @@ jobs:
         env:
           ALLOW_AUTO_MERGE: ${{ github.event.repository.allow_auto_merge == true }}
         run: |
+          write_summary() {
+            if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+              mkdir -p "$(dirname "$GITHUB_STEP_SUMMARY")"
+              printf '%s\n' "$1" >>"$GITHUB_STEP_SUMMARY"
+            else
+              printf '%s\n' "$1"
+            fi
+          }
+
           if [[ "${ALLOW_AUTO_MERGE}" == 'true' ]]; then
             echo "allowed=true" >> "$GITHUB_OUTPUT"
           else
             echo "allowed=false" >> "$GITHUB_OUTPUT"
-            if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-              echo "Auto-merge is disabled for this repository; skipping enablement." >>"$GITHUB_STEP_SUMMARY"
-            else
-              echo "Auto-merge is disabled for this repository; skipping enablement."
-            fi
+            write_summary "Auto-merge is disabled for this repository; skipping enablement."
           fi
 
       - name: Enable auto-merge for Dependabot PRs
@@ -181,37 +189,20 @@ jobs:
             --data "${payload}"); then
             echo "enabled=false" >> "$GITHUB_OUTPUT"
             echo "status=transport-error" >> "$GITHUB_OUTPUT"
-            if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-              {
-                printf '%s\n' "Unable to contact the GitHub API to enable auto-merge."
-              } >>"$GITHUB_STEP_SUMMARY"
-            else
-              printf '%s\n' "Unable to contact the GitHub API to enable auto-merge."
-            fi
+            write_summary "Unable to contact the GitHub API to enable auto-merge."
             exit 0
           fi
 
           if [[ "${status}" =~ ^2 ]]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
-            if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-              printf '%s\n' "Auto-merge enabled successfully (HTTP ${status})." >>"$GITHUB_STEP_SUMMARY"
-            else
-              printf '%s\n' "Auto-merge enabled successfully (HTTP ${status})."
-            fi
+            write_summary "Auto-merge enabled successfully (HTTP ${status})."
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"
             echo "status=${status}" >> "$GITHUB_OUTPUT"
+            write_summary "Unable to enable auto-merge automatically (HTTP ${status})."
             if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-              {
-                printf '%s\n' \
-                  "Unable to enable auto-merge automatically (HTTP ${status})." \
-                  "Response from the GitHub API:"
-                cat response.json
-              } >>"$GITHUB_STEP_SUMMARY"
+              cat response.json >>"$GITHUB_STEP_SUMMARY"
             else
-              printf '%s\n' \
-                "Unable to enable auto-merge automatically (HTTP ${status})." \
-                "Response from the GitHub API:"
               cat response.json
             fi
           fi
@@ -222,6 +213,7 @@ jobs:
         if: ${{ steps.enable_automerge.outputs.enabled == 'false' }}
         run: |
           if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+            mkdir -p "$(dirname "$GITHUB_STEP_SUMMARY")"
             printf '%s\n' \
               "Auto-merge could not be enabled automatically. Check repository settings or branch protection rules." \
               >>"$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- ensure the Dependabot skip job safely appends messages to the step summary
- guard all auto-merge steps with helper logic that creates the summary directory before writing
- keep API failure diagnostics visible even when the summary file is unavailable

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d2d6df1108832da33beeac6ce197ae