### PR TITLE
Fix Dependabot workflow actor filtering

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -14,12 +14,9 @@ permissions:
   contents: write
   pull-requests: write
 
-env:
-  DEPENDABOT_ACTORS_JSON: '["dependabot[bot]","dependabot-preview[bot]"]'
-
 jobs:
   skip-non-dependabot:
-    if: ${{ !(github.event_name == 'pull_request_target' && contains(fromJSON(env.DEPENDABOT_ACTORS_JSON), github.actor)) }}
+    if: ${{ github.event_name != 'pull_request_target' || (github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]') }}
     runs-on: ubuntu-latest
     steps:
       - name: Report skipped run
@@ -40,7 +37,7 @@ jobs:
           write_summary "Actor '${{ github.actor }}' on event '${{ github.event_name }}' does not require action."
 
   dependabot:
-    if: ${{ github.event_name == 'pull_request_target' && contains(fromJSON(env.DEPENDABOT_ACTORS_JSON), github.actor) }}
+    if: ${{ github.event_name == 'pull_request_target' && (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]') }}
     runs-on: ubuntu-latest
     steps:
       - name: Dependabot metadata


### PR DESCRIPTION
## Summary
- simplify the actor checks so that only Dependabot `pull_request_target` events run the automation job
- ensure non-Dependabot events execute the skip job without relying on JSON parsing of the actor list

## Testing
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_e_68d2d9e62c60832d91c4041ad49f55be