### PR TITLE
Fix ruff E501 in fallback HTTP client

### DIFF
--- a/gptoss_check/check_code.py
+++ b/gptoss_check/check_code.py
@@ -77,7 +77,14 @@ except Exception as import_error:  # pragma: no cover - fallback for CI containe
             def __init__(self, timeout: float = 10.0) -> None:
                 self.timeout = timeout
 
-            def _request(self, method: str, url: str, *, body: bytes | None, headers: dict[str, str]) -> _SimpleResponse:
+            def _request(
+                self,
+                method: str,
+                url: str,
+                *,
+                body: bytes | None,
+                headers: dict[str, str],
+            ) -> _SimpleResponse:
                 parsed = urlparse(url)
                 if parsed.scheme not in {"http", "https"}:
                     raise HTTPError(f"Unsupported URL scheme: {parsed.scheme}")


### PR DESCRIPTION
## Summary
- reformat the fallback `_SimpleClient._request` signature to respect Ruff's line-length rule

## Testing
- `ruff check`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d2dcf43bf4832da99f52e7613d7598