### PR TITLE
Fix dependency graph snapshot permissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  dependency-graph: write
   security-events: write
 
 jobs:


### PR DESCRIPTION
## Summary
- restore the dependency graph write permission required for submitting dependency snapshots

## Testing
- not run (not needed for workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d2dce5ffd8832dbc123362a884eea9