### PR TITLE
Fix Dockerfile pipefail usage for CPU image

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -71,15 +71,16 @@ PY
 # https://github.com/averinaleks/bot/actions/workflows/docker-publish.yml for the
 # historical failures.
 
-RUN set -euo pipefail; \
-    nvidia_packages="$($VIRTUAL_ENV/bin/pip freeze | grep -i '^nvidia-' || true)"; \
-    if [ -n "$nvidia_packages" ]; then \
-        printf '%s\n' "$nvidia_packages" | cut -d= -f1 | xargs -r "$VIRTUAL_ENV"/bin/pip uninstall -y; \
-    else \
-        echo "No NVIDIA packages detected in the virtual environment"; \
-    fi; \
-    find "$VIRTUAL_ENV" -type d -name '__pycache__' -exec rm -rf {} +; \
-    find "$VIRTUAL_ENV" -type f -name '*.pyc' -delete
+RUN bash -euo pipefail -c "
+    nvidia_packages=\"\$($VIRTUAL_ENV/bin/pip freeze | grep -i '^nvidia-' || true)\"
+    if [ -n \"\$nvidia_packages\" ]; then
+        printf '%s\\n' \"\$nvidia_packages\" | cut -d= -f1 | xargs -r \"$VIRTUAL_ENV\"/bin/pip uninstall -y
+    else
+        echo 'No NVIDIA packages detected in the virtual environment'
+    fi
+    find \"$VIRTUAL_ENV\" -type d -name '__pycache__' -exec rm -rf {} +
+    find \"$VIRTUAL_ENV\" -type f -name '*.pyc' -delete
+"
 
 FROM ubuntu:24.04
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Summary
- adjust the CPU Dockerfile cleanup step to run under bash so pipefail is supported

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d2dd97c4b0832db4c9c43e08363030