### PR TITLE
Fix dependency graph workflow permissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  dependency-graph: write
   security-events: write
 
 jobs:


### PR DESCRIPTION
## Summary
- remove the dependency-graph write permission from the dependency submission workflow to satisfy permission policy tests

## Testing
- pytest tests/test_dependency_graph_workflow.py

------
https://chatgpt.com/codex/tasks/task_e_68d2df66dc5c832d9373ca6c12b3dc97