### PR TITLE
Fix trivy workflow cache pin

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -31,8 +31,8 @@ jobs:
           TRIVY_CACHE_DIR: ${{ runner.temp }}/trivy-cache
 
       - name: Restore Trivy vulnerability database
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
-        # v4.2.4
+        uses: actions/cache@638ed79f9dc94c1de1baef91bcab5edaa19451f4
+        # 2025-09-16 commit (post v4.2.4) avoids deprecated cache runner enforcement
         with:
           path: ${{ runner.temp }}/trivy-cache
           key: ${{ runner.os }}-trivy-db-${{ hashFiles('requirements*.txt', 'Dockerfile*') }}


### PR DESCRIPTION
## Summary
- bump the pinned `actions/cache` reference in the Trivy workflow to the latest safe commit
- document the new pin to avoid future deprecation failures during job setup

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d2dd1f1118832da2dc34fb67c13878