### PR TITLE
Fix data handler import side effects and add timezone tests

### DIFF
--- a/data_handler/__init__.py
+++ b/data_handler/__init__.py
@@ -8,17 +8,20 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # pragma: no cover - Flask not installed
     api_app = None  # type: ignore[assignment]
 from .storage import DEFAULT_PRICE
-from bot import http_client as _http_client
 
 
 async def get_http_client():
     """Expose the shared async HTTP client used across the project."""
+
+    from bot import http_client as _http_client  # Local import avoids import side-effects
 
     return await _http_client.get_async_http_client()
 
 
 async def close_http_client() -> None:
     """Close the shared async HTTP client if it exists."""
+
+    from bot import http_client as _http_client  # Imported on demand to prevent env validation on import
 
     await _http_client.close_async_http_client()
 

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -1,9 +1,35 @@
+import importlib
+import sys
+
 import pandas as pd
+import pandas.testing as pdt
 
 
-def test_local_time_converts_to_utc():
-    """Локальное время должно корректно преобразовываться в UTC."""
-    local_time = pd.Timestamp.now()
-    utc_time = local_time.tz_localize("UTC").tz_convert("UTC")
-    assert utc_time.tzname() == "UTC"
-    assert utc_time.utcoffset() == pd.Timedelta(0)
+def test_ensure_utc_converts_series_to_utc(monkeypatch):
+    """ensure_utc должен конвертировать серию с локальным временем в UTC."""
+    monkeypatch.setenv("TEST_MODE", "1")
+    sys.modules.pop("data_handler", None)
+    sys.modules.pop("data_handler.utils", None)
+    ensure_utc = importlib.import_module("data_handler.utils").ensure_utc
+    local_series = pd.Series([pd.Timestamp("2024-01-01 12:30:00")])
+
+    utc_series = ensure_utc(local_series)
+
+    expected = pd.Series(
+        [pd.Timestamp("2024-01-01 12:30:00", tz="UTC")]
+    )
+    pdt.assert_series_equal(utc_series, expected)
+
+
+def test_ensure_utc_converts_index_to_utc(monkeypatch):
+    """ensure_utc должен корректно преобразовывать индекс в UTC."""
+    monkeypatch.setenv("TEST_MODE", "1")
+    sys.modules.pop("data_handler", None)
+    sys.modules.pop("data_handler.utils", None)
+    ensure_utc = importlib.import_module("data_handler.utils").ensure_utc
+    local_index = pd.Index([pd.Timestamp("2024-02-15 08:00:00")])
+
+    utc_index = ensure_utc(local_index)
+
+    expected = pd.DatetimeIndex([pd.Timestamp("2024-02-15 08:00:00", tz="UTC")])
+    pdt.assert_index_equal(utc_index, expected)


### PR DESCRIPTION
## Summary
- defer the bot.http_client import in data_handler to avoid environment validation during package import
- add timezone tests that exercise ensure_utc for both series and indexes without module caching side effects

## Testing
- pytest -q --maxfail=1 --disable-warnings

------
https://chatgpt.com/codex/tasks/task_e_68d2dd0e2890832db67fab00cda7e8bb