### PR TITLE
Fix CodeQL cyclic import warnings

### DIFF
--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -27,6 +27,7 @@ from services.logging_utils import sanitize_log_value
 from security import (
     ArtifactDeserializationError,
     safe_joblib_load,
+    set_model_dir,
     verify_model_state_signature,
     write_model_state_signature,
 )
@@ -189,6 +190,7 @@ MODEL_DIR = ensure_writable_directory(
     description="моделей",
     fallback_subdir="trading_bot_models",
 ).resolve()
+set_model_dir(MODEL_DIR)
 def _resolve_model_file(path_value: str | Path | None) -> Path:
     """Return a sanitised path for pre-trained model artefacts."""
 


### PR DESCRIPTION
## Summary
- avoid importing `services.model_builder_service` from the security helpers to remove the unsafe cyclic import flagged by CodeQL
- expose a `set_model_dir` helper and register the resolved model directory from the model builder service at import time

## Testing
- pytest tests/test_model_builder.py tests/test_model_builder_model_dir.py tests/test_model_builder_signatures.py tests/test_security.py

------
https://chatgpt.com/codex/tasks/task_e_68d2dcd561e0832d99c0ece5721eb9d1