### PR TITLE
Handle GPT-OSS readiness when completions require prompt

### DIFF
--- a/gptoss_check/check_code.py
+++ b/gptoss_check/check_code.py
@@ -284,14 +284,21 @@ def wait_for_api(api_url: str, timeout: int | None = None) -> None:
         except HTTPError:
             pass
 
+        payload = {"prompt": "ping"}
+        model = os.getenv("GPT_OSS_MODEL")
+        if model:
+            payload["model"] = model
+
         try:
             with get_httpx_client(timeout=5, trust_env=False) as client:
-                response = client.post(completions_url, json={})
+                response = client.post(completions_url, json=payload)
                 try:
+                    status_code = getattr(response, "status_code", None)
+                    if isinstance(status_code, int) and status_code < 500:
+                        return
                     response.raise_for_status()
                 finally:
                     response.close()
-            return
         except HTTPError:
             time.sleep(1)
 


### PR DESCRIPTION
## Summary
- update the GPT-OSS readiness probe to send a minimal prompt payload and treat non-server errors as readiness
- extend the GPT-OSS check tests to cover payload contents, model propagation, and graceful handling of 4xx responses

## Testing
- python -m flake8
- python -m mypy --exclude venv .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2dcc7f740832d9f3998a240cc2763