### PR TITLE
Handle connection cleanup errors in gptoss_check HTTP client

### DIFF
--- a/gptoss_check/check_code.py
+++ b/gptoss_check/check_code.py
@@ -89,6 +89,7 @@ except Exception as import_error:  # pragma: no cover - fallback for CI containe
                 if parsed.query:
                     path = f"{path}?{parsed.query}"
 
+                connection = None
                 try:
                     connection = connection_cls(host, port, timeout=self.timeout)  # type: ignore[arg-type]
                     connection.request(method.upper(), path, body=body, headers=headers)
@@ -99,10 +100,14 @@ except Exception as import_error:  # pragma: no cover - fallback for CI containe
                 except (HTTPException, OSError, ValueError, socket.error) as exc:
                     raise HTTPError(str(exc)) from exc
                 finally:
-                    try:
-                        connection.close()  # type: ignore[has-type]
-                    except Exception:  # pragma: no cover - best effort cleanup
-                        pass
+                    if connection is not None:
+                        try:
+                            connection.close()  # type: ignore[has-type]
+                        except Exception as close_exc:  # pragma: no cover - best effort cleanup
+                            logger.debug(
+                                "Failed to close HTTP connection: %s",
+                                sanitize_log_value(str(close_exc)),
+                            )
 
                 return _SimpleResponse(status, header_map, payload)
 


### PR DESCRIPTION
## Summary
- guard the lightweight HTTP client against partially initialised connections
- log sanitized close failures instead of swallowing exceptions so Bandit no longer reports B110

## Testing
- bandit -r . -ll -ii -x ./tests,./scripts,./gptoss_check
- bandit -r gptoss_check -ll -ii

------
https://chatgpt.com/codex/tasks/task_e_68d2dcb64470832d8a2d9e33d5a7cfac