### PR TITLE
Fix Dockerfile CPU cleanup script syntax

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -71,16 +71,16 @@ PY
 # https://github.com/averinaleks/bot/actions/workflows/docker-publish.yml for the
 # historical failures.
 
-RUN bash -euo pipefail -c "
-    nvidia_packages=\"\$($VIRTUAL_ENV/bin/pip freeze | grep -i '^nvidia-' || true)\"
-    if [ -n \"\$nvidia_packages\" ]; then
-        printf '%s\\n' \"\$nvidia_packages\" | cut -d= -f1 | xargs -r \"$VIRTUAL_ENV\"/bin/pip uninstall -y
-    else
-        echo 'No NVIDIA packages detected in the virtual environment'
-    fi
-    find \"$VIRTUAL_ENV\" -type d -name '__pycache__' -exec rm -rf {} +
-    find \"$VIRTUAL_ENV\" -type f -name '*.pyc' -delete
-"
+RUN bash -euo pipefail <<'BASH'
+nvidia_packages="$($VIRTUAL_ENV/bin/pip freeze | grep -i '^nvidia-' || true)"
+if [ -n "$nvidia_packages" ]; then
+    printf '%s\n' "$nvidia_packages" | cut -d= -f1 | xargs -r "$VIRTUAL_ENV"/bin/pip uninstall -y
+else
+    echo 'No NVIDIA packages detected in the virtual environment'
+fi
+find "$VIRTUAL_ENV" -type d -name '__pycache__' -exec rm -rf {} +
+find "$VIRTUAL_ENV" -type f -name '*.pyc' -delete
+BASH
 
 FROM ubuntu:24.04
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Summary
- fix the CPU Dockerfile cleanup step so the script runs via a heredoc
- prevent Docker from treating the cleanup commands as top-level instructions

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d2e94ec4a8832d85c4db9c77de38bf