### PR TITLE
Fix Dependabot workflow actor checks

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   skip-non-dependabot:
-    if: ${{ github.event_name != 'pull_request_target' || (github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]') }}
+    if: ${{ github.event_name != 'pull_request_target' || !contains(fromJson('["dependabot[bot]","dependabot-preview[bot]"]'), github.actor) }}
     runs-on: ubuntu-latest
     steps:
       - name: Report skipped run
@@ -37,7 +37,7 @@ jobs:
           write_summary "Actor '${{ github.actor }}' on event '${{ github.event_name }}' does not require action."
 
   dependabot:
-    if: ${{ github.event_name == 'pull_request_target' && (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]') }}
+    if: ${{ github.event_name == 'pull_request_target' && contains(fromJson('["dependabot[bot]","dependabot-preview[bot]"]'), github.actor) }}
     runs-on: ubuntu-latest
     steps:
       - name: Dependabot metadata


### PR DESCRIPTION
## Summary
- tighten the Dependabot workflow conditions to use a single allowlist helper
- ensure only Dependabot actors trigger the automation job

## Testing
- not run (workflow logic change only)


------
https://chatgpt.com/codex/tasks/task_e_68d2ea789b3c832d8bddfe1262d9bc79