### PR TITLE
Fix dependency graph manifest detection

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -32,6 +32,7 @@ jobs:
           import fnmatch
           import os
           import subprocess
+          from pathlib import Path
           from typing import Sequence
 
           patterns: Sequence[str] = (
@@ -81,11 +82,20 @@ jobs:
                       for line in completed.stdout.splitlines()
                       if line.strip()
                   ]
-                  changed = [
-                      file
-                      for file in files
-                      if any(fnmatch.fnmatch(file, pattern) for pattern in patterns)
-                  ]
+                  changed = []
+                  for file in files:
+                      if not file:
+                          continue
+                      try:
+                          filename = Path(file).name
+                      except Exception:
+                          filename = file
+                      if any(
+                          fnmatch.fnmatch(file, pattern)
+                          or fnmatch.fnmatch(filename, pattern)
+                          for pattern in patterns
+                      ):
+                          changed.append(file)
 
           changed_flag = "true" if diff_failed or bool(changed) else "false"
           output_path = os.environ.get("GITHUB_OUTPUT")

--- a/tests/test_dependency_graph_workflow.py
+++ b/tests/test_dependency_graph_workflow.py
@@ -45,3 +45,11 @@ def test_dependency_graph_permissions_are_valid() -> None:
 
     assert permissions.get("contents") == "read"
     assert permissions.get("security-events") == "write"
+
+
+def test_dependency_graph_detect_step_handles_nested_manifests() -> None:
+    workflow = Path(".github/workflows/dependency-graph.yml").read_text(encoding="utf-8")
+
+    assert "from pathlib import Path" in workflow
+    assert "Path(file).name" in workflow
+    assert "fnmatch(filename, pattern)" in workflow


### PR DESCRIPTION
## Summary
- update the dependency graph workflow to correctly detect nested requirement manifest changes
- guard the workflow detection code with basic assertions to ensure the new logic remains in place

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d2ea8ea548832dbc34894a2c72f016