### PR TITLE
Ensure model builder host validation before binding

### DIFF
--- a/model_builder.py
+++ b/model_builder.py
@@ -34,6 +34,7 @@ from bot.utils import (
     ensure_writable_directory,
     is_cuda_available,
     logger,
+    validate_host,
 )
 from models.architectures import KERAS_FRAMEWORKS, create_model
 from security import (
@@ -2321,7 +2322,7 @@ def ping():
 if __name__ == "__main__":
     configure_logging()
     load_dotenv()
-    host = os.getenv("HOST", "127.0.0.1")
+    host = validate_host()
     port = int(os.getenv("MODEL_BUILDER_PORT", "8001"))
     _load_model()
     logger.info("Запуск сервиса ModelBuilder на %s:%s", host, port)


### PR DESCRIPTION
## Summary
- update the standalone `model_builder` entry point to reuse the shared `validate_host` helper
- prevent the service from binding to non-loopback addresses when `HOST` is misconfigured

## Testing
- bandit -r . -ll -ii -x ./tests,./scripts,./gptoss_check

------
https://chatgpt.com/codex/tasks/task_e_68d2ea65a928832daabf1e7e71049bba