### PR TITLE
Fix Trivy workflow cache action reference

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -31,8 +31,8 @@ jobs:
           TRIVY_CACHE_DIR: ${{ runner.temp }}/trivy-cache
 
       - name: Restore Trivy vulnerability database
-        uses: actions/cache@638ed79f9dc94c1de1baef91bcab5edaa19451f4
-        # 2025-09-16 commit (post v4.2.4) avoids deprecated cache runner enforcement
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
+        # v4.2.4
         with:
           path: ${{ runner.temp }}/trivy-cache
           key: ${{ runner.os }}-trivy-db-${{ hashFiles('requirements*.txt', 'Dockerfile*') }}


### PR DESCRIPTION
## Summary
- repoint the Trivy workflow cache step to the published v4.2.4 commit of actions/cache

## Testing
- actionlint .github/workflows/trivy.yml

------
https://chatgpt.com/codex/tasks/task_e_68d2eab02088832db9c1a88918f1f8de