### PR TITLE
Fix dependabot workflow summary helper

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -171,6 +171,15 @@ jobs:
         run: |
           set -uo pipefail
 
+          write_summary() {
+            if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+              mkdir -p "$(dirname "$GITHUB_STEP_SUMMARY")"
+              printf '%s\n' "$1" >>"$GITHUB_STEP_SUMMARY"
+            else
+              printf '%s\n' "$1"
+            fi
+          }
+
           api_url="https://api.github.com/repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/auto-merge"
           payload='{"merge_method":"squash"}'
 


### PR DESCRIPTION
## Summary
- define the write_summary helper inside the auto-merge step so the workflow can use it when reporting API results

## Testing
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_e_68d2f2826368832d8698766117d4211e