### PR TITLE
Fix Dependabot workflow summary helper

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -171,6 +171,15 @@ jobs:
         run: |
           set -uo pipefail
 
+          write_summary() {
+            if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+              mkdir -p "$(dirname "$GITHUB_STEP_SUMMARY")"
+              printf '%s\n' "$1" >>"$GITHUB_STEP_SUMMARY"
+            else
+              printf '%s\n' "$1"
+            fi
+          }
+
           api_url="https://api.github.com/repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/auto-merge"
           payload='{"merge_method":"squash"}'
 


### PR DESCRIPTION
## Summary
- define the write_summary helper inside the Dependabot auto-merge step so the script can report outcomes

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d2f28d124c832d9669ea65422ea0a8