### PR TITLE
Ignore default model signature artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ venv/
 .venv/
 default.pkl
 nonexistent
+
+default.pkl.sig


### PR DESCRIPTION
## Summary
- add the default.pkl.sig artifact generated by tests to .gitignore so the working tree remains clean

## Testing
- pytest -q --maxfail=1 --disable-warnings

------
https://chatgpt.com/codex/tasks/task_e_68d2f2ec0f88832da3889260231fd10e