### PR TITLE
Fix release drafter trigger types

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,7 +7,7 @@ on:
   pull_request_target:
     branches:
       - main
-    types: [opened, reopened, synchronize, labeled, unlabeled, edited]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- remove unsupported edited event type from release drafter workflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d2f4aa82e8832dabb57ea388e0b567