### PR TITLE
Use random CSRF secrets in server tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import os
 import importlib.util
 import sys
 import asyncio
+import secrets
 
 import pytest
 
@@ -84,7 +85,7 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 @pytest.fixture
 def csrf_secret(monkeypatch):
-    secret = "testsecret"
+    secret = secrets.token_hex(32)
     monkeypatch.setenv("CSRF_SECRET", secret)
     return secret
 

--- a/tests/test_server_csrf_secret_required.py
+++ b/tests/test_server_csrf_secret_required.py
@@ -1,4 +1,5 @@
 import importlib
+import secrets
 import sys
 
 import pytest
@@ -16,10 +17,11 @@ def test_import_requires_csrf_secret(monkeypatch):
 
 
 def test_calling_resolve_without_secret_raises(monkeypatch):
-    monkeypatch.setenv("CSRF_SECRET", "static-test-secret")
+    secret = secrets.token_hex(32)
+    monkeypatch.setenv("CSRF_SECRET", secret)
     sys.modules.pop("server", None)
     server = importlib.import_module("server")
-    assert server._resolve_csrf_secret() == "static-test-secret"
+    assert server._resolve_csrf_secret() == secret
     monkeypatch.delenv("CSRF_SECRET", raising=False)
     with pytest.raises(RuntimeError, match="CSRF_SECRET environment variable is required"):
         server._resolve_csrf_secret()

--- a/tests/test_server_csrf_unexpected.py
+++ b/tests/test_server_csrf_unexpected.py
@@ -1,4 +1,6 @@
 import os
+import secrets
+
 import pytest
 
 pytest.importorskip("transformers")
@@ -6,7 +8,8 @@ pytest.importorskip("httpx")
 pytest.importorskip("fastapi")
 pytest.importorskip("fastapi_csrf_protect")
 
-os.environ.setdefault("CSRF_SECRET", "testsecret")
+if "CSRF_SECRET" not in os.environ:
+    os.environ["CSRF_SECRET"] = secrets.token_hex(32)
 try:
     import server
 except RuntimeError:

--- a/tests/test_server_missing_api_keys.py
+++ b/tests/test_server_missing_api_keys.py
@@ -1,4 +1,6 @@
+import secrets
 import sys
+
 import pytest
 
 pytest.importorskip("httpx")
@@ -8,7 +10,7 @@ from fastapi.testclient import TestClient
 
 def test_missing_api_keys_causes_startup_failure(monkeypatch):
     monkeypatch.delenv("API_KEYS", raising=False)
-    monkeypatch.setenv("CSRF_SECRET", "testsecret")
+    monkeypatch.setenv("CSRF_SECRET", secrets.token_hex(32))
     sys.modules.pop("server", None)
     import server
     server.API_KEYS.clear()

--- a/tests/test_server_model_loading.py
+++ b/tests/test_server_model_loading.py
@@ -1,9 +1,11 @@
-import sys
-import types
 import asyncio
-import pytest
 import importlib
 import os
+import secrets
+import sys
+import types
+
+import pytest
 
 
 class _FailingLoader:
@@ -23,7 +25,7 @@ def test_load_model_async_raises_runtime_error(monkeypatch):
         torch.cuda = types.SimpleNamespace(is_available=lambda: False)
         m.setitem(sys.modules, "torch", torch)
 
-        os.environ["CSRF_SECRET"] = "testsecret"
+        os.environ["CSRF_SECRET"] = secrets.token_hex(32)
         import server
 
         with pytest.raises(RuntimeError, match="Failed to load both primary and fallback models"):
@@ -77,7 +79,7 @@ def test_load_model_uses_local_cache(monkeypatch):
         torch.cuda = types.SimpleNamespace(is_available=lambda: False)
         m.setitem(sys.modules, "torch", torch)
 
-        os.environ["CSRF_SECRET"] = "testsecret"
+        os.environ["CSRF_SECRET"] = secrets.token_hex(32)
         import server
 
         result = server.model_manager.load_model()

--- a/tests/test_server_request_validation.py
+++ b/tests/test_server_request_validation.py
@@ -1,11 +1,14 @@
 import os
+import secrets
+
 import pytest
 pytest.importorskip("transformers")
 pytest.importorskip("httpx")
 pytest.importorskip("fastapi")
 pytest.importorskip("fastapi_csrf_protect")
 
-os.environ.setdefault("CSRF_SECRET", "testsecret")
+if "CSRF_SECRET" not in os.environ:
+    os.environ["CSRF_SECRET"] = secrets.token_hex(32)
 try:
     import server
 except RuntimeError:

--- a/tests/test_server_revision_validation.py
+++ b/tests/test_server_revision_validation.py
@@ -1,6 +1,8 @@
 import os
+import secrets
 import sys
 import types
+
 import pytest
 
 
@@ -30,7 +32,7 @@ def test_invalid_model_revision(monkeypatch):
         torch.cuda = types.SimpleNamespace(is_available=lambda: False)
         m.setitem(sys.modules, "torch", torch)
 
-        os.environ["CSRF_SECRET"] = "testsecret"
+        os.environ["CSRF_SECRET"] = secrets.token_hex(32)
         os.environ["GPT_MODEL_REVISION"] = "invalid"
 
         import server


### PR DESCRIPTION
## Summary
- replace the CSRF secret fixture with a cryptographically random value
- update server-focused tests to consume the dynamically generated secret instead of a hardcoded string

## Testing
- bandit -r . -ll -ii -x ./tests,./scripts,./gptoss_check
- pytest tests/test_server_csrf_secret_required.py
- pytest tests/test_server_request_validation.py tests/test_server_csrf_unexpected.py tests/test_server_revision_validation.py tests/test_server_missing_api_keys.py tests/test_server_model_loading.py

------
https://chatgpt.com/codex/tasks/task_e_68d2f25d6c04832dab40e71465268f58