### PR TITLE
docs: mark ccxtpro as optional manual dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -950,7 +950,7 @@ The test suite relies on the following packages:
 - pandas
 - torch
 - ccxt
-- ccxtpro
+- ccxtpro (опционально, требуется коммерческая лицензия и ручная установка)
 - pybit
 - python-telegram-bot
 - aiohttp

--- a/requirements-core.in
+++ b/requirements-core.in
@@ -1,7 +1,9 @@
 numpy>=2.2.6  # core numeric library
 pandas>=2.2.2
 ccxt==4.5.5
-ccxtpro>=0.9.0
+# ccxtpro is distributed under a commercial license and cannot be installed
+# automatically in CI. Install it manually in production environments if
+# real-time WebSocket support is required.
 python-telegram-bot>=20.7
 aiohttp>=3.12.15
 websockets>=12.0

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -41,7 +41,7 @@ cachetools==5.5.2
     #   google-auth
 ccxt==4.5.3
     # via -r requirements-core.in
-ccxtpro==1.0.1
+# ccxtpro==1.0.1  # install manually if you have a commercial license
     # via -r requirements-core.in
 certifi==2025.8.3
     # via

--- a/requirements.out
+++ b/requirements.out
@@ -57,7 +57,7 @@ cachetools==5.5.2
     # via -r requirements.txt
 ccxt==4.5.3
     # via -r requirements.txt
-ccxtpro==1.0.1
+# ccxtpro==1.0.1  # install manually if you have a commercial license
     # via -r requirements.txt
 certifi==2025.8.3
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ blinker==1.9.0
     # via flask
 ccxt==4.5.5
     # via -r requirements-core.in
-ccxtpro==1.0.1
+# ccxtpro==1.0.1  # install manually if you have a commercial license
     # via -r requirements-core.in
 certifi==2025.8.3
     # via


### PR DESCRIPTION
## Summary
- comment out ccxtpro entries in the pinned requirements so GitHub's dependency submission workflow no longer tries to install the commercial package
- document in the README that ccxtpro requires a commercial license and manual installation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2f24f9810832dba4b62fceec5b7cb