### PR TITLE
Fix dependency snapshot permissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   security-events: write
 
 jobs:


### PR DESCRIPTION
## Summary
- grant write access to repository contents for the dependency snapshot workflow so submissions succeed

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d2f29876d0832dafe2eddb788c1c51