### PR TITLE
Fix gptoss_check Docker Compose definition

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -164,6 +164,11 @@ services:
         soft: 65536
         hard: 65536
   gptoss_check:
+    image: python:3.12-slim
+    entrypoint:
+      - python
+      - -m
+      - gptoss_check
     working_dir: /workspace
     volumes:
       - .:/workspace


### PR DESCRIPTION
## Summary
- configure the `gptoss_check` service to run with the Python 3.12 slim image and explicit entrypoint so the compose stack can start the check container

## Testing
- pytest
- python -m flake8 --exclude venv .
- python -m mypy --exclude venv .

------
https://chatgpt.com/codex/tasks/task_e_68d2f3064bc8832da1778f9e1012a341