### PR TITLE
Adjust dependency graph workflow permissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
   security-events: write
 
 jobs:


### PR DESCRIPTION
## Summary
- set the dependency graph workflow's contents permission to read so it complies with validation

## Testing
- pytest tests/test_dependency_graph_workflow.py

------
https://chatgpt.com/codex/tasks/task_e_68d301d13f10832d8bd1bd3db52111d1