### PR TITLE
Use stdlib HTTPS client for dependency snapshot submission

### DIFF
--- a/scripts/submit_dependency_snapshot.py
+++ b/scripts/submit_dependency_snapshot.py
@@ -8,7 +8,9 @@ import os
 import re
 import sys
 import time
-import requests
+import http.client
+import socket
+import ssl
 from collections import OrderedDict
 from datetime import datetime, timezone
 from pathlib import Path
@@ -404,18 +406,18 @@ def _normalise_run_attempt(raw_value: str | None) -> int:
 
 def _submit_with_headers(url: str, body: bytes, headers: dict[str, str]) -> None:
     host, port, path = _https_components(url)
-    netloc = host if port == 443 else f"{host}:{port}"
-    target_url = f"https://{netloc}{path}"
     last_error: Exception | None = None
     for attempt in range(1, 4):
+        connection: http.client.HTTPSConnection | None = None
         try:
-            response = requests.post(
-                target_url,
-                data=body,
-                headers=headers,
-                timeout=30,
-            )
-        except requests.Timeout as exc:
+            context = ssl.create_default_context()
+            connection = http.client.HTTPSConnection(host, port, timeout=30, context=context)
+            connection.request("POST", path, body=body, headers=headers)
+            response = connection.getresponse()
+            status_code = int(response.status)
+            reason = response.reason or ""
+            payload = response.read()
+        except (socket.timeout, TimeoutError) as exc:
             message = str(exc) or "timed out"
             if attempt < 3:
                 wait_time = 2 ** (attempt - 1)
@@ -428,8 +430,8 @@ def _submit_with_headers(url: str, body: bytes, headers: dict[str, str]) -> None
                 continue
             last_error = exc
             break
-        except requests.RequestException as exc:
-            message = str(exc) or exc.__class__.__name__
+        except (OSError, http.client.HTTPException) as exc:
+            message = str(exc).strip() or exc.__class__.__name__
             if attempt < 3:
                 wait_time = 2 ** (attempt - 1)
                 print(
@@ -441,37 +443,39 @@ def _submit_with_headers(url: str, body: bytes, headers: dict[str, str]) -> None
                 continue
             last_error = exc
             break
-        else:
-            status_code = int(response.status_code)
-            reason = response.reason or ""
-            payload = response.content
+        finally:
+            if connection is not None:
+                try:
+                    connection.close()
+                except OSError:
+                    pass
 
-            if status_code in _RETRYABLE_STATUS_CODES and attempt < 3:
-                wait_time = 2 ** (attempt - 1)
-                print(
-                    f"Received retryable error HTTP {status_code}. Retrying in {wait_time} s...",
-                    file=sys.stderr,
-                )
-                time.sleep(wait_time)
-                last_error = DependencySubmissionError(
-                    status_code,
-                    f"Retryable HTTP {status_code}: {reason}",
-                )
-                continue
+        if status_code in _RETRYABLE_STATUS_CODES and attempt < 3:
+            wait_time = 2 ** (attempt - 1)
+            print(
+                f"Received retryable error HTTP {status_code}. Retrying in {wait_time} s...",
+                file=sys.stderr,
+            )
+            time.sleep(wait_time)
+            last_error = DependencySubmissionError(
+                status_code,
+                f"Retryable HTTP {status_code}: {reason}",
+            )
+            continue
 
-            if status_code >= 400:
-                message = payload.decode(errors="replace") or reason
-                print(
-                    f"Failed to submit dependency snapshot: HTTP {status_code}: {message}",
-                    file=sys.stderr,
-                )
-                raise DependencySubmissionError(
-                    status_code,
-                    f"GitHub отклонил snapshot зависимостей: HTTP {status_code}: {message}",
-                )
+        if status_code >= 400:
+            message = payload.decode(errors="replace") or reason
+            print(
+                f"Failed to submit dependency snapshot: HTTP {status_code}: {message}",
+                file=sys.stderr,
+            )
+            raise DependencySubmissionError(
+                status_code,
+                f"GitHub отклонил snapshot зависимостей: HTTP {status_code}: {message}",
+            )
 
-            print(f"Dependency snapshot submitted: HTTP {status_code}")
-            return
+        print(f"Dependency snapshot submitted: HTTP {status_code}")
+        return
 
     if last_error is not None:
         message = str(last_error) or last_error.__class__.__name__


### PR DESCRIPTION
## Summary
- replace the dependency snapshot uploader's use of requests with the standard library HTTPS client
- maintain existing retry and error handling logic while avoiding third-party dependencies

## Testing
- python -m compileall scripts/submit_dependency_snapshot.py

------
https://chatgpt.com/codex/tasks/task_e_68d3020479f4832db5258fdbd7d7a2af