### PR TITLE
Fix dependency graph workflow permissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
   security-events: write
 
 jobs:


### PR DESCRIPTION
## Summary
- reduce the permissions granted to the dependency graph workflow to the required minimum

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d301dde198832d9460ae1c0d4acc47