### PR TITLE
Fix dependency graph workflow permissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
   security-events: write
 
 jobs:


### PR DESCRIPTION
## Summary
- limit the dependency graph workflow to read access on repository contents to match policy expectations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d30218be74832d8fa20409dd01ddca