### PR TITLE
Fix dependency workflow permissions and add sklearn fallbacks

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
   security-events: write
 
 jobs:


### PR DESCRIPTION
## Summary
- restrict the dependency graph workflow to read-only contents access as required by the tests
- provide lightweight LogisticRegression and StandardScaler fallbacks when scikit-learn is unavailable in the model builder service

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3023033a0832db24baa14fb5a053f