### PR TITLE
Fix Trivy workflow cache pin

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -31,8 +31,10 @@ jobs:
           TRIVY_CACHE_DIR: ${{ runner.temp }}/trivy-cache
 
       - name: Restore Trivy vulnerability database
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
-        # v4.2.4
+        # GitHub deprecated older cache runner implementations on 2024-12-05.
+        # Pin to the patched v4.2.4 lineage commit to avoid automatic job failures.
+        uses: actions/cache@638ed79f9dc94c1de1baef91bcab5edaa19451f4
+        # main@638ed79f9dc94c1de1baef91bcab5edaa19451f4 (post-v4.2.4)
         with:
           path: ${{ runner.temp }}/trivy-cache
           key: ${{ runner.os }}-trivy-db-${{ hashFiles('requirements*.txt', 'Dockerfile*') }}


### PR DESCRIPTION
## Summary
- update the Trivy workflow to use a non-deprecated actions/cache commit
- document the GitHub deprecation so future updates are easier

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d3023d215c832d810ca2e544eae0f4