### PR TITLE
Fix lint issue in cache tests

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -53,7 +53,6 @@ def test_load_multiindex_timestamps_localized(tmp_path, monkeypatch):
 def test_load_rejects_pickle_cache(tmp_path, monkeypatch, suffix):
     monkeypatch.setattr(psutil, "virtual_memory", _mock_virtual_memory)
     cache = HistoricalDataCache(cache_dir=str(tmp_path), min_free_disk_gb=0)
-    df = pd.DataFrame({"close": [1, 2, 3]})
     old_file = tmp_path / f"BTCUSDT_1m{suffix}"
     legacy_payload = b"legacy pickle data"
     if suffix.endswith(".gz"):


### PR DESCRIPTION
## Summary
- remove the unused DataFrame creation from the pickle cache regression test to keep lint clean

## Testing
- ruff check
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d395d659f4832dbd019a843dc3ba1a