### PR TITLE
Skip redundant .in manifests in dependency snapshot

### DIFF
--- a/scripts/submit_dependency_snapshot.py
+++ b/scripts/submit_dependency_snapshot.py
@@ -53,7 +53,7 @@ def _should_skip_manifest(name: str, available: set[str]) -> bool:
     """Return ``True`` when the manifest is redundant and can be dropped."""
 
     path = Path(name)
-    if path.suffix == ".out":
+    if path.suffix in {".out", ".in"}:
         candidate = path.with_suffix(".txt").as_posix()
         if candidate in available:
             return True

--- a/tests/test_dependency_snapshot.py
+++ b/tests/test_dependency_snapshot.py
@@ -176,3 +176,12 @@ def test_build_manifests_skips_out_files_when_txt_present(tmp_path: Path) -> Non
     manifests = snapshot._build_manifests(tmp_path)
 
     assert set(manifests.keys()) == {"requirements.txt"}
+
+
+def test_build_manifests_skips_in_files_when_txt_present(tmp_path: Path) -> None:
+    (tmp_path / "requirements.txt").write_text("httpx==0.27.2\n")
+    (tmp_path / "requirements.in").write_text("httpx>=0.27.0\n")
+
+    manifests = snapshot._build_manifests(tmp_path)
+
+    assert set(manifests.keys()) == {"requirements.txt"}


### PR DESCRIPTION
## Summary
- avoid submitting requirements input manifests when a compiled .txt file is available
- cover the new behaviour with a dependency snapshot unit test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d395df5f40832d87499470fc600f3c