### PR TITLE
Remove unused dataframe from cache regression test

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -53,7 +53,6 @@ def test_load_multiindex_timestamps_localized(tmp_path, monkeypatch):
 def test_load_rejects_pickle_cache(tmp_path, monkeypatch, suffix):
     monkeypatch.setattr(psutil, "virtual_memory", _mock_virtual_memory)
     cache = HistoricalDataCache(cache_dir=str(tmp_path), min_free_disk_gb=0)
-    df = pd.DataFrame({"close": [1, 2, 3]})
     old_file = tmp_path / f"BTCUSDT_1m{suffix}"
     legacy_payload = b"legacy pickle data"
     if suffix.endswith(".gz"):


### PR DESCRIPTION
## Summary
- remove the unused dataframe created in the pickle-cache regression test to satisfy ruff

## Testing
- python -m ruff check bot tests
- python -m mypy bot --hide-error-context --pretty --no-site-packages
- python -m bandit -r bot -x tests -ll
- python -m flake8 .
- pytest -m "not integration"
- pytest -m integration

------
https://chatgpt.com/codex/tasks/task_e_68d39603b2e0832d99fe6d14ab258921