### PR TITLE
Fix Dependabot workflow expressions

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -14,22 +14,22 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  DEPENDABOT_ACTORS_JSON: '["dependabot[bot]","dependabot-preview[bot]"]'
+
 jobs:
   skip-non-dependabot:
-    if: ${{ github.event_name != 'pull_request_target' || !contains(fromJson('["dependabot[bot]","dependabot-preview[bot]"]'), github.actor) }}
+    if: ${{ !(github.event_name == 'pull_request_target' && contains(fromJson(env.DEPENDABOT_ACTORS_JSON), github.actor)) }}
     runs-on: ubuntu-latest
     steps:
       - name: Report skipped run
         run: |
           write_summary() {
-            local message
-            message=$1
-
             if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
               mkdir -p "$(dirname "$GITHUB_STEP_SUMMARY")"
-              printf '%s\n' "${message}" >>"$GITHUB_STEP_SUMMARY"
+              printf '%s\n' "$1" >>"$GITHUB_STEP_SUMMARY"
             else
-              printf '%s\n' "${message}"
+              printf '%s\n' "$1"
             fi
           }
 
@@ -37,7 +37,7 @@ jobs:
           write_summary "Actor '${{ github.actor }}' on event '${{ github.event_name }}' does not require action."
 
   dependabot:
-    if: ${{ github.event_name == 'pull_request_target' && contains(fromJson('["dependabot[bot]","dependabot-preview[bot]"]'), github.actor) }}
+    if: ${{ github.event_name == 'pull_request_target' && contains(fromJson(env.DEPENDABOT_ACTORS_JSON), github.actor) }}
     runs-on: ubuntu-latest
     steps:
       - name: Dependabot metadata
@@ -218,12 +218,13 @@ jobs:
       - name: Report auto-merge failure
         if: ${{ steps.enable_automerge.outputs.enabled == 'false' }}
         run: |
-          if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-            mkdir -p "$(dirname "$GITHUB_STEP_SUMMARY")"
-            printf '%s\n' \
-              "Auto-merge could not be enabled automatically. Check repository settings or branch protection rules." \
-              >>"$GITHUB_STEP_SUMMARY"
-          else
-            printf '%s\n' \
-              "Auto-merge could not be enabled automatically. Check repository settings or branch protection rules."
-          fi
+          write_summary() {
+            if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+              mkdir -p "$(dirname "$GITHUB_STEP_SUMMARY")"
+              printf '%s\n' "$1" >>"$GITHUB_STEP_SUMMARY"
+            else
+              printf '%s\n' "$1"
+            fi
+          }
+
+          write_summary "Auto-merge could not be enabled automatically. Check repository settings or branch protection rules."


### PR DESCRIPTION
## Summary
- fix the Dependabot actor filter to use the correct `fromJson` helper
- restore robust step-summary helpers while using the shared actor allow list

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d396265534832d9ce03a567c61d958