### PR TITLE
Add regression test for dependency snapshot imports

### DIFF
--- a/tests/test_dependency_snapshot_import.py
+++ b/tests/test_dependency_snapshot_import.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def test_dependency_snapshot_import_succeeds_without_requests(monkeypatch) -> None:
+    """Ensure the dependency snapshot script has no hard dependency on ``requests``."""
+
+    monkeypatch.setitem(sys.modules, "requests", None)
+
+    module_name = "dependency_snapshot_no_requests"
+    spec = importlib.util.spec_from_file_location(
+        module_name, Path("scripts/submit_dependency_snapshot.py")
+    )
+    assert spec is not None and spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(module_name, None)
+
+    assert hasattr(module, "submit_dependency_snapshot")
+    assert callable(module.submit_dependency_snapshot)


### PR DESCRIPTION
## Summary
- add a regression test that imports the dependency snapshot script when the `requests` package is unavailable
- verify the module still exposes the `submit_dependency_snapshot` entry point without optional dependencies

## Testing
- `pytest tests/test_dependency_snapshot_import.py`
- `pytest tests/test_dependency_snapshot.py tests/test_dependency_snapshot_parser.py`


------
https://chatgpt.com/codex/tasks/task_e_68d3962ff3cc832db90d965a2e48c258