### PR TITLE
Pin Trivy CLI version in security scan workflow

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -49,6 +49,8 @@ jobs:
         env:
           TRIVY_CACHE_DIR: ${{ runner.temp }}/trivy-cache
         with:
+          # Pin the Trivy CLI version to avoid unexpected regressions during scheduled runs.
+          version: v0.66.0
           scan-type: fs
           scanners: vuln
           format: sarif


### PR DESCRIPTION
## Summary
- pin the Trivy CLI version used by the security scan workflow to v0.66.0 to prevent upstream regressions

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d3966c1d44832dbc43ee6b1c18c8fd