### PR TITLE
Improve cache symbol validation

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -136,3 +136,18 @@ def test_timeframe_path_traversal_rejected(tmp_path, monkeypatch, caplog):
     caplog.set_level(logging.WARNING)
     loaded = cache.load_cached_data("BTCUSDT", "../etc/passwd")
     assert loaded is None
+
+
+def test_symbol_path_traversal_rejected(tmp_path, monkeypatch, caplog):
+    monkeypatch.setattr(psutil, "virtual_memory", _mock_virtual_memory)
+    cache = HistoricalDataCache(cache_dir=str(tmp_path), min_free_disk_gb=0)
+    df = pd.DataFrame({"close": [1, 2, 3]})
+
+    caplog.set_level(logging.ERROR)
+    cache.save_cached_data("../etc/passwd", "1m", df)
+
+    assert not any(tmp_path.glob("*.parquet"))
+
+    caplog.set_level(logging.WARNING)
+    loaded = cache.load_cached_data("../etc/passwd", "1m")
+    assert loaded is None


### PR DESCRIPTION
## Summary
- harden cache symbol sanitisation to reject empty or path traversal values before writing files
- ensure invalid symbols are ignored when loading cached data and add regression coverage for traversal attempts

## Testing
- `pytest -q --maxfail=1 --disable-warnings`
- `PYENV_VERSION=3.10.17 pytest -q --maxfail=1 --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_68d39661fdbc832d9d2d798ebc0558e0