### PR TITLE
Fix dependabot workflow actor detection

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   skip-non-dependabot:
-    if: ${{ !(github.event_name == 'pull_request_target' && contains(fromJson(env.DEPENDABOT_ACTORS_JSON), github.actor)) }}
+    if: ${{ !(github.event_name == 'pull_request_target' && github.event.pull_request && contains(fromJson(env.DEPENDABOT_ACTORS_JSON), github.event.pull_request.user.login)) }}
     runs-on: ubuntu-latest
     steps:
       - name: Report skipped run
@@ -37,7 +37,7 @@ jobs:
           write_summary "Actor '${{ github.actor }}' on event '${{ github.event_name }}' does not require action."
 
   dependabot:
-    if: ${{ github.event_name == 'pull_request_target' && contains(fromJson(env.DEPENDABOT_ACTORS_JSON), github.actor) }}
+    if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request && contains(fromJson(env.DEPENDABOT_ACTORS_JSON), github.event.pull_request.user.login) }}
     runs-on: ubuntu-latest
     steps:
       - name: Dependabot metadata


### PR DESCRIPTION
## Summary
- ensure the Dependabot workflow checks the pull request author instead of the triggering actor
- allow the job to run correctly when maintainers re-run Dependabot pull_request_target workflows

## Testing
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_e_68d39e7a48c8832d91d40d8b72fe5400