### PR TITLE
Fix Dependabot workflow guard conditions

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   skip-non-dependabot:
-    if: ${{ !(github.event_name == 'pull_request_target' && github.event.pull_request && contains(fromJson(env.DEPENDABOT_ACTORS_JSON), github.event.pull_request.user.login)) }}
+    if: ${{ !(github.event_name == 'pull_request_target' && contains(fromJson(env.DEPENDABOT_ACTORS_JSON), github.actor)) }}
     runs-on: ubuntu-latest
     steps:
       - name: Report skipped run
@@ -37,7 +37,7 @@ jobs:
           write_summary "Actor '${{ github.actor }}' on event '${{ github.event_name }}' does not require action."
 
   dependabot:
-    if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request && contains(fromJson(env.DEPENDABOT_ACTORS_JSON), github.event.pull_request.user.login) }}
+    if: ${{ github.event_name == 'pull_request_target' && contains(fromJson(env.DEPENDABOT_ACTORS_JSON), github.actor) }}
     runs-on: ubuntu-latest
     steps:
       - name: Dependabot metadata


### PR DESCRIPTION
## Summary
- update the Dependabot skip job guard to rely on the actor instead of PR metadata
- adjust the Dependabot job condition to avoid accessing missing pull request fields on non-PR events

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d3a29c33a0832d878b2ffc8d666d82