### PR TITLE
Fix Dockerfile CPU cleanup step

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -71,9 +71,8 @@ PY
 # error". Historical failures:
 # https://github.com/averinaleks/bot/actions/workflows/docker-publish.yml
 
-RUN bash <<'BASH'
-set -euo pipefail
-nvidia_packages="$($VIRTUAL_ENV/bin/pip freeze | grep -i "^nvidia-" || true)"
+RUN bash -euo pipefail -c '
+nvidia_packages="$("$VIRTUAL_ENV"/bin/pip freeze | grep -i "^nvidia-" || true)"
 if [ -n "$nvidia_packages" ]; then
     printf "%s\n" "$nvidia_packages" | cut -d= -f1 | xargs -r "$VIRTUAL_ENV"/bin/pip uninstall -y
 else
@@ -81,7 +80,7 @@ else
 fi
 find "$VIRTUAL_ENV" -type d -name "__pycache__" -exec rm -rf {} +
 find "$VIRTUAL_ENV" -type f -name "*.pyc" -delete
-BASH
+'
 
 FROM ubuntu:24.04
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Summary
- replace the heredoc-based cleanup in `Dockerfile.cpu` with an explicit `bash -c` script to avoid BuildKit parse failures when `docker buildx` runs in CI

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d3ac8deed8832d8b4b1571cab5d3a9