### PR TITLE
Ensure dependency snapshot workflow installs requests

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -179,6 +179,11 @@ jobs:
                       updated = "".join(filtered)
                       path.write_text(updated, encoding="utf-8")
           PY
+      - name: Install dependency snapshot dependencies
+        if: steps.detect.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install requests
       - name: Submit dependency snapshot
         if: steps.detect.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
         env:


### PR DESCRIPTION
## Summary
- install pip and the requests library before submitting dependency snapshots when the workflow runs

## Testing
- python -m compileall scripts/submit_dependency_snapshot.py

------
https://chatgpt.com/codex/tasks/task_e_68d3acbe7dcc832daee013a35153addc