### PR TITLE
Guard GPT-OSS workflow when LLM port missing

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -159,6 +159,11 @@ jobs:
         run: |
           set -euo pipefail
 
+          if [ -z "${LLM_PORT:-}" ]; then
+            echo "::warning::Переменная LLM_PORT не задана – пропускаю ожидание сервера" >&2
+            exit 0
+          fi
+
           output_file="${GITHUB_OUTPUT:-}"
           if [ -n "$output_file" ]; then
             ready_output="false"
@@ -238,6 +243,11 @@ jobs:
         id: llm_review
         run: |
           set -euo pipefail
+
+          if [ -z "${LLM_PORT:-}" ]; then
+            echo "::warning::Переменная LLM_PORT не задана – пропускаю генерацию обзора" >&2
+            exit 0
+          fi
 
           output_file="${GITHUB_OUTPUT:-}"
           if [ -n "$output_file" ]; then


### PR DESCRIPTION
## Summary
- skip waiting for the mock GPT-OSS server when no port is exported
- stop the review step early if the LLM port is unavailable

## Testing
- pytest tests/test_gptoss_workflow_python3.py

------
https://chatgpt.com/codex/tasks/task_e_68d3accb4c74832da77548fe1171d17a