### PR TITLE
Adjust release drafter workflow to skip forks gracefully

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -17,10 +17,14 @@ permissions:
 
 jobs:
   update_release_draft:
-    if: github.event_name != 'pull_request_target' || (github.event.pull_request != null && github.event.pull_request.head != null && github.event.pull_request.head.repo != null && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     steps:
+      - name: Skip update for forked pull requests
+        if: github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
+        run: echo "Skipping release drafter for pull requests from forks."
+
       - name: Update release draft
+        if: github.event_name != 'pull_request_target' || (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository)
         uses: release-drafter/release-drafter@v6.1.0
         with:
           config-name: release-drafter.yml


### PR DESCRIPTION
## Summary
- update the Release Drafter workflow to log and skip runs triggered by pull requests from forks
- keep the release draft step gated so it only executes when the event has permissions to update the draft

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d3acd827b4832d98e9cb7c0d710eca