### PR TITLE
Усиление проверок безопасности при загрузке моделей

### DIFF
--- a/model_builder.py
+++ b/model_builder.py
@@ -974,6 +974,9 @@ class ModelBuilder:
         )
         self.cache_dir = Path(resolved_cache_dir).resolve()
         config["cache_dir"] = str(self.cache_dir)
+        # Ensure security-sensitive helpers restrict deserialisation to the
+        # active cache directory.
+        set_model_dir(self.cache_dir)
         self.state_file_path = (self.cache_dir / "model_builder_state.pkl").resolve(
             strict=False
         )


### PR DESCRIPTION
## Summary
- запретил `safe_joblib_load` следовать симлинкам, принимать не-обычные файлы и пути вне `MODEL_DIR`
- синхронизировал `ModelBuilder` с актуальным каталогом кэша для применения новых ограничений
- расширил тесты безопасности отдельным фикстурным каталогом и проверками отказа для симлинков и внешних путей

## Testing
- `pytest`
- `bandit -r . -ll -ii -x ./tests,./scripts,./gptoss_check`


------
https://chatgpt.com/codex/tasks/task_e_68d3ac82b080832dbae01ed6169ba365