### PR TITLE
Fix CI bootstrap toolchain versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
             requirements*.txt
             pyproject.toml
       - name: Install pip/setuptools/wheel with fixed versions
-        run: python -m pip install "pip==24.0" "setuptools<72" "wheel<0.44"
+        run: python -m pip install "pip==24.0" "setuptools>=78.1.1" "wheel>=0.44"
       - name: Install deps (ci + extras if exist)
         run: |
           set -eux


### PR DESCRIPTION
## Summary
- align the GitHub Actions toolchain setup with the setuptools and wheel versions expected by the CI requirements file to prevent conflicts

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d3acf1ed40832daad10374b240ca54