### PR TITLE
ci: pin trivy cache step to patched actions commit

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -32,9 +32,10 @@ jobs:
 
       - name: Restore Trivy vulnerability database
         # GitHub deprecated older cache runner implementations on 2024-12-05.
-        # Pin to the patched v4.2.4 lineage commit to avoid automatic job failures.
-        uses: actions/cache@638ed79f9dc94c1de1baef91bcab5edaa19451f4
-        # main@638ed79f9dc94c1de1baef91bcab5edaa19451f4 (post-v4.2.4)
+        # Pin directly to the v4.2.4 tag commit to satisfy the new runner
+        # enforcement and avoid automatic job failures.
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
+        # v4.2.4
         with:
           path: ${{ runner.temp }}/trivy-cache
           key: ${{ runner.os }}-trivy-db-${{ hashFiles('requirements*.txt', 'Dockerfile*') }}


### PR DESCRIPTION
## Summary
- pin the Trivy workflow cache restore step to the v4.2.4 tag commit that satisfies the latest GitHub Actions cache enforcement
- refresh the inline documentation to explain the new requirement and prevent automatic job failures

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d3acfcf088832db9f99921e7faf637