### PR TITLE
Mask authorization header values in server logs

### DIFF
--- a/server.py
+++ b/server.py
@@ -73,7 +73,15 @@ logger = logging.getLogger(__name__)
 
 _MASKED_HEADER_VALUE = "***"
 _SENSITIVE_BOUNDARY_RE = re.compile(r"(^|[^a-z0-9])(auth|key|cookie)([^a-z0-9]|$)")
-_SENSITIVE_KEYWORDS = ("token", "secret", "session", "sessionid", "password", "apikey")
+_SENSITIVE_KEYWORDS = (
+    "token",
+    "secret",
+    "session",
+    "sessionid",
+    "password",
+    "apikey",
+    "authorization",
+)
 
 
 def _mask_header_value(name: str, value: Any) -> str:


### PR DESCRIPTION
## Summary
- mask Authorization header values when logging incoming request headers
- ensure authentication failures redact bearer tokens alongside other sensitive headers

## Testing
- pytest -m "not integration"
- pytest -m integration
- python -m ruff check bot tests
- python -m mypy bot
- python -m bandit -r bot -x tests -ll
- python -m flake8 .
- python -m pip_audit --strict -f json -o pip-audit.json

------
https://chatgpt.com/codex/tasks/task_e_68d3ac994d9c832d9c26c31085d4d827