### PR TITLE
Ensure Dependabot workflow skip job always executes

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -16,10 +16,10 @@ permissions:
 
 jobs:
   skip-non-dependabot:
-    if: ${{ !(github.event_name == 'pull_request_target' && (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Report skipped run
+        if: ${{ github.event_name != 'pull_request_target' || (github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]') }}
         run: |
           write_summary() {
             if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then


### PR DESCRIPTION
## Summary
- run the skip helper job on every event and gate its summary step with the Dependabot-specific condition to avoid empty job matrices

## Testing
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_e_68d3ac75af80832d947c558ce2349dc9