### PR TITLE
Fix dependency snapshot import when requests is missing

### DIFF
--- a/scripts/submit_dependency_snapshot.py
+++ b/scripts/submit_dependency_snapshot.py
@@ -15,9 +15,6 @@ from typing import Dict, Iterable, TypedDict
 
 from urllib.parse import quote, urlparse
 
-import requests
-from requests import exceptions as requests_exceptions
-
 MANIFEST_PATTERNS = (
     "requirements*.txt",
     "requirements*.in",
@@ -404,6 +401,15 @@ def _normalise_run_attempt(raw_value: str | None) -> int:
 
 
 def _submit_with_headers(url: str, body: bytes, headers: dict[str, str]) -> None:
+    try:
+        import requests
+        from requests import exceptions as requests_exceptions
+    except ModuleNotFoundError as exc:  # pragma: no cover - exercised via import test
+        raise RuntimeError(
+            "The 'requests' package is required to submit dependency snapshots."
+            " Установите requests, чтобы включить отправку снапшотов."
+        ) from exc
+
     host, port, path = _https_components(url)
     if port == 443:
         request_url = f"https://{host}{path}"


### PR DESCRIPTION
## Summary
- import `requests` lazily inside the dependency snapshot submission helper
- raise a clear runtime error when attempting to submit without the `requests` package installed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3c1203380832d983eb74608b4a30a