### PR TITLE
Harden package bootstrap imports

### DIFF
--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,30 +1,39 @@
 from __future__ import annotations
 
-import importlib
 import os
 import subprocess
 import sys
-from typing import Iterable
+from importlib import import_module
+from types import ModuleType
+from typing import Callable, Mapping, NamedTuple
 
 
-def _ensure_packages(packages: Iterable[tuple[str, str]]) -> None:
+class PackageConfig(NamedTuple):
+    """Configuration describing how to install and import a dependency."""
+
+    requirement: str
+    importer: Callable[[], ModuleType]
+
+
+def _ensure_packages(packages: Mapping[str, PackageConfig]) -> None:
     if os.environ.get("BOT_AUTO_INSTALL_DISABLED") == "1":
         return
 
-    for module_name, requirement in packages:
+    for module_name, config in packages.items():
         try:
-            importlib.import_module(module_name)
+            config.importer()
             continue
         except ModuleNotFoundError:
             pass
 
-        _run_pip_install(requirement)
+        _run_pip_install(config.requirement)
 
         try:
-            importlib.import_module(module_name)
+            config.importer()
         except ModuleNotFoundError as exc:  # pragma: no cover - unexpected
             raise RuntimeError(
-                f"Dependency '{requirement}' was installed but importing '{module_name}' still failed"
+                "Dependency '%s' was installed but importing '%s' still failed"
+                % (config.requirement, module_name)
             ) from exc
 
 
@@ -39,18 +48,56 @@ def _run_pip_install(requirement: str) -> None:
     )
 
 
-_required_packages: list[tuple[str, str]] = [
-    ("numpy", "numpy==2.2.6"),
-    ("pandas", "pandas==2.3.2"),
-    ("pydantic", "pydantic==2.11.9"),
-    ("flask", "flask>=3.0.3,<4"),
-    ("psutil", "psutil>=5.9.0"),
-    ("polars", "polars>=1.6.0"),
-    ("pyarrow", "pyarrow>=15.0.0"),
-    ("joblib", "joblib>=1.3"),
-]
+def _import_numpy() -> ModuleType:
+    return import_module("numpy")
+
+
+def _import_pandas() -> ModuleType:
+    return import_module("pandas")
+
+
+def _import_pydantic() -> ModuleType:
+    return import_module("pydantic")
+
+
+def _import_flask() -> ModuleType:
+    return import_module("flask")
+
+
+def _import_psutil() -> ModuleType:
+    return import_module("psutil")
+
+
+def _import_polars() -> ModuleType:
+    return import_module("polars")
+
+
+def _import_pyarrow() -> ModuleType:
+    return import_module("pyarrow")
+
+
+def _import_joblib() -> ModuleType:
+    return import_module("joblib")
+
+
+def _import_sklearn() -> ModuleType:
+    return import_module("sklearn")
+
+
+_REQUIRED_PACKAGES: dict[str, PackageConfig] = {
+    "numpy": PackageConfig("numpy==2.2.6", _import_numpy),
+    "pandas": PackageConfig("pandas==2.3.2", _import_pandas),
+    "pydantic": PackageConfig("pydantic==2.11.9", _import_pydantic),
+    "flask": PackageConfig("flask>=3.0.3,<4", _import_flask),
+    "psutil": PackageConfig("psutil>=5.9.0", _import_psutil),
+    "polars": PackageConfig("polars>=1.6.0", _import_polars),
+    "pyarrow": PackageConfig("pyarrow>=15.0.0", _import_pyarrow),
+    "joblib": PackageConfig("joblib>=1.3", _import_joblib),
+}
 
 if sys.version_info < (3, 12):
-    _required_packages.append(("scikit-learn", "scikit-learn==1.7.2"))
+    _REQUIRED_PACKAGES["scikit-learn"] = PackageConfig(
+        "scikit-learn==1.7.2", _import_sklearn
+    )
 
-_ensure_packages(_required_packages)
+_ensure_packages(_REQUIRED_PACKAGES)


### PR DESCRIPTION
## Summary
- replace dynamic importlib usage in `sitecustomize.py` with explicit importer helpers
- whitelist the dependencies that can be auto-installed so Semgrep no longer flags dynamic imports

## Testing
- `semgrep --config p/ci --error`
- `semgrep --config auto --error`


------
https://chatgpt.com/codex/tasks/task_e_68d3c1a1a6dc832d9e311ce35f69fe8c