### PR TITLE
Refine release drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -15,16 +15,16 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: release-drafter-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   update_release_draft:
+    if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - name: Skip update for forked pull requests
-        if: github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
-        run: echo "Skipping release drafter for pull requests from forks."
-
       - name: Update release draft
-        if: github.event_name != 'pull_request_target' || (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository)
         uses: release-drafter/release-drafter@v6.1.0
         with:
           config-name: release-drafter.yml


### PR DESCRIPTION
## Summary
- add concurrency control to avoid overlapping Release Drafter runs on the same ref
- gate the Release Drafter job so forked pull requests are skipped without running the action

## Testing
- actionlint .github/workflows/release-drafter.yml

------
https://chatgpt.com/codex/tasks/task_e_68d3c1882bec832db272af7f30aaac89