### PR TITLE
Fix Dependabot workflow actor checks

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -17,9 +17,11 @@ permissions:
 jobs:
   skip-non-dependabot:
     runs-on: ubuntu-latest
+    env:
+      IS_DEPENDABOT: ${{ github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]' }}
     steps:
       - name: Report skipped run
-        if: ${{ github.event_name != 'pull_request_target' || (github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]') }}
+        if: ${{ github.event_name != 'pull_request_target' || env.IS_DEPENDABOT != 'true' }}
         run: |
           write_summary() {
             if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then


### PR DESCRIPTION
## Summary
- avoid string wrapping issues in actor checks by deriving a reusable IS_DEPENDABOT flag
- rely on the flag to skip the workflow gracefully for non-Dependabot events

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d3d0e72434832d93d7c5d1b8aae9ac