### PR TITLE
Fix Dockerfile cleanup script quoting

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -64,23 +64,20 @@ exec(textwrap.dedent("""
 """))
 PY
 
-# NOTE: keep the cleanup below in a dedicated RUN step. When this block was
-# previously implemented via a heredoc and chained to the snippet above, Docker
-# occasionally parsed the first statement ("nvidia_packages=...") as a top-level
-# instruction, breaking the docker-publish workflow with a "dockerfile parse
-# error". Historical failures:
+# NOTE: keep the cleanup below in a dedicated RUN step. The exec form avoids the
+# Dockerfile parser occasionally treating the first line of the script as a
+# separate instruction ("nvidia_packages=...") when heredocs or loose quoting
+# are used, which previously broke the docker-publish workflow with a
+# "dockerfile parse error". Historical failures:
 # https://github.com/averinaleks/bot/actions/workflows/docker-publish.yml
 
-RUN bash -euo pipefail -c '
-nvidia_packages="$("$VIRTUAL_ENV"/bin/pip freeze | grep -i "^nvidia-" || true)"
-if [ -n "$nvidia_packages" ]; then
-    printf "%s\n" "$nvidia_packages" | cut -d= -f1 | xargs -r "$VIRTUAL_ENV"/bin/pip uninstall -y
-else
-    echo "No NVIDIA packages detected in the virtual environment"
-fi
-find "$VIRTUAL_ENV" -type d -name "__pycache__" -exec rm -rf {} +
-find "$VIRTUAL_ENV" -type f -name "*.pyc" -delete
-'
+RUN [
+    "/bin/bash",
+    "-euo",
+    "pipefail",
+    "-c",
+    "nvidia_packages=\"$($VIRTUAL_ENV/bin/pip freeze | grep -i '^nvidia-' || true)\"; if [ -n \"$nvidia_packages\" ]; then printf '%s\\n' \"$nvidia_packages\" | cut -d= -f1 | xargs -r $VIRTUAL_ENV/bin/pip uninstall -y; else echo 'No NVIDIA packages detected in the virtual environment'; fi; find \"$VIRTUAL_ENV\" -type d -name '__pycache__' -exec rm -rf {} +; find \"$VIRTUAL_ENV\" -type f -name '*.pyc' -delete"
+]
 
 FROM ubuntu:24.04
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Summary
- replace the problematic inline shell block in Dockerfile.cpu with the exec-form RUN command to prevent Docker parser errors when building the image
- update the surrounding comment to document the new approach that keeps the cleanup step stable in CI

## Testing
- not run (docker is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d3d0c8f214832dafb3d4869cc121e9