### PR TITLE
Harden HTTP URL handling for CodeQL

### DIFF
--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -4,13 +4,40 @@ import sys
 from typing import Iterable
 
 import logging
+from ipaddress import ip_address
+from urllib.parse import urlparse
+
 import requests  # type: ignore[import-untyped]
 
 
 logger = logging.getLogger(__name__)
 
 
+def _is_local_host(hostname: str | None) -> bool:
+    if not hostname:
+        return False
+    lowered = hostname.lower()
+    if lowered == "localhost":
+        return True
+    try:
+        parsed = ip_address(lowered)
+    except ValueError:
+        return False
+    return parsed.is_loopback or parsed.is_private
+
+
 def check_endpoints(base_url: str, endpoints: Iterable[str]) -> int:
+    parsed = urlparse(base_url)
+    if parsed.scheme not in {"http", "https"}:
+        logger.error("Unsupported base URL scheme: %s", parsed.scheme or "<missing>")
+        return 1
+    if parsed.scheme == "http" and not _is_local_host(parsed.hostname):
+        logger.error(
+            "Refusing to perform insecure HTTP health checks for non-local host %s",
+            parsed.hostname or "<missing>",
+        )
+        return 1
+
     for endpoint in endpoints:
         url = f"{base_url.rstrip('/')}{endpoint}"
         try:


### PR DESCRIPTION
## Summary
- harden the fallback GPT-OSS HTTP client by rejecting non-local plain HTTP URLs
- add base URL validation to the health check script to block insecure remote HTTP targets

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3de268d68832d86489a63ac730d7d