### PR TITLE
Fix release drafter concurrency expression

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,7 +16,10 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: release-drafter-${{ github.event.pull_request.number || github.ref }}
+  group: ${{
+    github.event_name == 'pull_request_target' && format('release-drafter-pr-{0}', github.event.number)
+    || format('release-drafter-ref-{0}', github.ref)
+  }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary
- update the Release Drafter workflow concurrency group to avoid null property access on push events

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3de51c2d4832d8704dc3f5b48d1f0