### PR TITLE
Fix Dockerfile.cpu cleanup RUN command

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -71,13 +71,7 @@ PY
 # "dockerfile parse error". Historical failures:
 # https://github.com/averinaleks/bot/actions/workflows/docker-publish.yml
 
-RUN [
-    "/bin/bash",
-    "-euo",
-    "pipefail",
-    "-c",
-    "nvidia_packages=\"$($VIRTUAL_ENV/bin/pip freeze | grep -i '^nvidia-' || true)\"; if [ -n \"$nvidia_packages\" ]; then printf '%s\\n' \"$nvidia_packages\" | cut -d= -f1 | xargs -r $VIRTUAL_ENV/bin/pip uninstall -y; else echo 'No NVIDIA packages detected in the virtual environment'; fi; find \"$VIRTUAL_ENV\" -type d -name '__pycache__' -exec rm -rf {} +; find \"$VIRTUAL_ENV\" -type f -name '*.pyc' -delete"
-]
+RUN ["/bin/bash", "-euo", "pipefail", "-c", "nvidia_packages=\"$($VIRTUAL_ENV/bin/pip freeze | grep -i '^nvidia-' || true)\"; if [ -n \"$nvidia_packages\" ]; then printf '%s\\n' \"$nvidia_packages\" | cut -d= -f1 | xargs -r $VIRTUAL_ENV/bin/pip uninstall -y; else echo 'No NVIDIA packages detected in the virtual environment'; fi; find \"$VIRTUAL_ENV\" -type d -name '__pycache__' -exec rm -rf {} +; find \"$VIRTUAL_ENV\" -type f -name '*.pyc' -delete"]
 
 FROM ubuntu:24.04
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Summary
- keep the exec-form RUN invocation in `Dockerfile.cpu` on a single line so BuildKit treats it as a valid instruction

## Testing
- not run (docker unavailable in the development environment)


------
https://chatgpt.com/codex/tasks/task_e_68d3de039cfc832daddd56e61fbe6b89