### PR TITLE
Fix mypy failures triggered in CI

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ pytest-cov
 requests-mock
 flask
 hypothesis>=6.90.0
+types-requests
 pytest-asyncio
 iniconfig
 tomli

--- a/scripts/prepare_gptoss_diff.py
+++ b/scripts/prepare_gptoss_diff.py
@@ -152,10 +152,14 @@ def _perform_https_request(
     else:
         path = sanitised.path
 
+    hostname = sanitised.hostname
+    if hostname is None:  # pragma: no cover - guarded by earlier validation
+        raise RuntimeError("Не удалось определить хост GitHub API")
+
     if sanitised.port and sanitised.port != 443:
-        host = f"{sanitised.hostname}:{sanitised.port}"
+        host = f"{hostname}:{sanitised.port}"
     else:
-        host = sanitised.hostname
+        host = hostname
 
     connection = http.client.HTTPSConnection(
         host,

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -6,12 +6,16 @@ import os
 import runpy
 import sys
 from contextlib import contextmanager
-from typing import Iterable, Iterator, Sequence
+from typing import Callable, Iterable, Iterator, Sequence, cast
+
+_PipMain = Callable[[Sequence[str] | None], int]
 
 try:
-    from pip._internal.cli.main import main as _pip_main
+    from pip._internal.cli.main import main as _pip_main_impl
 except Exception:  # pragma: no cover - pip should always be importable, but guard just in case
-    _pip_main = None
+    _pip_main: _PipMain | None = None
+else:
+    _pip_main = cast(_PipMain, _pip_main_impl)
 
 
 def _ensure_packages(packages: Iterable[tuple[str, str]]) -> None:


### PR DESCRIPTION
## Summary
- add the missing types-requests stub to the dev requirements so local mypy matches CI
- guard hostname resolution in the GPT-OSS diff helper to avoid optional-str assignments
- annotate the pip bootstrapper in sitecustomize.py so mypy accepts the callable fallback logic

## Testing
- python -m flake8 --exclude venv .
- python -m mypy --exclude venv .
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d3de1caee8832da8a5493864fb5b53