### PR TITLE
Handle missing requests dependency in snapshot script

### DIFF
--- a/tests/test_dependency_snapshot_import.py
+++ b/tests/test_dependency_snapshot_import.py
@@ -24,3 +24,23 @@ def test_dependency_snapshot_import_succeeds_without_requests(monkeypatch) -> No
 
     assert hasattr(module, "submit_dependency_snapshot")
     assert callable(module.submit_dependency_snapshot)
+
+
+def test_submit_dependency_snapshot_skips_when_requests_missing(monkeypatch, capsys):
+    """The script should report a friendly message when ``requests`` is unavailable."""
+
+    from scripts import submit_dependency_snapshot as snapshot
+
+    monkeypatch.setattr(snapshot, "requests", None, raising=False)
+    monkeypatch.setattr(
+        snapshot,
+        "_REQUESTS_IMPORT_ERROR",
+        ImportError("requests package is not installed"),
+        raising=False,
+    )
+
+    snapshot.submit_dependency_snapshot()
+
+    captured = capsys.readouterr()
+    assert "requests" in captured.err
+    assert "Skipping submission" in captured.err


### PR DESCRIPTION
## Summary
- make the dependency snapshot script gracefully handle environments without the `requests` package by recording the import error, logging a skip message, and exiting early instead of failing
- include the recorded import error as the cause when submission is attempted without `requests`
- add a regression test that verifies the script reports the skip message when `requests` is unavailable

## Testing
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_e_68d3de313e14832d96f345ed003b8cd7