### PR TITLE
Fix dependency graph workflow permissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   contents: read
-  security-events: write
+  dependency-graph: write
 
 jobs:
   submit:


### PR DESCRIPTION
## Summary
- grant the dependency submission workflow the correct dependency graph write permission

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3de3b9248832dacee0dd733fbe310