### PR TITLE
Allow gptoss host for GPT OSS API defaults

### DIFF
--- a/gpt_client.py
+++ b/gpt_client.py
@@ -39,7 +39,13 @@ MAX_RETRIES = 3
 # Marker stored in allowed IP sets when DNS resolution failed in TEST_MODE.
 _TEST_MODE_DNS_FALLBACK = "__test_mode_dns_fallback__"
 # Default hosts that are considered safe targets for GPT OSS API requests.
-_DEFAULT_ALLOWED_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+#
+# ``gptoss`` is the service name used inside docker-compose setups for the
+# GPT-OSS container.  Allowing it here keeps local development and the
+# integration tests (which rely on that hostname) working without requiring
+# additional configuration.  Loopback addresses remain permitted out of the
+# box for single-host deployments.
+_DEFAULT_ALLOWED_HOSTS = frozenset({"127.0.0.1", "localhost", "::1", "gptoss"})
 
 
 def _allow_insecure_url() -> bool:


### PR DESCRIPTION
## Summary
- allow the docker-compose gptoss hostname in the default GPT OSS allowlist so CI and local checks keep working without extra configuration

## Testing
- pytest -q --maxfail=1 --disable-warnings
- pytest tests/test_gpt_client.py tests/test_gptoss_check.py -q
- PYENV_VERSION=3.10.17 pytest tests/test_gptoss_check.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d3de69f240832d8b6e6b622e50b32e