### PR TITLE
Fix Trivy workflow cache permissions

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -139,5 +139,5 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      actions: read
+      actions: write
     steps: *trivy_steps


### PR DESCRIPTION
## Summary
- grant the Trivy pull request job permission to write actions cache data so cache restore succeeds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3de7492a4832d8a9f2b7db9f0869a