### PR TITLE
Fix dependency graph workflow permissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   contents: read
-  dependency-graph: write
+  security-events: write
 
 jobs:
   submit:


### PR DESCRIPTION
## Summary
- grant the dependency graph workflow the GitHub-required `security-events: write` permission
- keep read-only access to repository contents

## Testing
- pytest tests/test_dependency_graph_workflow.py

------
https://chatgpt.com/codex/tasks/task_e_68d3e633f950832dbd3a94b86285d6dc