### PR TITLE
Fix release drafter concurrency expression

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,10 +16,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{
-    github.event_name == 'pull_request_target' && format('release-drafter-pr-{0}', github.event.number)
-    || format('release-drafter-ref-{0}', github.ref)
-  }}
+  group: ${{ github.event_name == 'pull_request_target' && format('release-drafter-pr-{0}', github.event.number) || format('release-drafter-ref-{0}', github.ref) }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary
- simplify the concurrency group expression in the Release Drafter workflow to avoid multi-line expression parsing issues

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d3e63d8228832da487e7780dff3bc2