### PR TITLE
Fix mypy and runtime robustness for CI scripts

### DIFF
--- a/scripts/run_gptoss_review.py
+++ b/scripts/run_gptoss_review.py
@@ -77,16 +77,20 @@ def _perform_http_request(
     """Execute an HTTP(S) request and return status, reason and body."""
 
     parsed = urlparse(url)
+    host = parsed.hostname
+    if host is None:
+        raise RuntimeError("Недопустимый URL без hostname для GPT-OSS API")
+
     if parsed.scheme == "https":
         connection: http.client.HTTPConnection = http.client.HTTPSConnection(
-            parsed.hostname,
+            host,
             parsed.port or 443,
             timeout=timeout,
             context=ssl.create_default_context(),
         )
     else:
         connection = http.client.HTTPConnection(
-            parsed.hostname,
+            host,
             parsed.port or 80,
             timeout=timeout,
         )


### PR DESCRIPTION
## Summary
- ensure the GPT-OSS review helper validates parsed hostnames before opening HTTP connections
- tighten typing in the diff preparation helper to satisfy mypy and guard against missing return codes
- load `pip._internal.cli.main.main` dynamically in `sitecustomize` so the helper keeps working when pip is unavailable

## Testing
- python -m flake8 --exclude venv .
- python -m mypy --exclude venv .
- pytest -ra

------
https://chatgpt.com/codex/tasks/task_e_68d415d18c78832d881b3f6ac5dab872