### PR TITLE
Guard release drafter job condition for non-PR events

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   update_release_draft:
-    if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name != 'pull_request_target' || (github.event.pull_request != null && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     steps:
       - name: Update release draft


### PR DESCRIPTION
## Summary
- guard the release drafter job condition so it doesn't access pull request fields on push/workflow_dispatch events

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d416121028832d804f2af6c6a8d6f5