### PR TITLE
Refine joblib stubs to avoid insecure pickle fallback

### DIFF
--- a/model_builder.py
+++ b/model_builder.py
@@ -39,6 +39,7 @@ from bot.utils import (
 from models.architectures import KERAS_FRAMEWORKS, create_model
 from security import (
     ArtifactDeserializationError,
+    create_joblib_stub,
     harden_mlflow,
     safe_joblib_load,
     set_model_dir,
@@ -261,17 +262,9 @@ except Exception as exc:  # pragma: no cover - stub for tests
         "Не удалось импортировать joblib: %s. Сериализация моделей будет отключена.",
         exc,
     )
-
-    import types
-
-    def _joblib_unavailable(*_args, **_kwargs):  # type: ignore[override]
-        raise RuntimeError(
-            "joblib недоступен: установите зависимость для сохранения/загрузки моделей"
-        )
-
-    joblib = types.ModuleType("joblib")
-    joblib.dump = _joblib_unavailable  # type: ignore[attr-defined]
-    joblib.load = _joblib_unavailable  # type: ignore[attr-defined]
+    joblib = create_joblib_stub(
+        "joblib недоступен: установите зависимость для сохранения/загрузки моделей"
+    )
     sys.modules.setdefault("joblib", joblib)
 
 try:

--- a/security.py
+++ b/security.py
@@ -43,6 +43,7 @@ try:  # joblib is optional in some environments
 except Exception:  # pragma: no cover - joblib not available
     joblib = None  # type: ignore[assignment]
     _joblib_numpy_pickle = None  # type: ignore[assignment]
+    _joblib_numpy_pickle_compat = None  # type: ignore[assignment]
 else:  # pragma: no cover - exercised in integration tests
     try:
         from joblib import numpy_pickle_compat as _joblib_numpy_pickle_compat  # type: ignore
@@ -89,6 +90,18 @@ _DEFAULT_SAFE_JOBLIB_MODULES: Tuple[str, ...] = (
 
 class ArtifactDeserializationError(RuntimeError):
     """Raised when a joblib artefact cannot be safely deserialised."""
+
+
+def create_joblib_stub(message: str) -> ModuleType:
+    """Return a ``joblib``-like module that refuses to serialise artefacts."""
+
+    def _unavailable(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError(message)
+
+    stub = ModuleType("joblib")
+    stub.dump = _unavailable  # type: ignore[attr-defined]
+    stub.load = _unavailable  # type: ignore[attr-defined]
+    return stub
 
 
 def _normalise_allowed_modules(allowed: Iterable[str] | None) -> Tuple[str, ...]:

--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -26,6 +26,7 @@ from bot.utils import ensure_writable_directory
 from services.logging_utils import sanitize_log_value
 from security import (
     ArtifactDeserializationError,
+    create_joblib_stub,
     safe_joblib_load,
     set_model_dir,
     verify_model_state_signature,
@@ -78,17 +79,9 @@ except Exception as exc:  # pragma: no cover - joblib is optional in tests
     LOGGER.warning(
         "Не удалось импортировать joblib: %s. Сохранение моделей отключено.", exc
     )
-
-    import types
-
-    def _joblib_unavailable(*_args, **_kwargs):
-        raise RuntimeError(
-            "joblib недоступен: установите зависимость для работы с артефактами"
-        )
-
-    joblib = types.ModuleType("joblib")
-    joblib.dump = _joblib_unavailable  # type: ignore[attr-defined]
-    joblib.load = _joblib_unavailable  # type: ignore[attr-defined]
+    joblib = create_joblib_stub(
+        "joblib недоступен: установите зависимость для работы с артефактами"
+    )
     sys.modules.setdefault("joblib", joblib)
 
 try:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -15,6 +15,7 @@ from security import (
     _MLFLOW_DISABLED_ATTRS,
     ArtifactDeserializationError,
     apply_ray_security_defaults,
+    create_joblib_stub,
     ensure_minimum_ray_version,
     harden_mlflow,
     safe_joblib_load,
@@ -200,6 +201,16 @@ def test_safe_joblib_load_rejects_symlink(tmp_path: Path) -> None:
         safe_joblib_load(link)
 
     assert "симлинк" in str(exc.value)
+
+
+def test_create_joblib_stub_denies_usage() -> None:
+    stub = create_joblib_stub("joblib unavailable")
+
+    with pytest.raises(RuntimeError, match="joblib unavailable"):
+        stub.dump({}, "ignored")
+
+    with pytest.raises(RuntimeError, match="joblib unavailable"):
+        stub.load("ignored")
 
 
 def test_safe_joblib_load_rejects_path_outside_model_dir(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a reusable helper in `security.py` that produces a safe joblib stub which always raises
- reuse the helper in `model_builder.py` and `services/model_builder_service.py` to keep pickle-based fallbacks out of the codebase
- extend the security test-suite to cover the new stub and guarantee it rejects serialization attempts

## Testing
- `pytest tests/test_security.py::test_create_joblib_stub_denies_usage`
- `bandit -r . -ll -ii -x ./tests,./scripts,./gptoss_check`


------
https://chatgpt.com/codex/tasks/task_e_68d415acac60832d8b20079cec9916e3