### PR TITLE
Add tests guarding dependency graph workflow prerequisites

### DIFF
--- a/tests/test_dependency_graph_workflow.py
+++ b/tests/test_dependency_graph_workflow.py
@@ -53,3 +53,19 @@ def test_dependency_graph_detect_step_handles_nested_manifests() -> None:
     assert "from pathlib import Path" in workflow
     assert "Path(file).name" in workflow
     assert "fnmatch(filename, pattern)" in workflow
+
+
+def test_dependency_graph_installs_requests_before_submission() -> None:
+    workflow = Path(".github/workflows/dependency-graph.yml").read_text(encoding="utf-8")
+
+    assert "Install dependency snapshot dependencies" in workflow
+    assert "python -m pip install --upgrade pip" in workflow
+    assert "python -m pip install requests" in workflow
+
+
+def test_dependency_graph_filters_ccxtpro_lines_before_snapshot() -> None:
+    workflow = Path(".github/workflows/dependency-graph.yml").read_text(encoding="utf-8")
+
+    assert "Prepare requirements" in workflow
+    assert 'if stripped.startswith("ccxtpro")' in workflow
+    assert 'if stripped.startswith("#") and "ccxtpro" in stripped' in workflow


### PR DESCRIPTION
## Summary
- add regression tests ensuring the dependency graph workflow keeps the pip install step
- assert the workflow retains the ccxtpro filtering logic before submitting snapshots

## Testing
- pytest tests/test_dependency_graph_workflow.py

------
https://chatgpt.com/codex/tasks/task_e_68d415fa54d8832da131772dd46365fe