### PR TITLE
Fix dependency snapshot metadata defaults

### DIFF
--- a/scripts/submit_dependency_snapshot.py
+++ b/scripts/submit_dependency_snapshot.py
@@ -608,10 +608,13 @@ def submit_dependency_snapshot() -> None:
     job_metadata = _job_metadata(repository, run_id, correlator)
     job_metadata["correlator"] = f"{correlator}:attempt-{run_attempt}"
 
+    metadata_workflow = os.getenv("DEPENDENCY_SNAPSHOT_WORKFLOW") or "dependency-graph"
+    metadata_job = os.getenv("DEPENDENCY_SNAPSHOT_JOB") or "submit"
+
     metadata = {
         "run_attempt": str(run_attempt),
-        "job": job_name,
-        "workflow": workflow,
+        "job": str(metadata_job),
+        "workflow": str(metadata_workflow),
     }
 
     payload = {


### PR DESCRIPTION
## Summary
- ensure the dependency snapshot uploader always emits string metadata defaults even when GitHub injects workflow/job environment variables
- allow overriding the submitted metadata job and workflow names through DEPENDENCY_SNAPSHOT_JOB/DEPENDENCY_SNAPSHOT_WORKFLOW overrides

## Testing
- TEST_MODE=1 CSRF_SECRET=testsecret PYTHONPYCACHEPREFIX=/mnt/pycache pytest -m "not integration"
- pytest -m integration
- python -m ruff check bot tests
- python -m mypy bot
- python -m bandit -r bot -x tests -ll
- python -m flake8 .
- python -m pip_audit --strict

------
https://chatgpt.com/codex/tasks/task_e_68d415c66384832d9504c78914533e78