### PR TITLE
Fix offline service import path

### DIFF
--- a/run_bot.py
+++ b/run_bot.py
@@ -171,7 +171,7 @@ def _log_mode(command: str, offline: bool) -> None:
 
 
 def _patch_offline_services():
-    from bot.services.offline import OfflineBybit, OfflineTelegram, OfflineGPT
+    from services.offline import OfflineBybit, OfflineTelegram, OfflineGPT
 
     import bot.utils as utils_module
     import bot.telegram_logger as telegram_logger_module


### PR DESCRIPTION
## Summary
- correct the offline stub import in `run_bot.py` to reference the existing `services.offline` module

## Testing
- pytest *(fails: known upstream issues in tests/test_run_gptoss_review.py)*

------
https://chatgpt.com/codex/tasks/task_e_68d41c67a658832da7957b009502ce34