### PR TITLE
fix: bump keras to mitigate CVE-2025-9905

### DIFF
--- a/requirements-gpu.in
+++ b/requirements-gpu.in
@@ -1,5 +1,6 @@
 cupy-cuda12x>=13.5.1
 torch==2.8.0
 tensorflow==2.20.0
+keras>=3.11.3,<3.12
 jsonschema==4.25.1
 setuptools>=78.1.1,<81

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -44,7 +44,7 @@ jsonschema==4.25.1
     # via -r requirements-gpu.in
 jsonschema-specifications==2025.4.1
     # via jsonschema
-keras==3.11.2
+keras==3.11.3
     # via tensorflow
 libclang==18.1.1
     # via tensorflow


### PR DESCRIPTION
## Summary
- add an explicit keras constraint in requirements-gpu.in to ensure patched builds
- update requirements-gpu.txt to pin keras 3.11.3 which resolves CVE-2025-9905

## Testing
- trivy fs --severity HIGH,CRITICAL --ignore-unfixed --scanners vuln .
- trivy fs --severity HIGH,CRITICAL --ignore-unfixed --format table /tmp/trivy_gpu | head


------
https://chatgpt.com/codex/tasks/task_e_68d416361c34832db494f995a423a27e