### PR TITLE
Apply upstream PAM fixes for CVE-2024-10041

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Update linux-libc-dev to a patched revision to close CVE-2025-21946.
 - Replace Ray's commons-lang3 JAR with version 3.18.0 to address vulnerabilities.
 - Explicitly upgrade libpam0g to mitigate CVE-2024-10963.
+- Bundle upstream PAM fixes for CVE-2024-10041 alongside the CVE-2024-10963
+  mitigation.
 - Drop direct Ray and MLflow dependencies from default requirements to satisfy
   Trivy (CVE-2023-48022, CVE-2024-37052…37060) and provide a safe in-process
   Ray stub for local execution.

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,9 @@ ENV TF_CPP_MIN_LOG_LEVEL=3
 
 # Установка необходимых пакетов для сборки и обновление критических библиотек
 # Обновление linux-libc-dev устраняет CVE-2024-50217 и CVE-2025-21976, а libgcrypt20 — CVE-2024-2236.
-# Дополнительно собираем пропатченные пакеты PAM, чтобы закрыть CVE-2024-10963 (HIGH).
+# Дополнительно собираем пропатченные пакеты PAM, чтобы закрыть CVE-2024-10963 и CVE-2024-10041.
 COPY docker/patches/linux-pam-CVE-2024-10963.patch /tmp/security/linux-pam-CVE-2024-10963.patch
+COPY docker/patches/linux-pam-CVE-2024-10041.patch /tmp/security/linux-pam-CVE-2024-10041.patch
 COPY docker/scripts/update_pam_changelog.py /tmp/security/update_pam_changelog.py
 COPY docker/scripts/setup_zlib_and_pam.sh /tmp/security/setup_zlib_and_pam.sh
 
@@ -63,7 +64,7 @@ WORKDIR /tmp/build
 
 RUN rm -rf zlib.tar.gz zlib-src
 
-RUN /tmp/security/build_patched_pam.sh /tmp/security/linux-pam-CVE-2024-10963.patch \
+RUN /tmp/security/build_patched_pam.sh "/tmp/security/linux-pam-CVE-2024-10963.patch /tmp/security/linux-pam-CVE-2024-10041.patch" \
     /tmp/security/update_pam_changelog.py noble /tmp/security/pam-build /tmp/pam-fixed
 
 RUN set -eux; \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -19,10 +19,11 @@ RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recomme
     && dirmngr --version
 
 COPY docker/patches/linux-pam-CVE-2024-10963.patch /tmp/security/linux-pam-CVE-2024-10963.patch
+COPY docker/patches/linux-pam-CVE-2024-10041.patch /tmp/security/linux-pam-CVE-2024-10041.patch
 COPY docker/scripts/update_pam_changelog.py /tmp/security/update_pam_changelog.py
 COPY docker/scripts/build_patched_pam.sh /tmp/security/build_patched_pam.sh
 
-RUN /tmp/security/build_patched_pam.sh /tmp/security/linux-pam-CVE-2024-10963.patch \
+RUN /tmp/security/build_patched_pam.sh "/tmp/security/linux-pam-CVE-2024-10963.patch /tmp/security/linux-pam-CVE-2024-10041.patch" \
     /tmp/security/update_pam_changelog.py noble /tmp/security/pam-build /tmp/pam-fixed
 
 WORKDIR /app

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -24,10 +24,11 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/*
 
 COPY docker/patches/linux-pam-CVE-2024-10963.patch /tmp/security/linux-pam-CVE-2024-10963.patch
+COPY docker/patches/linux-pam-CVE-2024-10041.patch /tmp/security/linux-pam-CVE-2024-10041.patch
 COPY docker/scripts/update_pam_changelog.py /tmp/security/update_pam_changelog.py
 COPY docker/scripts/build_patched_pam.sh /tmp/security/build_patched_pam.sh
 
-RUN /tmp/security/build_patched_pam.sh /tmp/security/linux-pam-CVE-2024-10963.patch \
+RUN /tmp/security/build_patched_pam.sh "/tmp/security/linux-pam-CVE-2024-10963.patch /tmp/security/linux-pam-CVE-2024-10041.patch" \
     /tmp/security/update_pam_changelog.py noble /tmp/security/pam-build /tmp/pam-fixed
 WORKDIR /app
 

--- a/docker/patches/linux-pam-CVE-2024-10041.patch
+++ b/docker/patches/linux-pam-CVE-2024-10041.patch
@@ -1,0 +1,168 @@
+From b3020da7da384d769f27a8713257fbe1001878be Mon Sep 17 00:00:00 2001
+From: "Dmitry V. Levin" <ldv@strace.io>
+Date: Mon, 1 Jan 2024 12:00:00 +0000
+Subject: [PATCH] pam_unix/passverify: always run the helper to obtain shadow
+ password file entries
+
+Initially, when pam_unix.so verified the password, it used to try to
+obtain the shadow password file entry for the given user by invoking
+getspnam(3), and only when that didn't work and the effective uid
+was nonzero, pam_unix.so used to invoke the helper as a fallback.
+
+When SELinux support was introduced by commit
+67aab1ff5515054341a438cf9804e9c9b3a88033, the fallback was extended
+also for the case when SELinux was enabled.
+
+Later, commit f220cace205332a3dc34e7b37a85e7627e097e7d extended the
+fallback conditions for the case when pam_modutil_getspnam() failed
+with EACCES.
+
+Since commit 470823c4aacef5cb3b1180be6ed70846b61a3752, the helper is
+invoked as a fallback when pam_modutil_getspnam() fails for any reason.
+
+The ultimate solution for the case when pam_unix.so does not have
+permissions to obtain the shadow password file entry is to stop trying
+to use pam_modutil_getspnam() and to invoke the helper instead.
+Here are two recent examples.
+
+https://github.com/linux-pam/linux-pam/pull/484 describes a system
+configuration where libnss_systemd is enabled along with libnss_files
+in the shadow entry of nsswitch.conf, so when libnss_files is unable
+to obtain the shadow password file entry for the root user, e.g. when
+SELinux is enabled, NSS falls back to libnss_systemd which returns
+a synthesized shadow password file entry for the root user, which
+in turn locks the root user out.
+
+https://bugzilla.redhat.com/show_bug.cgi?id=2150155 describes
+essentially the same problem in a similar system configuration.
+
+This commit is the final step in the direction of addressing the issue:
+for password verification pam_unix.so now invokes the helper instead of
+making the pam_modutil_getspnam() call.
+
+* modules/pam_unix/passverify.c (get_account_info) [!HELPER_COMPILE]:
+Always return PAM_UNIX_RUN_HELPER instead of trying to obtain
+the shadow password file entry.
+
+Complements: https://github.com/linux-pam/linux-pam/pull/386
+Resolves: https://github.com/linux-pam/linux-pam/pull/484
+Link: https://github.com/authselect/authselect/commit/1e78f7e048747024a846fd22d68afc6993734e92
+---
+ modules/pam_unix/passverify.c | 21 +++++++++++----------
+ 1 file changed, 11 insertions(+), 10 deletions(-)
+
+diff --git a/modules/pam_unix/passverify.c b/modules/pam_unix/passverify.c
+index 2474fa7a..c48e3c5a 100644
+--- a/modules/pam_unix/passverify.c
++++ b/modules/pam_unix/passverify.c
+@@ -238,20 +238,21 @@ PAMH_ARG_DECL(int get_account_info,
+ 			return PAM_UNIX_RUN_HELPER;
+ #endif
+ 		} else if (is_pwd_shadowed(*pwd)) {
++#ifdef HELPER_COMPILE
+ 			/*
+-			 * ...and shadow password file entry for this user,
++			 * shadow password file entry for this user,
+ 			 * if shadowing is enabled
+ 			 */
+-			*spwdent = pam_modutil_getspnam(pamh, name);
+-			if (*spwdent == NULL) {
+-#ifndef HELPER_COMPILE
+-				/* still a chance the user can authenticate */
+-				return PAM_UNIX_RUN_HELPER;
+-#endif
+-				return PAM_AUTHINFO_UNAVAIL;
+-			}
+-			if ((*spwdent)->sp_pwdp == NULL)
++			*spwdent = getspnam(name);
++			if (*spwdent == NULL || (*spwdent)->sp_pwdp == NULL)
+ 				return PAM_AUTHINFO_UNAVAIL;
++#else
++			/*
++			 * The helper has to be invoked to deal with
++			 * the shadow password file entry.
++			 */
++			return PAM_UNIX_RUN_HELPER;
++#endif
+ 		}
+ 	} else {
+ 		return PAM_USER_UNKNOWN;
+-- 
+2.43.0
+
+From b7b96362087414e52524d3d9d9b3faa21e1db620 Mon Sep 17 00:00:00 2001
+From: Tobias Stoeckmann <tobias@stoeckmann.org>
+Date: Wed, 24 Jan 2024 18:57:42 +0100
+Subject: [PATCH] pam_unix: try to set uid to 0 for unix_chkpwd
+
+The geteuid check does not cover all cases. If a program runs with
+elevated capabilities like CAP_SETUID then we can still check
+credentials of other users.
+
+Keep logging for future analysis though.
+
+Resolves: https://github.com/linux-pam/linux-pam/issues/747
+Fixes: b3020da7da38 ("pam_unix/passverify: always run the helper to obtain shadow password file entries")
+
+Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>
+---
+ modules/pam_unix/pam_unix_acct.c | 17 +++++++++--------
+ modules/pam_unix/support.c       | 14 +++++++-------
+ 2 files changed, 16 insertions(+), 15 deletions(-)
+
+diff --git a/modules/pam_unix/pam_unix_acct.c b/modules/pam_unix/pam_unix_acct.c
+index 8f5ed3e0..7ffcb9e3 100644
+--- a/modules/pam_unix/pam_unix_acct.c
++++ b/modules/pam_unix/pam_unix_acct.c
+@@ -110,14 +110,15 @@ int _unix_run_verify_binary(pam_handle_t *pamh, unsigned long long ctrl,
+       _exit(PAM_AUTHINFO_UNAVAIL);
+     }
+ 
+-    if (geteuid() == 0) {
+-      /* must set the real uid to 0 so the helper will not error
+-         out if pam is called from setuid binary (su, sudo...) */
+-      if (setuid(0) == -1) {
+-          pam_syslog(pamh, LOG_ERR, "setuid failed: %m");
+-          printf("-1\n");
+-          fflush(stdout);
+-          _exit(PAM_AUTHINFO_UNAVAIL);
++    /* must set the real uid to 0 so the helper will not error
++       out if pam is called from setuid binary (su, sudo...) */
++    if (setuid(0) == -1) {
++      uid_t euid = geteuid();
++      pam_syslog(pamh, euid == 0 ? LOG_ERR : LOG_DEBUG, "setuid failed: %m");
++      if (euid == 0) {
++	printf("-1\n");
++	fflush(stdout);
++	_exit(PAM_AUTHINFO_UNAVAIL);
+       }
+     }
+ 
+diff --git a/modules/pam_unix/support.c b/modules/pam_unix/support.c
+index d391973f..69811048 100644
+--- a/modules/pam_unix/support.c
++++ b/modules/pam_unix/support.c
+@@ -562,13 +562,13 @@ static int _unix_run_helper_binary(pam_handle_t *pamh, const char *passwd,
+ 		_exit(PAM_AUTHINFO_UNAVAIL);
+ 	}
+ 
+-	if (geteuid() == 0) {
+-          /* must set the real uid to 0 so the helper will not error
+-	     out if pam is called from setuid binary (su, sudo...) */
+-	  if (setuid(0) == -1) {
+-             D(("setuid failed"));
+-	     _exit(PAM_AUTHINFO_UNAVAIL);
+-          }
++	/* must set the real uid to 0 so the helper will not error
++	   out if pam is called from setuid binary (su, sudo...) */
++	if (setuid(0) == -1) {
++	   D(("setuid failed"));
++	   if (geteuid() == 0) {
++	      _exit(PAM_AUTHINFO_UNAVAIL);
++	   }
+ 	}
+ 
+ 	/* exec binary helper */
+-- 
+2.43.0
+

--- a/docker/scripts/build_patched_pam.sh
+++ b/docker/scripts/build_patched_pam.sh
@@ -1,11 +1,66 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PATCH_PATH="${1:-/tmp/security/linux-pam-CVE-2024-10963.patch}"
+PATCH_SPECS="${1:-/tmp/security/linux-pam-CVE-2024-10963.patch}"
 CHANGELOG_HELPER="${2:-/tmp/security/update_pam_changelog.py}"
 DIST_CODENAME="${3:-noble}"
 BUILD_ROOT="${4:-/tmp/security/pam-build}"
 OUTPUT_DIR="${5:-/tmp/pam-fixed}"
+
+read -r -a PATCH_PATHS <<<"${PATCH_SPECS}"
+
+determine_sentinels() {
+  local patch_name
+  patch_name=$(basename "$1")
+  case "${patch_name}" in
+    linux-pam-CVE-2024-10963.patch)
+      printf '%s\n' \
+        'modules/pam_access/pam_access.c:nodns'
+      ;;
+    linux-pam-CVE-2024-10041.patch)
+      printf '%s\n' \
+        'modules/pam_unix/passverify.c:The helper has to be invoked to deal with' \
+        'modules/pam_unix/pam_unix_acct.c:pam_syslog(pamh, euid == 0 ? LOG_ERR : LOG_DEBUG)'
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+apply_patch_or_skip() {
+  local patch_file="$1"
+  local -a sentinels
+
+  mapfile -t sentinels < <(determine_sentinels "${patch_file}" || true)
+
+  if patch -p1 --forward <"${patch_file}"; then
+    return 0
+  fi
+
+  if [[ ${#sentinels[@]} -eq 0 ]]; then
+    echo "Не удалось применить патч ${patch_file}" >&2
+    return 1
+  fi
+
+  local all_present=1
+  for entry in "${sentinels[@]}"; do
+    local target=${entry%%:*}
+    local marker=${entry#*:}
+    if [[ ! -f "${target}" ]] || ! grep -Fq "${marker}" "${target}"; then
+      all_present=0
+      break
+    fi
+  done
+
+  if [[ ${all_present} -eq 1 ]]; then
+    echo "Патч ${patch_file} уже присутствует, пропускаем." >&2
+    return 0
+  fi
+
+  echo "Не удалось применить патч ${patch_file}" >&2
+  return 1
+}
 
 mkdir -p "${BUILD_ROOT}"
 cd "${BUILD_ROOT}"
@@ -32,7 +87,14 @@ rm -rf pam-src
 mv "${pam_src_dir}" pam-src
 
 pushd pam-src >/dev/null
-patch -p1 < "${PATCH_PATH}"
+for patch_file in "${PATCH_PATHS[@]}"; do
+  [[ -z "${patch_file}" ]] && continue
+  if [[ ! -f "${patch_file}" ]]; then
+    echo "Файл патча ${patch_file} не найден" >&2
+    exit 1
+  fi
+  apply_patch_or_skip "${patch_file}"
+done
 python3 "${CHANGELOG_HELPER}"
 export DEB_BUILD_OPTIONS=nocheck
 dpkg-buildpackage -b -uc -us

--- a/docker/scripts/update_pam_changelog.py
+++ b/docker/scripts/update_pam_changelog.py
@@ -11,8 +11,10 @@ from pathlib import Path
 
 CHANGELOG_PATH = Path("debian/changelog")
 ENTRY_TEMPLATE = (
-    "pam (1.5.3-5ubuntu5.4+bot1) noble; urgency=medium\n\n"
-    "  * Apply upstream fix 940747f to address CVE-2024-10963 in pam_access.\n\n"
+    "pam (1.5.3-5ubuntu5.5+bot1) noble; urgency=medium\n\n"
+    "  * Pull in upstream commits b3020da7 and b7b96362 to harden pam_unix\n"
+    "    against CVE-2024-10041 and retain the pam_access nodns fix for\n"
+    "    CVE-2024-10963.\n\n"
     " -- Security Bot <security@example.com>  {timestamp}\n\n"
 )
 


### PR DESCRIPTION
## Summary
- add upstream PAM patches for CVE-2024-10041 alongside the existing CVE-2024-10963 mitigation
- extend the PAM rebuild helper to accept multiple patch files and skip already-applied fixes via sentinels
- refresh changelog metadata and Dockerfiles to bundle the new patch set

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d41b3358f0832da1dc07c6c66cc7da