### PR TITLE
Improve Release Drafter workflow robustness

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,17 +16,33 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.event_name == 'pull_request_target' && format('release-drafter-pr-{0}', github.event.number) || format('release-drafter-ref-{0}', github.ref) }}
+  group: ${{ github.event_name == 'pull_request_target' && github.event.pull_request != null && github.event.number && format('release-drafter-pr-{0}', github.event.number) || format('release-drafter-ref-{0}', github.ref) }}
   cancel-in-progress: false
 
 jobs:
   update_release_draft:
-    if: github.event_name != 'pull_request_target' || (github.event.pull_request != null && github.event.pull_request.head.repo.full_name == github.repository)
+    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - name: Update release draft
         uses: release-drafter/release-drafter@v6.1.0
         with:
           config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  autolabel_pull_request:
+    if: |
+      github.event_name == 'pull_request_target'
+      && github.event.pull_request != null
+      && github.event.pull_request.head.repo != null
+      && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update pull request metadata
+        uses: release-drafter/release-drafter@v6.1.0
+        with:
+          config-name: release-drafter.yml
+          disable-releases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- tighten the concurrency group guard so pull request runs only compute PR-specific identifiers when available
- split the workflow into dedicated jobs for push/workflow dispatch and pull_request_target events
- disable release updates on pull_request_target executions while still running the autolabeler safely for in-repo branches

## Testing
- /root/.local/share/mise/installs/go/1.24.3/bin/actionlint -oneline .github/workflows/release-drafter.yml

------
https://chatgpt.com/codex/tasks/task_e_68d428575b28832d85d18553e01243f3