### PR TITLE
Configure CodeQL to ignore repository metadata

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,6 +35,7 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
+          config-file: ./codeql-config.yml
 
       - name: Install dependencies
         run: |

--- a/codeql-config.yml
+++ b/codeql-config.yml
@@ -1,0 +1,3 @@
+name: bot-codeql-config
+paths-ignore:
+  - .git/**


### PR DESCRIPTION
## Summary
- configure the CodeQL workflow to load a repository-level configuration
- add a CodeQL configuration file that excludes the .git directory from analysis so commit logs with .py suffixes are ignored

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d42b2fcb20832d821d82eed35e3a45