### PR TITLE
Handle push events for GPT-OSS review workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -8,6 +8,11 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   issue_comment:
     types: [created]
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/gptoss_review.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- allow the GPT-OSS review workflow to run on pushes to main that modify the workflow file so GitHub's safety runs succeed

## Testing
- pytest tests/test_gptoss_workflow_python3.py

------
https://chatgpt.com/codex/tasks/task_e_68d428113920832da9f77ad84d5ccdf0