### PR TITLE
Prevent CodeQL from parsing git logs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,6 +26,9 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
+      - name: Remove git logs to avoid CodeQL parsing artifacts
+        run: rm -rf .git/logs
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
- remove git logs after checkout so CodeQL will not scan remote branch history files

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d42f298a10832d85762ede3507d697