### PR TITLE
Run CodeQL after pruning git logs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,6 +40,9 @@ jobs:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
 
+      - name: Remove git logs after CodeQL init
+        run: rm -rf .git/logs
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- rerun the git log cleanup step after CodeQL initialization so remotes recreated during init do not confuse the analyzer

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4330cfa2c832dafb12ff6bf384cb7