### PR TITLE
Fix concurrency evaluation for GPT-OSS review workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -22,8 +22,8 @@ permissions:
 concurrency:
   group: >-
     gptoss-review-${{ github.workflow }}-${{
-      (github.event.pull_request && github.event.pull_request.number)
-        || (github.event.issue && github.event.issue.number)
+      (github.event_name == 'pull_request_target' && github.event.pull_request.number)
+        || (github.event_name == 'issue_comment' && github.event.issue.number)
         || github.run_id
     }}
   cancel-in-progress: true
@@ -58,8 +58,8 @@ jobs:
         shell: bash
     env:
       PR_NUMBER: ${{
-        (github.event.pull_request && github.event.pull_request.number)
-          || (github.event.issue && github.event.issue.number)
+        (github.event_name == 'pull_request_target' && github.event.pull_request.number)
+          || (github.event_name == 'issue_comment' && github.event.issue.number)
           || ''
       }}
       MODEL_NAME: ${{ vars.LLM_MODEL || 'Qwen/Qwen2.5-Coder-0.5B-Instruct' }}


### PR DESCRIPTION
## Summary
- guard the GPT-OSS review workflow's concurrency group and PR_NUMBER logic so push events no longer reference missing issue fields

## Testing
- python -m pytest tests/test_gptoss_workflow_python3.py

------
https://chatgpt.com/codex/tasks/task_e_68d441856bd0832d922ac459f37218c9