### PR TITLE
Fix GPT-OSS review concurrency expression

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -22,8 +22,8 @@ permissions:
 concurrency:
   group: >-
     gptoss-review-${{ github.workflow }}-${{
-      (github.event_name == 'pull_request_target' && github.event.pull_request.number)
-        || (github.event_name == 'issue_comment' && github.event.issue.number)
+      (github.event.pull_request && github.event.pull_request.number)
+        || (github.event.issue && github.event.issue.number)
         || github.run_id
     }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- guard the GPT-OSS review workflow concurrency key against events without pull_request or issue payloads to prevent evaluation failures

## Testing
- pytest tests/test_gptoss_workflow_python3.py

------
https://chatgpt.com/codex/tasks/task_e_68d44b54fefc832d82cfafbb63ab39b4