### PR TITLE
Handle already applied PAM patches in docker build script

### DIFF
--- a/docker/scripts/build_patched_pam.sh
+++ b/docker/scripts/build_patched_pam.sh
@@ -38,6 +38,11 @@ apply_patch_or_skip() {
     return 0
   fi
 
+  if patch -p1 --reverse --dry-run <"${patch_file}"; then
+    echo "Патч ${patch_file} уже применён (обратное применение прошло успешно), пропускаем." >&2
+    return 0
+  fi
+
   if [[ ${#sentinels[@]} -eq 0 ]]; then
     echo "Не удалось применить патч ${patch_file}" >&2
     return 1


### PR DESCRIPTION
## Summary
- allow docker/scripts/build_patched_pam.sh to detect already applied Linux-PAM patches using a reverse dry-run
- keep fallback sentinel check to skip patches safely when upstream already includes the fixes

## Testing
- bash -n docker/scripts/build_patched_pam.sh

------
https://chatgpt.com/codex/tasks/task_e_68d44b6ff244832da347b5dea0e40534