### PR TITLE
Improve CodeQL ignore rules for git logs

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,3 +1,5 @@
 name: bot CodeQL configuration
 paths-ignore:
   - .git/**
+  - '**/.git/**'
+  - '**/.git'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           persist-credentials: false
-          fetch-depth: 0
+          fetch-depth: 2
 
       - name: Remove git logs to avoid CodeQL parsing artifacts
         run: rm -rf .git/logs


### PR DESCRIPTION
## Summary
- expand the CodeQL configuration to ignore any `.git` directory contents regardless of location
- reduce the checkout fetch depth so remote tracking branches ending in `.py` no longer create log files that confuse CodeQL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d44ecb4c84832d818d20400d562a53