### PR TITLE
Fix release drafter concurrency expression

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,7 +16,12 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.event_name == 'pull_request_target' && github.event.pull_request != null && github.event.number && format('release-drafter-pr-{0}', github.event.number) || format('release-drafter-ref-{0}', github.ref) }}
+  group: ${{ (
+    github.event_name == 'pull_request_target'
+    && github.event.pull_request != null
+    && github.event.pull_request.number != null
+    && format('release-drafter-pr-{0}', github.event.pull_request.number)
+  ) || format('release-drafter-ref-{0}', github.ref) }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary
- ensure the concurrency group expression stays on a single evaluated expression
- guard against missing pull request payload by checking pull_request.number before formatting the group key

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d44ef2ba58832db96ed18ac2777ef1