### PR TITLE
Improve CodeQL workflow filtering of git metadata

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -3,3 +3,4 @@ paths-ignore:
   - .git/**
   - '**/.git/**'
   - '**/.git'
+  - '**/.git/refs/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,8 +26,10 @@ jobs:
           persist-credentials: false
           fetch-depth: 2
 
-      - name: Remove git logs to avoid CodeQL parsing artifacts
-        run: rm -rf .git/logs
+      - name: Remove git metadata that can confuse CodeQL
+        run: |
+          rm -rf .git/logs
+          rm -rf .git/refs/remotes
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -40,8 +42,10 @@ jobs:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
 
-      - name: Remove git logs after CodeQL init
-        run: rm -rf .git/logs
+      - name: Remove git metadata after CodeQL init
+        run: |
+          rm -rf .git/logs
+          rm -rf .git/refs/remotes
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- remove Git metadata directories that include Python-like file names before and after CodeQL initialization
- extend the CodeQL configuration to explicitly ignore Git ref metadata files

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d450a8c5f4832d9ca8f4f166e32ca7