### PR TITLE
Fix release drafter concurrency string quoting

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,12 +16,12 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ (
+  group: "${{ (
     github.event_name == 'pull_request_target'
     && github.event.pull_request != null
     && github.event.pull_request.number != null
     && format('release-drafter-pr-{0}', github.event.pull_request.number)
-  ) || format('release-drafter-ref-{0}', github.ref) }}
+  ) || format('release-drafter-ref-{0}', github.ref) }}"
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary
- quote the concurrency group expression so YAML parsing succeeds during workflow loading

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d45124196c832daa014f5026b557a8