### PR TITLE
Disable git reflog creation during CodeQL runs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,6 +26,9 @@ jobs:
           persist-credentials: false
           fetch-depth: 2
 
+      - name: Disable git reference logs
+        run: git config --global core.logallrefupdates false
+
       - name: Remove git metadata that can confuse CodeQL
         run: |
           rm -rf .git/logs


### PR DESCRIPTION
## Summary
- prevent git from recreating reference logs during the CodeQL workflow so that CodeQL no longer attempts to parse reflog entries as Python files

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d453076324832db20cafd53fb133a4