### PR TITLE
Fix CodeQL workflow removing remote refs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Remove git metadata that can confuse CodeQL
         run: |
           rm -rf .git/logs
-          rm -rf .git/refs/remotes
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -48,7 +47,6 @@ jobs:
       - name: Remove git metadata after CodeQL init
         run: |
           rm -rf .git/logs
-          rm -rf .git/refs/remotes
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- stop deleting `.git/refs/remotes` in the CodeQL workflow so the action can read remote refs
- keep the log cleanup step before and after CodeQL initialization

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d459e93284832da1f57b0f5d59b627