### PR TITLE
Prevent CodeQL from parsing git logs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,14 +20,14 @@ jobs:
       matrix:
         language: [ 'python' ]
     steps:
+      - name: Disable git reference logs
+        run: git config --global core.logallrefupdates false
+
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
           persist-credentials: false
           fetch-depth: 2
-
-      - name: Disable git reference logs
-        run: git config --global core.logallrefupdates false
 
       - name: Remove git metadata that can confuse CodeQL
         run: |
@@ -54,6 +54,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements-ci.txt
+
+      - name: Remove git metadata before analysis
+        run: rm -rf .git
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary
- disable git reference logging before checking out the repository in the CodeQL workflow
- delete the git metadata directory right before running the analyzer to avoid scanning leftover log files

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d45ac01ec0832dad4d87d3721d159f