### PR TITLE
Fix concurrency expression in GPT-OSS workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -20,12 +20,17 @@ permissions:
   issues: write
 
 concurrency:
-  group: >-
-    gptoss-review-${{ github.workflow }}-${{
-      (github.event.pull_request && github.event.pull_request.number)
-        || (github.event.issue && github.event.issue.number)
-        || github.run_id
-    }}
+  group: ${{
+    format(
+      'gptoss-review-{0}-{1}',
+      github.workflow,
+      github.event_name == 'pull_request_target'
+        ? github.event.pull_request.number
+        : github.event_name == 'issue_comment'
+          ? github.event.issue.number
+          : github.run_id
+    )
+  }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- replace the GPT-OSS review workflow concurrency group expression with a format()-based ternary chain
- ensure we never dereference pull_request or issue payloads on push events so the workflow can run for pushes without errors

## Testing
- pytest tests/test_gptoss_workflow_python3.py

------
https://chatgpt.com/codex/tasks/task_e_68d45acb1240832d960a11cab4fc119a