### PR TITLE
Fix push handling in GPT-OSS workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -35,7 +35,7 @@ concurrency:
 
 jobs:
   skip:
-    if: ${{ github.event_name != 'pull_request_target' && github.event_name != 'issue_comment' }}
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     steps:
       - name: Skip unsupported event


### PR DESCRIPTION
## Summary
- ensure the skip job only runs on push events so workflow runs succeed when triggered by pushes to main

## Testing
- pytest tests/test_gptoss_workflow_python3.py

------
https://chatgpt.com/codex/tasks/task_e_68d4e101c1f8832d959654bcef2b7ec3