### PR TITLE
Prevent CodeQL from parsing git log branches

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -4,3 +4,4 @@ paths-ignore:
   - '**/.git/**'
   - '**/.git'
   - '**/.git/refs/**'
+  - '**/.git/logs/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Remove git metadata that can confuse CodeQL
         run: |
           rm -rf .git/logs
+          find .git -type f -name '*.py' -delete || true
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -47,6 +48,7 @@ jobs:
       - name: Remove git metadata after CodeQL init
         run: |
           rm -rf .git/logs
+          find .git -type f -name '*.py' -delete || true
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- ensure git log files with `.py` suffix are removed before CodeQL initializes
- expand CodeQL ignore list to cover `.git/logs` paths

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68d4e3387094832d9f833bd80bac10f1