### PR TITLE
Ensure patch tool is available during Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN set -eux; \
         tzdata \
         linux-libc-dev \
         build-essential \
+        patch \
         ca-certificates \
         wget \
         curl \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -9,7 +9,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Обновление linux-libc-dev устраняет CVE-2025-21976, а libgcrypt20 — CVE-2024-2236.
 # Дополнительно выполняем upgrade, чтобы подтянуть свежие патчи безопасности из Ubuntu.
 RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y \
-    python3 python3-venv build-essential linux-libc-dev libgcrypt20 git \
+    python3 python3-venv build-essential linux-libc-dev libgcrypt20 git patch \
     && apt-get install -y --no-install-recommends gnupg dirmngr \
     && python3 -m venv /venv \
     && apt-get purge -y --auto-remove build-essential \

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -12,7 +12,7 @@ RUN set -eux; \
         linux-libc-dev \
         libssl3t64 \
         python3.12-minimal \
-        build-essential \
+        build-essential patch \
         curl \
         python3 python3-venv python3-dev python3-pip \
         zlib1g-dev; \


### PR DESCRIPTION
## Summary
- add the `patch` package to every Docker builder stage that applies PAM security patches so the workflow can apply patches reliably

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4eb07ea4c832d9ea7128565f5e95b