### PR TITLE
Fix mypy typing for HTTP connection selection

### DIFF
--- a/scripts/run_gptoss_review.py
+++ b/scripts/run_gptoss_review.py
@@ -151,6 +151,7 @@ def _perform_http_request(
     allowed_hosts = _load_allowed_hosts() if parsed.scheme == "https" else set()
 
     connection_kwargs: dict[str, object] = {"timeout": timeout}
+    connection_cls: type[http.client.HTTPConnection] | type[http.client.HTTPSConnection]
     if parsed.scheme == "https":
         if allowed_hosts and hostname not in allowed_hosts:
             if not _host_ips_are_private(resolved_ips):


### PR DESCRIPTION
## Summary
- annotate the GPT-OSS review helper to declare the HTTP(S) connection class type before branching

## Testing
- python -m flake8 --exclude venv .
- python -m mypy --exclude venv .
- python -m pytest


------
https://chatgpt.com/codex/tasks/task_e_68d4eb32d824832dac67165e78ef7f78