### PR TITLE
Ensure CodeQL ignores git metadata

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,8 +31,7 @@ jobs:
 
       - name: Remove git metadata that can confuse CodeQL
         run: |
-          rm -rf .git/logs
-          find .git -type f -name '*.py' -delete || true
+          rm -rf .git
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -47,8 +46,7 @@ jobs:
 
       - name: Remove git metadata after CodeQL init
         run: |
-          rm -rf .git/logs
-          find .git -type f -name '*.py' -delete || true
+          rm -rf .git
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- delete the entire .git directory before and after CodeQL initialization to guarantee no git log files remain

## Testing
- python -m py_compile $(git ls-files '*.py')

------
https://chatgpt.com/codex/tasks/task_e_68d4ee9aed2c832d9174f0049f47e5a9