### PR TITLE
Expand CodeQL ignore patterns for git metadata

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,7 +1,17 @@
 name: bot CodeQL configuration
 paths-ignore:
+  # Ensure Git metadata created during checkout (including reference logs) is never
+  # analysed by CodeQL. CodeQL interprets any *.py file it discovers as Python
+  # source, so logs for remote refs with names that end in ".py" must be
+  # excluded explicitly. We therefore ignore every possible .git directory or
+  # file pattern, regardless of depth or naming, to avoid future false parse
+  # errors when CodeQL walks the workspace.
   - .git/**
-  - '**/.git/**'
+  - '.git'
+  - '.git*'
   - '**/.git'
+  - '**/.git/**'
+  - '**/.git*'
+  - '**/.git*/**'
   - '**/.git/refs/**'
   - '**/.git/logs/**'


### PR DESCRIPTION
## Summary
- expand the CodeQL configuration ignore list to cover every variation of .git metadata
- document why ignoring .git logs prevents CodeQL from attempting to parse remote ref logs ending in .py

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d4f1c42634832dac3ad0e0350e0ce1