### PR TITLE
Harden CodeQL workflow git cleanup

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,7 +54,17 @@ jobs:
           python -m pip install -r requirements-ci.txt
 
       - name: Remove git metadata before analysis
-        run: rm -rf .git
+        run: |
+          rm -rf .git
+          # Guard against any git metadata recreated by tooling between steps.
+          # Some package installers and third-party actions may vendor
+          # repositories that include their own .git directories. They can
+          # contain files with misleading extensions (for example ref logs that
+          # end in ".py"), which causes CodeQL to treat them as Python source
+          # files and emit parse warnings. Removing all nested .git directories
+          # immediately before analysis ensures the extractor never sees these
+          # files.
+          find "$PWD" -name '.git' -type d -prune -exec rm -rf '{}' +
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary
- harden the CodeQL workflow to recursively delete any leftover .git directories before analysis so CodeQL cannot misinterpret git ref logs as Python files

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4f7db9f48832da1b4e33e9812f631