### PR TITLE
Harden CodeQL workflow cleanup of git metadata

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,10 @@ jobs:
 
       - name: Remove git metadata that can confuse CodeQL
         run: |
-          rm -rf .git
+          if [ -d .git ]; then
+            chmod -R u+w .git || true
+            rm -rf .git || true
+          fi
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -46,7 +49,10 @@ jobs:
 
       - name: Remove git metadata after CodeQL init
         run: |
-          rm -rf .git
+          if [ -d .git ]; then
+            chmod -R u+w .git || true
+            rm -rf .git || true
+          fi
 
       - name: Install dependencies
         run: |
@@ -55,7 +61,10 @@ jobs:
 
       - name: Remove git metadata before analysis
         run: |
-          rm -rf .git
+          if [ -d .git ]; then
+            chmod -R u+w .git || true
+            rm -rf .git || true
+          fi
           # Guard against any git metadata recreated by tooling between steps.
           # Some package installers and third-party actions may vendor
           # repositories that include their own .git directories. They can
@@ -64,7 +73,13 @@ jobs:
           # files and emit parse warnings. Removing all nested .git directories
           # immediately before analysis ensures the extractor never sees these
           # files.
-          find "$PWD" -name '.git' -type d -prune -exec rm -rf '{}' +
+          find "$PWD" -name '.git' -type d -print0 | while IFS= read -r -d '' dir; do
+            chmod -R u+w "$dir" || true
+            rm -rf "$dir" || true
+          done
+          # As a final safeguard, proactively delete any reflog files that may
+          # have been recreated with misleading Python extensions.
+          find "$PWD" -path '*/.git/logs/*' -type f -name '*.py' -delete || true
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary
- ensure every git metadata cleanup step grants write access before removal
- recursively delete nested .git directories using a robust find loop
- add a final guard that drops any reflog entries misidentified as Python files

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d4fc43d3a4832da47f04f5a74417ca