### PR TITLE
Fix PR status check in GPT-OSS workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -157,7 +157,15 @@ jobs:
             exit 0
           fi
 
-          printf '%s\n' "$response" | python3 - <<'PY'
+          response_file=$(mktemp)
+          cleanup() {
+            rm -f "$response_file"
+          }
+          trap cleanup EXIT
+
+          printf '%s\n' "$response" >"$response_file"
+
+          python3 - "$response_file" <<'PY'
             import json
             import os
             import sys
@@ -165,11 +173,17 @@ jobs:
             output_path = os.getenv("GITHUB_OUTPUT")
             repository = os.getenv("REPOSITORY", "")
 
+            if len(sys.argv) != 2:
+                raise SystemExit("Ожидается путь к файлу с ответом GitHub API")
+
+            response_path = sys.argv[1]
+
             skip = False
             notices: list[str] = []
 
             try:
-                data = json.load(sys.stdin)
+                with open(response_path, "r", encoding="utf-8") as fh:
+                    data = json.load(fh)
             except json.JSONDecodeError:
                 skip = True
                 notices.append("Ответ GitHub API не является корректным JSON")


### PR DESCRIPTION
## Summary
- guard the PR readiness check against shell pipeline failures by storing the GitHub API response in a temporary file before invoking Python
- add explicit validation for the captured response path to keep the skip flag handling reliable

## Testing
- pytest tests/test_gptoss_workflow_python3.py
- pytest tests/test_run_gptoss_review.py tests/test_gptoss_mock_server.py tests/test_prepare_gptoss_diff.py

------
https://chatgpt.com/codex/tasks/task_e_68d4fc60e69c832d843e433ba869d9f2