### PR TITLE
Harden CodeQL against git reflog parse warnings

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -3,15 +3,10 @@ paths-ignore:
   # Ensure Git metadata created during checkout (including reference logs) is never
   # analysed by CodeQL. CodeQL interprets any *.py file it discovers as Python
   # source, so logs for remote refs with names that end in ".py" must be
-  # excluded explicitly. We therefore ignore every possible .git directory or
-  # file pattern, regardless of depth or naming, to avoid future false parse
-  # errors when CodeQL walks the workspace.
+  # excluded explicitly. We therefore ignore .git directories (and everything
+  # beneath them) no matter where they appear in the workspace tree to avoid
+  # future false parse errors when CodeQL walks the workspace.
+  - .git
   - .git/**
-  - '.git'
-  - '.git*'
   - '**/.git'
   - '**/.git/**'
-  - '**/.git*'
-  - '**/.git*/**'
-  - '**/.git/refs/**'
-  - '**/.git/logs/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,11 +29,14 @@ jobs:
           persist-credentials: false
           fetch-depth: 2
 
-      - name: Remove git metadata that can confuse CodeQL
+      - name: Purge git reference logs that can look like Python files
         run: |
           if [ -d .git ]; then
-            chmod -R u+w .git || true
-            rm -rf .git || true
+            git reflog expire --expire=now --all || true
+            find "$PWD" -path '*/.git/logs' -type d -prune -print0 | while IFS= read -r -d '' dir; do
+              chmod -R u+w "$dir" || true
+              rm -rf "$dir" || true
+            done
           fi
 
       - name: Set up Python
@@ -50,8 +53,11 @@ jobs:
       - name: Remove git metadata after CodeQL init
         run: |
           if [ -d .git ]; then
-            chmod -R u+w .git || true
-            rm -rf .git || true
+            git reflog expire --expire=now --all || true
+            find "$PWD" -path '*/.git/logs' -type d -prune -print0 | while IFS= read -r -d '' dir; do
+              chmod -R u+w "$dir" || true
+              rm -rf "$dir" || true
+            done
           fi
 
       - name: Install dependencies
@@ -62,8 +68,11 @@ jobs:
       - name: Remove git metadata before analysis
         run: |
           if [ -d .git ]; then
-            chmod -R u+w .git || true
-            rm -rf .git || true
+            git reflog expire --expire=now --all || true
+            find "$PWD" -path '*/.git/logs' -type d -prune -print0 | while IFS= read -r -d '' dir; do
+              chmod -R u+w "$dir" || true
+              rm -rf "$dir" || true
+            done
           fi
           # Guard against any git metadata recreated by tooling between steps.
           # Some package installers and third-party actions may vendor
@@ -77,9 +86,6 @@ jobs:
             chmod -R u+w "$dir" || true
             rm -rf "$dir" || true
           done
-          # As a final safeguard, proactively delete any reflog files that may
-          # have been recreated with misleading Python extensions.
-          find "$PWD" -path '*/.git/logs/*' -type f -name '*.py' -delete || true
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary
- purge reflog data after checkout, CodeQL init and before analysis so parse warnings from remote branches ending in `.py` disappear
- simplify the CodeQL configuration to ignore any `.git` directory at any depth so the extractor never sees git metadata

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_e_68d4ff7a1de8832d80d334351e7494f2