### PR TITLE
Fix release drafter concurrency expression

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,12 +16,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: "${{ (
-    github.event_name == 'pull_request_target'
-    && github.event.pull_request != null
-    && github.event.pull_request.number != null
-    && format('release-drafter-pr-{0}', github.event.pull_request.number)
-  ) || format('release-drafter-ref-{0}', github.ref) }}"
+  group: ${{ github.event_name == 'pull_request_target' && github.event.pull_request != null && github.event.pull_request.number != null && format('release-drafter-pr-{0}', github.event.pull_request.number) || format('release-drafter-ref-{0}', github.ref) }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary
- fix the release drafter workflow concurrency group expression so it evaluates correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d503deb7f8832dbaeb53f01a3e7e87