### PR TITLE
Avoid reapplying PAM nodns patch when already present

### DIFF
--- a/docker/scripts/build_patched_pam.sh
+++ b/docker/scripts/build_patched_pam.sh
@@ -89,6 +89,11 @@ apply_patch_or_skip() {
   local patch_file="$1"
   local -a sentinels
 
+  if patch_already_present "${patch_file}"; then
+    echo "Патч ${patch_file} уже присутствует (обнаружено до применения), пропускаем." >&2
+    return 0
+  fi
+
   mapfile -t sentinels < <(determine_sentinels "${patch_file}" || true)
 
   if patch -p1 --forward <"${patch_file}"; then


### PR DESCRIPTION
## Summary
- skip reapplying the linux-pam CVE-2024-10963 patch when its changes are already present in the unpacked sources to avoid duplicate helper definitions during Docker builds

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d50a7a3ec8832d8ba796076ae14b7c