### PR TITLE
Ensure cached CI venv refreshes dependencies

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -77,12 +77,13 @@ runs:
       run: |
         if [ ! -f /mnt/venv/bin/activate ]; then
           python -m venv /mnt/venv
-          source /mnt/venv/bin/activate
-          mkdir -p /mnt/tmp /mnt/pip-cache
-          export TMPDIR=/mnt/tmp
-          export PIP_CACHE_DIR=/mnt/pip-cache
-          python -m pip install -r requirements-ci.txt -r requirements-cpu.txt
         fi
+        source /mnt/venv/bin/activate
+        mkdir -p /mnt/tmp /mnt/pip-cache
+        export TMPDIR=/mnt/tmp
+        export PIP_CACHE_DIR=/mnt/pip-cache
+        python -m pip install --upgrade pip
+        python -m pip install -r requirements-ci.txt -r requirements-cpu.txt
         echo "/mnt/venv/bin" >> $GITHUB_PATH
         printf 'VIRTUAL_ENV=%s\n' "/mnt/venv" >> "$GITHUB_ENV"
         printf 'PATH=%s:%s\n' "/mnt/venv/bin" "$PATH" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary
- always activate the cached CI virtualenv before dependency installation
- upgrade pip and reinstall requirements on every run so security updates like setuptools fixes are applied

## Testing
- python -m pip_audit --strict
- python -m ruff check bot tests
- python -m mypy bot
- python -m bandit -r bot -x tests -ll
- python -m flake8 .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d50a862fcc832d8dd8deca7f9bc3ac