### PR TITLE
Handle missing GITHUB_OUTPUT in GPT-OSS workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -89,11 +89,15 @@ jobs:
             skip_reason="Workflow triggered for $EVENT_NAME – no review required."
           fi
 
-          {
-            echo "run_review=$run_review"
-            echo "pr_number=$pr_number"
-            echo "skip_reason=$skip_reason"
-          } >>"$GITHUB_OUTPUT"
+          if [ -n "${GITHUB_OUTPUT:-}" ]; then
+            {
+              echo "run_review=$run_review"
+              echo "pr_number=$pr_number"
+              echo "skip_reason=$skip_reason"
+            } >>"$GITHUB_OUTPUT"
+          else
+            echo "::debug::Переменная GITHUB_OUTPUT не задана – пропускаю экспорт выходных данных evaluate."
+          fi
 
   skip:
     needs: evaluate


### PR DESCRIPTION
## Summary
- guard the evaluate step in gptoss_review workflow against a missing GITHUB_OUTPUT file
- add debug logging when outputs cannot be exported

## Testing
- python -m pytest tests/test_gptoss_workflow_python3.py

------
https://chatgpt.com/codex/tasks/task_e_68d50ab2d5cc832dbf4d7319a75b0e52