### PR TITLE
Harden GitHub Actions workflows against untrusted checkouts

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -36,7 +36,7 @@ jobs:
           write_summary "Actor '${{ github.actor }}' on event '${{ github.event_name }}' does not require action."
 
   dependabot:
-    if: ${{ github.event_name == 'pull_request_target' && (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]') }}
+    if: ${{ github.event_name == 'pull_request_target' && (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]') && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     steps:
       - name: Dependabot metadata
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           fetch-depth: 0
-          repository: ${{ (github.event.pull_request && github.event.pull_request.head.repo.full_name) || github.repository }}
+          repository: ${{ github.repository }}
           ref: ${{ (github.event.pull_request && github.event.pull_request.head.sha) || github.sha }}
 
       # Set up a lightweight Python environment and install only the
@@ -72,7 +72,7 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
       - name: Install dependencies
-        if: ${{ steps.metadata.outputs['package-ecosystem'] == 'pip' }}
+        if: ${{ steps.metadata.outputs['package-ecosystem'] == 'pip' && github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements-ci.txt
@@ -85,7 +85,7 @@ jobs:
       # resolving the entire environment from scratch, keeping the job fast
       # while still validating the new packages.
       - name: Install Dependabot updates
-        if: ${{ steps.metadata.outputs['package-ecosystem'] == 'pip' }}
+        if: ${{ steps.metadata.outputs['package-ecosystem'] == 'pip' && github.event.pull_request.head.repo.full_name == github.repository }}
         env:
           DEPENDENCIES_JSON: ${{ steps.metadata.outputs['updated-dependencies-json'] }}
         run: |
@@ -134,7 +134,7 @@ jobs:
       # the main CI.  If any test fails this step will surface the
       # error and prevent automatic merging of the pull request.
       - name: Run unit tests
-        if: ${{ steps.metadata.outputs['package-ecosystem'] == 'pip' }}
+        if: ${{ steps.metadata.outputs['package-ecosystem'] == 'pip' && github.event.pull_request.head.repo.full_name == github.repository }}
         run: pytest -m "not integration" -q
 
       - name: Check auto-merge availability

--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -110,7 +110,7 @@ jobs:
 
   review:
     needs: evaluate
-    if: ${{ needs.evaluate.outputs.run_review == 'true' }}
+    if: ${{ needs.evaluate.outputs.run_review == 'true' && (github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:
@@ -221,11 +221,19 @@ jobs:
                     print(f"::warning::Не удалось записать GITHUB_OUTPUT: {exc}", file=sys.stderr)
           PY
 
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
-        if: ${{ steps.validate_event.outputs.skip != 'true' && steps.ensure_pr_ready.outputs.skip != 'true' }}
+      - name: Checkout PR head
+        if: ${{ steps.validate_event.outputs.skip != 'true' && steps.ensure_pr_ready.outputs.skip != 'true' && github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           fetch-depth: 0
           ref: refs/pull/${{ env.PR_NUMBER }}/head
+
+      - name: Checkout repository
+        if: ${{ steps.validate_event.outputs.skip != 'true' && steps.ensure_pr_ready.outputs.skip != 'true' && github.event_name != 'pull_request_target' }}
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+        with:
+          fetch-depth: 0
+          ref: ${{ github.sha }}
 
       - name: Start mock GPT-OSS server
         if: ${{ steps.validate_event.outputs.skip != 'true' && steps.ensure_pr_ready.outputs.skip != 'true' }}


### PR DESCRIPTION
## Summary
- restrict the Dependabot automation workflow to trusted pull_request_target events and internal repositories before executing mutable steps
- split the GPT-OSS review workflow checkout into separate safe paths for pull_request_target and other triggers, keeping automation limited to trusted contexts

## Testing
- /tmp/codeql/codeql/codeql database analyze /tmp/codeql-db-actions codeql/actions-all --format=sarif-latest --output=/tmp/actions.sarif --download *(fails: SunCertPathBuilderException "unable to find valid certification path to requested target")*

------
https://chatgpt.com/codex/tasks/task_e_68d4ff8adb14832da893a755df051b6e