### PR TITLE
Fix CodeQL workflow removing repo git dir

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -82,7 +82,7 @@ jobs:
           # files and emit parse warnings. Removing all nested .git directories
           # immediately before analysis ensures the extractor never sees these
           # files.
-          find "$PWD" -name '.git' -type d -print0 | while IFS= read -r -d '' dir; do
+          find "$PWD" -mindepth 2 -name '.git' -type d -print0 | while IFS= read -r -d '' dir; do
             chmod -R u+w "$dir" || true
             rm -rf "$dir" || true
           done


### PR DESCRIPTION
## Summary
- keep the repository’s root .git directory intact during CodeQL runs to avoid execution failures

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d519dda12c832db83a7c8bf9659215