### PR TITLE
Fix release drafter workflow expressions

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,7 +16,9 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.event_name == 'pull_request_target' && github.event.pull_request != null && github.event.pull_request.number != null && format('release-drafter-pr-{0}', github.event.pull_request.number) || format('release-drafter-ref-{0}', github.ref) }}
+  group: ${{ github.event_name == 'pull_request_target' && github.event.pull_request != null && github.event.pull_request.number != null
+    ? format('release-drafter-pr-{0}', github.event.pull_request.number)
+    : format('release-drafter-ref-{0}', github.ref) }}
   cancel-in-progress: false
 
 jobs:
@@ -32,11 +34,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   autolabel_pull_request:
-    if: |
-      github.event_name == 'pull_request_target'
-      && github.event.pull_request != null
-      && github.event.pull_request.head.repo != null
-      && github.event.pull_request.head.repo.full_name == github.repository
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request != null &&
+      github.event.pull_request.head.repo != null &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Update pull request metadata


### PR DESCRIPTION
## Summary
- guard Release Drafter concurrency with a clear ternary expression to avoid ambiguous evaluation
- fold the pull request job condition to keep the expression valid across multiple lines

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5213b4e18832dbdfcccfb8cb87fb3