### PR TITLE
Fix GPT-OSS review workflow checkout for manual triggers

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -226,18 +226,18 @@ jobs:
           PY
 
       - name: Checkout PR head
-        if: ${{ steps.validate_event.outputs.skip != 'true' && steps.ensure_pr_ready.outputs.skip != 'true' && github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ steps.validate_event.outputs.skip != 'true' && steps.ensure_pr_ready.outputs.skip != 'true' && github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository && env.PR_NUMBER != '' }}
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           fetch-depth: 0
-          ref: refs/pull/${{ env.PR_NUMBER }}/head
+          ref: ${{ format('refs/pull/{0}/head', env.PR_NUMBER) }}
 
       - name: Checkout repository
-        if: ${{ steps.validate_event.outputs.skip != 'true' && steps.ensure_pr_ready.outputs.skip != 'true' && github.event_name != 'pull_request_target' }}
+        if: ${{ steps.validate_event.outputs.skip != 'true' && steps.ensure_pr_ready.outputs.skip != 'true' && github.event_name != 'pull_request_target' && env.PR_NUMBER != '' }}
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           fetch-depth: 0
-          ref: ${{ github.sha }}
+          ref: ${{ format('refs/pull/{0}/head', env.PR_NUMBER) }}
 
       - name: Start mock GPT-OSS server
         if: ${{ steps.validate_event.outputs.skip != 'true' && steps.ensure_pr_ready.outputs.skip != 'true' }}


### PR DESCRIPTION
## Summary
- ensure the GPT-OSS review workflow always checks out the pull request head when running
- guard checkout steps so they only execute when a PR number is available

## Testing
- pytest tests/test_gptoss_workflow_python3.py -q
- pytest tests/test_prepare_gptoss_diff.py tests/test_run_gptoss_review.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d5212f83e4832dabf7beded47f08aa