### PR TITLE
Fix dependency snapshot permissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   contents: read
-  security-events: write
+  dependency-graph: write
 
 jobs:
   submit:


### PR DESCRIPTION
## Summary
- grant the workflow dependency graph write permissions so dependency snapshots can be uploaded

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d521214700832dbe386fc0909274ef