### PR TITLE
Fix release drafter concurrency expression

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,9 +16,10 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.event_name == 'pull_request_target' && github.event.pull_request != null && github.event.pull_request.number != null
-    ? format('release-drafter-pr-{0}', github.event.pull_request.number)
-    : format('release-drafter-ref-{0}', github.ref) }}
+  group: >-
+    ${{ github.event_name == 'pull_request_target' && github.event.pull_request != null && github.event.pull_request.number != null
+      ? format('release-drafter-pr-{0}', github.event.pull_request.number)
+      : format('release-drafter-ref-{0}', github.ref) }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary
- fix the Release Drafter workflow concurrency group formatting to avoid syntax errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d525c5e414832da941d0ddf560e266