### PR TITLE
Skip checkout for non-pip Dependabot updates

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -53,6 +53,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-number: ${{ (github.event.pull_request && github.event.pull_request.number) || '' }}
       - name: Checkout code
+        if: ${{ steps.metadata.outputs['package-ecosystem'] == 'pip' }}
         # v5.0.0
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:


### PR DESCRIPTION
## Summary
- skip the checkout step in the Dependabot automation when the update is not for pip packages
- keep the remaining validation steps unchanged so pip updates continue to run tests before auto-merge

## Testing
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_e_68d52113dd94832d8ce7bf91f54ed2a3