### PR TITLE
Fix release drafter concurrency condition

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,10 +16,10 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: >-
-    ${{ github.event_name == 'pull_request_target' && github.event.pull_request != null && github.event.pull_request.number != null
-      ? format('release-drafter-pr-{0}', github.event.pull_request.number)
-      : format('release-drafter-ref-{0}', github.ref) }}
+    group: >-
+      ${{ github.event_name == 'pull_request_target' && github.event.pull_request && github.event.pull_request.number
+        ? format('release-drafter-pr-{0}', github.event.pull_request.number)
+        : format('release-drafter-ref-{0}', github.ref) }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary
- simplify the concurrency group expression in the release drafter workflow
- rely on truthy checks for pull request data before formatting the concurrency key

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5285a5354832db70a52ed92f21774