### PR TITLE
Prevent CodeQL from parsing reflog entries with .py suffix

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,6 +32,14 @@ jobs:
       - name: Purge git reference logs that can look like Python files
         run: |
           if [ -d .git ]; then
+            git config core.logallrefupdates false || true
+            git for-each-ref --format='%(refname)' refs/remotes | while IFS= read -r ref; do
+              case "$ref" in
+                *.py)
+                  git update-ref -d "$ref" || true
+                  ;;
+              esac
+            done
             git reflog expire --expire=now --all || true
             find "$PWD" -path '*/.git/logs' -type d -prune -print0 | while IFS= read -r -d '' dir; do
               chmod -R u+w "$dir" || true
@@ -53,6 +61,14 @@ jobs:
       - name: Remove git metadata after CodeQL init
         run: |
           if [ -d .git ]; then
+            git config core.logallrefupdates false || true
+            git for-each-ref --format='%(refname)' refs/remotes | while IFS= read -r ref; do
+              case "$ref" in
+                *.py)
+                  git update-ref -d "$ref" || true
+                  ;;
+              esac
+            done
             git reflog expire --expire=now --all || true
             find "$PWD" -path '*/.git/logs' -type d -prune -print0 | while IFS= read -r -d '' dir; do
               chmod -R u+w "$dir" || true
@@ -68,6 +84,14 @@ jobs:
       - name: Remove git metadata before analysis
         run: |
           if [ -d .git ]; then
+            git config core.logallrefupdates false || true
+            git for-each-ref --format='%(refname)' refs/remotes | while IFS= read -r ref; do
+              case "$ref" in
+                *.py)
+                  git update-ref -d "$ref" || true
+                  ;;
+              esac
+            done
             git reflog expire --expire=now --all || true
             find "$PWD" -path '*/.git/logs' -type d -prune -print0 | while IFS= read -r -d '' dir; do
               chmod -R u+w "$dir" || true


### PR DESCRIPTION
## Summary
- extend the CodeQL workflow cleanup steps to disable reflogs locally and drop any remote refs ending in .py
- continue purging reflog directories afterwards so CodeQL never sees misleading Python-like files

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d52840be60832daf0ccda1dc23944c