### PR TITLE
Fix dependency graph workflow permissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -9,7 +9,6 @@ on:
 permissions:
   contents: read
   security-events: write
-  dependency-graph: write
 
 jobs:
   submit:

--- a/tests/test_dependency_graph_workflow.py
+++ b/tests/test_dependency_graph_workflow.py
@@ -40,12 +40,11 @@ def test_dependency_graph_permissions_are_valid() -> None:
 
     assert permissions, "permissions block must be present"
 
-    allowed_keys = {"contents", "security-events", "dependency-graph"}
+    allowed_keys = {"contents", "security-events"}
     assert set(permissions) <= allowed_keys
 
     assert permissions.get("contents") == "read"
     assert permissions.get("security-events") == "write"
-    assert permissions.get("dependency-graph") == "write"
 
 
 def test_dependency_graph_detect_step_handles_nested_manifests() -> None:


### PR DESCRIPTION
## Summary
- remove the unsupported dependency-graph permission from the dependency submission workflow
- update the dependency graph workflow test to match the valid permission set

## Testing
- ./actionlint .github/workflows/dependency-graph.yml
- pytest tests/test_dependency_graph_workflow.py

------
https://chatgpt.com/codex/tasks/task_e_68d528505384832dab9e16462a59bce8