### PR TITLE
Fix release drafter concurrency group

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -29,7 +29,7 @@ concurrency:
       && github.event.pull_request != null
       && github.event.pull_request.number != null
       ? format('release-drafter-pr-{0}', github.event.pull_request.number)
-      : format('release-drafter-ref-{0}', github.ref)
+      : format('release-drafter-ref-{0}', replace(github.ref, '/', '-'))
     }}
   cancel-in-progress: false
 


### PR DESCRIPTION
## Summary
- sanitize the release drafter concurrency group for non-PR events by replacing slashes in refs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d52caee5f8832db7890e2f9cfe517f