### PR TITLE
Fix CodeQL workflow cleanup script

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,6 +42,9 @@ jobs:
             done
             git reflog expire --expire=now --all || true
             find "$PWD" -path '*/.git/logs' -type d -prune -print0 | while IFS= read -r -d '' dir; do
+              if [ -z "$dir" ]; then
+                continue
+              fi
               chmod -R u+w "$dir" || true
               rm -rf "$dir" || true
             done
@@ -71,6 +74,9 @@ jobs:
             done
             git reflog expire --expire=now --all || true
             find "$PWD" -path '*/.git/logs' -type d -prune -print0 | while IFS= read -r -d '' dir; do
+              if [ -z "$dir" ]; then
+                continue
+              fi
               chmod -R u+w "$dir" || true
               rm -rf "$dir" || true
             done
@@ -94,6 +100,9 @@ jobs:
             done
             git reflog expire --expire=now --all || true
             find "$PWD" -path '*/.git/logs' -type d -prune -print0 | while IFS= read -r -d '' dir; do
+              if [ -z "$dir" ]; then
+                continue
+              fi
               chmod -R u+w "$dir" || true
               rm -rf "$dir" || true
             done
@@ -107,6 +116,9 @@ jobs:
           # immediately before analysis ensures the extractor never sees these
           # files.
           find "$PWD" -mindepth 2 -name '.git' -type d -print0 | while IFS= read -r -d '' dir; do
+            if [ -z "$dir" ]; then
+              continue
+            fi
             chmod -R u+w "$dir" || true
             rm -rf "$dir" || true
           done


### PR DESCRIPTION
## Summary
- skip cleanup actions when the find command returns empty results during CodeQL runs
- prevent chmod/rm invocations on empty directory names while removing git metadata

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68d52cc5b630832d934f0523c77b2bef