### PR TITLE
Fix release drafter workflow concurrency expression

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -23,14 +23,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: >-
-    ${{
-      github.event_name == 'pull_request_target'
-      && github.event.pull_request != null
-      && github.event.pull_request.number != null
-      ? format('release-drafter-pr-{0}', github.event.pull_request.number)
-      : format('release-drafter-ref-{0}', replace(github.ref, '/', '-'))
-    }}
+  group: ${{ github.event_name == 'pull_request_target' && github.event.pull_request != null && github.event.pull_request.number != null && format('release-drafter-pr-{0}', github.event.pull_request.number) || format('release-drafter-ref-{0}', github.ref_name) }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary
- simplify the Release Drafter workflow concurrency group expression so it parses correctly
- rely on `github.ref_name` for non-PR events while still using the PR number when present

## Testing
- actionlint .github/workflows/release-drafter.yml

------
https://chatgpt.com/codex/tasks/task_e_68d537db109c832da3d1ddc99c161232