### PR TITLE
Harden health check host validation

### DIFF
--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -1,16 +1,24 @@
 #!/usr/bin/env python
 """Simple health check for API endpoints."""
-import sys
-from typing import Iterable
-
 import logging
+import os
+import re
+import sys
+from typing import Iterable, Set
+
 from ipaddress import ip_address
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 import requests  # type: ignore[import-untyped]
 
+from services.logging_utils import sanitize_log_value
+
 
 logger = logging.getLogger(__name__)
+
+
+_ALLOWED_HOSTS_ENV = "HEALTH_CHECK_ALLOWED_HOSTS"
+_DEFAULT_ALLOWED_HOSTS: frozenset[str] = frozenset({"localhost", "127.0.0.1", "::1"})
 
 
 def _is_local_host(hostname: str | None) -> bool:
@@ -26,26 +34,91 @@ def _is_local_host(hostname: str | None) -> bool:
     return parsed.is_loopback or parsed.is_private
 
 
-def check_endpoints(base_url: str, endpoints: Iterable[str]) -> int:
+def _load_allowed_hosts() -> Set[str]:
+    hosts: Set[str] = set(_DEFAULT_ALLOWED_HOSTS)
+    raw = os.getenv(_ALLOWED_HOSTS_ENV)
+    if not raw:
+        return hosts
+    for part in raw.split(","):
+        candidate = part.strip()
+        if not candidate:
+            continue
+        if candidate.startswith("[") and candidate.endswith("]"):
+            candidate = candidate[1:-1]
+        hosts.add(candidate.lower())
+    return hosts
+
+
+def _normalise_base_url(base_url: str, allowed_hosts: Set[str]) -> str:
     parsed = urlparse(base_url)
     if parsed.scheme not in {"http", "https"}:
-        logger.error("Unsupported base URL scheme: %s", parsed.scheme or "<missing>")
-        return 1
-    if parsed.scheme == "http" and not _is_local_host(parsed.hostname):
-        logger.error(
-            "Refusing to perform insecure HTTP health checks for non-local host %s",
-            parsed.hostname or "<missing>",
+        raise ValueError(
+            f"Unsupported base URL scheme: {parsed.scheme or '<missing>'}"
         )
+    if parsed.username or parsed.password:
+        raise ValueError("Base URL must not include credentials")
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError("Base URL must include a hostname")
+
+    lowered = hostname.lower()
+    is_local = _is_local_host(hostname)
+    if lowered not in allowed_hosts and not is_local:
+        raise ValueError(f"Base URL host {hostname!r} is not permitted")
+
+    if parsed.scheme == "http" and not is_local:
+        raise ValueError(
+            f"Refusing insecure HTTP health checks for non-local host {hostname!r}"
+        )
+
+    if parsed.query or parsed.fragment:
+        raise ValueError("Base URL must not include query or fragment components")
+
+    if parsed.path and parsed.path != "/":
+        collapsed = re.sub(r"/+/", "/", parsed.path)
+        if not collapsed.startswith("/"):
+            collapsed = f"/{collapsed}"
+        path = collapsed.rstrip("/")
+    else:
+        path = ""
+
+    netloc = hostname
+    if parsed.port:
+        if not (0 < parsed.port < 65536):
+            raise ValueError("Base URL port is out of range")
+        netloc = f"{hostname}:{parsed.port}"
+
+    normalised = urlunparse((parsed.scheme, netloc, path, "", "", ""))
+    return normalised.rstrip("/") or normalised
+
+
+def check_endpoints(base_url: str, endpoints: Iterable[str]) -> int:
+    allowed_hosts = _load_allowed_hosts()
+    try:
+        normalised = _normalise_base_url(base_url, allowed_hosts)
+    except ValueError as exc:
+        logger.error("%s", sanitize_log_value(str(exc)))
         return 1
 
+    base = normalised.rstrip("/")
     for endpoint in endpoints:
-        url = f"{base_url.rstrip('/')}{endpoint}"
+        suffix = endpoint if endpoint.startswith("/") else f"/{endpoint}"
+        url = f"{base}{suffix}"
         try:
             response = requests.get(url, timeout=10)
             response.raise_for_status()
-            logger.info("%s -> %s", url, response.status_code)
+            logger.info(
+                "%s -> %s",
+                sanitize_log_value(url),
+                response.status_code,
+            )
         except requests.RequestException as exc:
-            logger.error("Health check failed for %s: %s", url, exc)
+            logger.error(
+                "Health check failed for %s: %s",
+                sanitize_log_value(url),
+                sanitize_log_value(str(exc)),
+            )
             return 1
     return 0
 

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -1,0 +1,66 @@
+import logging
+from typing import Iterable
+
+import pytest
+
+import scripts.health_check as hc
+
+
+class DummyResponse:
+    def __init__(self, status_code: int = 200) -> None:
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise hc.requests.HTTPError(f"HTTP {self.status_code}")
+
+
+def _call_check(base_url: str, endpoints: Iterable[str]) -> int:
+    return hc.check_endpoints(base_url, list(endpoints))
+
+
+def test_normalise_base_url_allows_loopback() -> None:
+    allowed = hc._load_allowed_hosts()
+    assert (
+        hc._normalise_base_url("http://127.0.0.1:8080/api", allowed)
+        == "http://127.0.0.1:8080/api"
+    )
+
+
+def test_normalise_base_url_rejects_http_non_local() -> None:
+    allowed = hc._load_allowed_hosts()
+    with pytest.raises(ValueError):
+        hc._normalise_base_url("http://example.com", allowed)
+
+
+def test_normalise_base_url_respects_allowed_hosts_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HEALTH_CHECK_ALLOWED_HOSTS", "example.com")
+    allowed = hc._load_allowed_hosts()
+    assert (
+        hc._normalise_base_url("https://example.com:8443/base", allowed)
+        == "https://example.com:8443/base"
+    )
+
+
+def test_normalise_base_url_rejects_query(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HEALTH_CHECK_ALLOWED_HOSTS", "example.com")
+    allowed = hc._load_allowed_hosts()
+    with pytest.raises(ValueError):
+        hc._normalise_base_url("https://example.com/path?bad=1", allowed)
+
+
+def test_check_endpoints_sanitises_logs(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    class DummyError(hc.requests.RequestException):
+        pass
+
+    def fake_get(url: str, timeout: float = 0) -> DummyResponse:
+        raise DummyError("boom\nfail")
+
+    monkeypatch.setattr(hc.requests, "get", fake_get)
+    caplog.set_level(logging.ERROR)
+    result = _call_check("http://localhost:8000", ["/bad\nendpoint"])
+    assert result == 1
+    record = caplog.records[0]
+    message = record.getMessage()
+    assert "http://localhost:8000/bad\\nendpoint" in message
+    assert "boom\\nfail" in message


### PR DESCRIPTION
## Summary
- harden `scripts/health_check.py` by enforcing allow-listed hosts, rejecting credentials and query fragments, and sanitising log output before emitting URLs or exceptions
- add a dedicated unit test suite covering the new URL normalisation rules and log sanitisation behaviour

## Testing
- `pytest tests/test_health_check.py`
- `ruff check scripts/health_check.py tests/test_health_check.py`
- `/tmp/codeql/codeql/codeql database analyze /tmp/bot-db --format=sarifv2.1.0 --output=/tmp/codeql-results-extended.sarif codeql/python-queries:codeql-suites/python-security-extended.qls`


------
https://chatgpt.com/codex/tasks/task_e_68d53aa8d918832da7284ddc85c69e0f