### PR TITLE
Fix CodeQL workflow to keep root git metadata

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -122,16 +122,10 @@ jobs:
             chmod -R u+w "$dir" || true
             rm -rf "$dir" || true
           done
-          # Remove the repository's root .git directory as a final safeguard so
-          # that no Git metadata remains for CodeQL to misinterpret as Python
-          # source files (for example reflogs for remote refs ending with
-          # ".py"). Once dependencies are installed the workflow no longer
-          # requires Git metadata, so deleting it here prevents future parse
-          # warnings.
-          if [ -d .git ]; then
-            chmod -R u+w .git || true
-            rm -rf .git || true
-          fi
+          # The repository's root .git directory must remain intact; CodeQL uses
+          # it during analysis (for example to resolve commit metadata). Removing
+          # nested .git directories is sufficient to suppress false positives
+          # from vendored dependencies while keeping the root repository healthy.
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary
- stop deleting the repository’s root .git directory in the CodeQL workflow
- document why the root git metadata must be preserved while still pruning nested .git folders

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d53ab18380832dbd1a8f6f69bdf24b