### PR TITLE
Harden CodeQL git metadata cleanup

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,6 +41,7 @@ jobs:
               esac
             done
             git reflog expire --expire=now --all || true
+            find .git -type f -name '*.py' -print0 | xargs -0r rm -f || true
             if [ -d .git/logs ]; then
               chmod -R u+w .git/logs || true
               find .git/logs -type f -name '*.py' -print0 | xargs -0r rm -f || true
@@ -90,6 +91,9 @@ jobs:
             chmod -R u+w "$dir" || true
             rm -rf "$dir" || true
           done
+          if [ -d .git ]; then
+            find .git -type f -name '*.py' -print0 | xargs -0r rm -f || true
+          fi
           if [ -d .git/logs ]; then
             chmod -R u+w .git/logs || true
             find .git/logs -type f -name '*.py' -print0 | xargs -0r rm -f || true


### PR DESCRIPTION
## Summary
- remove any Python-named files under the repository's .git directory before CodeQL analysis to avoid false syntax errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d58bdc1b6c832da138d0a4197ada2d