### PR TITLE
Handle missing GITHUB_OUTPUT in review workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -157,8 +157,14 @@ jobs:
           set -euo pipefail
 
           pr_number="${PR_NUMBER:-}"
+          output_file="${GITHUB_OUTPUT:-}"
+
           if [ -z "$pr_number" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
+            if [ -n "$output_file" ]; then
+              echo "skip=true" >> "$output_file"
+            else
+              echo "::warning::Переменная GITHUB_OUTPUT не задана – не удалось записать skip=true" >&2
+            fi
             exit 0
           fi
 
@@ -168,7 +174,11 @@ jobs:
             -H "Authorization: Bearer ${GITHUB_TOKEN}" \
             "$api_url"); then
             echo "::warning::Не удалось получить данные PR ${pr_number} – пропускаю обзор" >&2
-            echo "skip=true" >> "$GITHUB_OUTPUT"
+            if [ -n "$output_file" ]; then
+              echo "skip=true" >> "$output_file"
+            else
+              echo "::warning::Переменная GITHUB_OUTPUT не задана – не удалось записать skip=true" >&2
+            fi
             exit 0
           fi
 


### PR DESCRIPTION
## Summary
- guard writes to GITHUB_OUTPUT in the review workflow to avoid failures when the variable is missing
- emit warnings instead of failing the PR status check when GITHUB_OUTPUT is unavailable

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d58c5e9a64832dab4b107f392348a5