### PR TITLE
Fix CodeQL workflow configuration

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,7 +67,6 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
-          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- remove the advanced CodeQL configuration reference so GitHub can process the default setup results

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d58f99fdac832db14a5eddbc15bd2b