### PR TITLE
Harden CodeQL cleanup for Git metadata

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -6,7 +6,10 @@ paths-ignore:
   # excluded explicitly. We therefore ignore .git directories (and everything
   # beneath them) no matter where they appear in the workspace tree to avoid
   # future false parse errors when CodeQL walks the workspace.
+  - /.git
+  - /.git/**
   - .git
   - .git/**
   - '**/.git'
   - '**/.git/**'
+  - '**/.git/logs/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,6 +41,10 @@ jobs:
               esac
             done
             git reflog expire --expire=now --all || true
+            if [ -d .git/refs ]; then
+              find .git/refs -type f -name '*.py' -print0 | xargs -0r rm -f || true
+              find .git/refs -type d -name '*.py' -print0 | xargs -0r rm -rf || true
+            fi
             find .git -type f -name '*.py' -print0 | xargs -0r rm -f || true
             if [ -d .git/logs ]; then
               chmod -R u+w .git/logs || true
@@ -92,6 +96,10 @@ jobs:
             rm -rf "$dir" || true
           done
           if [ -d .git ]; then
+            if [ -d .git/refs ]; then
+              find .git/refs -type f -name '*.py' -print0 | xargs -0r rm -f || true
+              find .git/refs -type d -name '*.py' -print0 | xargs -0r rm -rf || true
+            fi
             find .git -type f -name '*.py' -print0 | xargs -0r rm -f || true
           fi
           if [ -d .git/logs ]; then


### PR DESCRIPTION
## Summary
- broaden the CodeQL configuration ignore patterns to cover the root .git directory and nested Git logs explicitly
- extend the workflow cleanup steps to delete any Git reference files or directories whose names end in .py before CodeQL analysis

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d58ff26064832d8b4f16402f8b617d