### PR TITLE
Simplify release drafter concurrency group

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -23,7 +23,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.event_name == 'pull_request_target' && github.event.pull_request != null && github.event.pull_request.number != null && format('release-drafter-pr-{0}', github.event.pull_request.number) || format('release-drafter-ref-{0}', github.ref_name) }}
+  group: release-drafter-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary
- simplify the release drafter concurrency group expression to avoid unsupported context references

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d592d0d4b4832da2a429dfccaf9313