### PR TITLE
Clarify dependency snapshot permissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  # Required by the dependency submission API; avoid granting broader dependency-graph scope.
   security-events: write
 
 jobs:


### PR DESCRIPTION
## Summary
- document that the dependency snapshot workflow keeps the minimal `contents` and `security-events` permissions so CI passes.

## Testing
- pytest tests/test_dependency_graph_workflow.py

------
https://chatgpt.com/codex/tasks/task_e_68d592eab860832dab9afa778f016c0e