### PR TITLE
Configure CodeQL to ignore .git logs via repo config

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,6 +37,7 @@ jobs:
         uses: github/codeql-action/init@192325c86100d080feab897ff886c34abd4c83a3 # v3.30.3
         with:
           languages: ${{ matrix.language }}
+          config-file: .github/codeql/codeql-config.yml
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- configure the CodeQL init step to load the repository's codeql-config.yml so that .git paths are excluded from analysis

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d596c7b2d0832d9d31cda32767325d