### PR TITLE
Guard dependabot workflow from non-PR events

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -36,7 +36,13 @@ jobs:
           write_summary "Actor '${{ github.actor }}' on event '${{ github.event_name }}' does not require action."
 
   dependabot:
-    if: ${{ github.event_name == 'pull_request_target' && (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]') && github.event.pull_request.head.repo.full_name == github.repository }}
+    if: >-
+      ${{
+        github.event_name == 'pull_request_target' &&
+        (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]') &&
+        github.event.pull_request != null &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      }}
     runs-on: ubuntu-latest
     steps:
       - name: Dependabot metadata


### PR DESCRIPTION
## Summary
- ensure the Dependabot workflow only runs when pull_request data is available to avoid evaluation errors on push events

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d5975316e4832d85b686a0b9239ed6