### PR TITLE
Remove git logs before CodeQL analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,6 +26,9 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
+      - name: Remove Git reference logs that mimic Python files
+        run: rm -rf .git/logs
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
- delete the .git/logs directory before running CodeQL so branch names ending in `.py` no longer trigger parse errors during analysis

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d598a890e8832da95880624720d7d1