### PR TITLE
Fix TradeManager import path in run_bot

### DIFF
--- a/run_bot.py
+++ b/run_bot.py
@@ -191,7 +191,7 @@ def _build_components(cfg: "BotConfig", offline: bool, symbols: list[str] | None
 
     from bot.data_handler import DataHandler
     from bot.model_builder import ModelBuilder
-    from bot.bot.trade_manager.core import TradeManager
+    from bot.trade_manager import TradeManager
 
     exchange = exchange_cls() if exchange_cls else None
 


### PR DESCRIPTION
## Summary
- update run_bot to import TradeManager from the bot.trade_manager package

## Testing
- python run_bot.py --offline trade --runtime 0.1

------
https://chatgpt.com/codex/tasks/task_e_68d599efbe58832d928156adb622d2bf