### PR TITLE
Remove Git metadata before CodeQL analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,8 +26,8 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Remove Git reference logs that mimic Python files
-        run: rm -rf .git/logs
+      - name: Remove Git metadata directories that mimic Python files
+        run: find "$PWD" -type d -name ".git" -prune -exec rm -rf '{}' +
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- delete all .git directories during the CodeQL workflow so extractor never sees git reference files that resemble Python modules

## Testing
- no tests were run (not needed for this change)


------
https://chatgpt.com/codex/tasks/task_e_68d59b32a6b0832d946099af07b435ec