### PR TITLE
Silence mypy missing requests stubs

### DIFF
--- a/scripts/submit_dependency_snapshot.py
+++ b/scripts/submit_dependency_snapshot.py
@@ -18,8 +18,8 @@ from urllib.parse import quote, urlparse
 _REQUESTS_IMPORT_ERROR: ImportError | None = None
 
 try:
-    import requests
-    from requests import exceptions as requests_exceptions
+    import requests  # type: ignore[import-untyped]
+    from requests import exceptions as requests_exceptions  # type: ignore[import-untyped]
 except ImportError as exc:  # pragma: no cover - exercised via import hook in tests
     _REQUESTS_IMPORT_ERROR = exc
     requests = None  # type: ignore[assignment]


### PR DESCRIPTION
## Summary
- silence mypy missing stub error for the requests dependency used by the dependency snapshot script

## Testing
- pytest
- mypy --exclude venv .


------
https://chatgpt.com/codex/tasks/task_e_68d59beda120832d95035918b4edaf5c