### PR TITLE
Add robust PR status checker for GPT-OSS workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -163,101 +163,12 @@ jobs:
         run: |
           set -euo pipefail
 
-          pr_number="${PR_NUMBER:-}"
-          output_file="${GITHUB_OUTPUT:-}"
-
-          if [ -z "$pr_number" ]; then
-            if [ -n "$output_file" ]; then
-              echo "skip=true" >> "$output_file"
-            else
-              echo "::warning::Переменная GITHUB_OUTPUT не задана – не удалось записать skip=true" >&2
-            fi
-            exit 0
+          if ! python3 scripts/check_pr_status.py \
+            --repo "${REPOSITORY}" \
+            --pr-number "${PR_NUMBER:-}" \
+            --token "${GITHUB_TOKEN}"; then
+            echo "::warning::Проверка статуса PR завершилась с ошибкой – пропускаю обзор"
           fi
-
-          api_url="https://api.github.com/repos/${REPOSITORY}/pulls/${pr_number}"
-          if ! response=$(curl -fsSL \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-            "$api_url"); then
-            echo "::warning::Не удалось получить данные PR ${pr_number} – пропускаю обзор" >&2
-            if [ -n "$output_file" ]; then
-              echo "skip=true" >> "$output_file"
-            else
-              echo "::warning::Переменная GITHUB_OUTPUT не задана – не удалось записать skip=true" >&2
-            fi
-            exit 0
-          fi
-
-          response_file=$(mktemp)
-          cleanup() {
-            rm -f "$response_file"
-          }
-          trap cleanup EXIT
-
-          printf '%s\n' "$response" >"$response_file"
-
-          python3 - "$response_file" <<'PY'
-            import json
-            import os
-            import sys
-
-            output_path = os.getenv("GITHUB_OUTPUT")
-            repository = os.getenv("REPOSITORY", "")
-
-            if len(sys.argv) != 2:
-                raise SystemExit("Ожидается путь к файлу с ответом GitHub API")
-
-            response_path = sys.argv[1]
-
-            skip = False
-            notices: list[str] = []
-            head_sha = ""
-
-            try:
-                with open(response_path, "r", encoding="utf-8") as fh:
-                    data = json.load(fh)
-            except json.JSONDecodeError:
-                skip = True
-                notices.append("Ответ GitHub API не является корректным JSON")
-            else:
-                state = data.get("state")
-                head = data.get("head") or {}
-                head_repo = (head.get("repo") or {}).get("full_name")
-                head_sha = (head.get("sha") or "").strip()
-
-                if state != "open":
-                    skip = True
-                    notices.append(f"PR находится в состоянии {state!r}")
-
-                if head_repo is None:
-                    skip = True
-                    notices.append("head-репозиторий недоступен (ветка могла быть удалена)")
-                elif head_repo and repository and head_repo != repository:
-                    skip = True
-                    notices.append(
-                        f"PR создан из репозитория {head_repo}, ожидается {repository}"
-                    )
-                if not head_sha:
-                    skip = True
-                    notices.append("Не удалось получить SHA head-коммита PR")
-
-            if skip:
-                if notices:
-                    print("::notice::" + "; ".join(notices) + ". Пропускаю запуск обзора.")
-                else:
-                    print("::notice::PR не подходит для обзора. Пропускаю запуск обзора.")
-            else:
-                print("::debug::PR прошёл проверку статуса и источника.")
-
-            if output_path:
-                try:
-                    with open(output_path, "a", encoding="utf-8") as fh:
-                        fh.write(f"skip={'true' if skip else 'false'}\n")
-                        fh.write(f"head_sha={head_sha}\n")
-                except OSError as exc:
-                    print(f"::warning::Не удалось записать GITHUB_OUTPUT: {exc}", file=sys.stderr)
-          PY
 
       - name: Checkout PR head
         if: >-

--- a/scripts/check_pr_status.py
+++ b/scripts/check_pr_status.py
@@ -1,0 +1,225 @@
+"""Helper for validating pull request readiness in the GPT-OSS workflow.
+
+The previous implementation embedded the logic directly into the workflow
+using a shell script with inline Python.  That approach made debugging
+failures difficult – any unexpected API response caused the step to fail
+hard with a non-zero exit code.  This module centralises the behaviour in a
+tested Python entry point that always exits successfully while emitting clear
+GitHub Actions annotations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import ssl
+import sys
+from dataclasses import dataclass
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import HTTPSHandler, Request, build_opener
+
+
+_DEFAULT_TIMEOUT = 10.0
+
+
+@dataclass(slots=True)
+class PRStatus:
+    """Result of evaluating whether a PR is eligible for review."""
+
+    skip: bool
+    head_sha: str
+    notices: list[str]
+
+
+def _write_github_output(skip: bool, head_sha: str) -> None:
+    """Append outputs for downstream workflow steps if possible."""
+
+    output_path = os.getenv("GITHUB_OUTPUT")
+    if not output_path:
+        return
+
+    try:
+        with open(output_path, "a", encoding="utf-8") as handle:
+            handle.write(f"skip={'true' if skip else 'false'}\n")
+            handle.write(f"head_sha={head_sha}\n")
+    except OSError as exc:  # pragma: no cover - extremely rare on GitHub runners
+        print(f"::warning::Не удалось записать GITHUB_OUTPUT: {exc}", file=sys.stderr)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Check pull request status")
+    parser.add_argument("--repo", default=os.getenv("REPOSITORY", ""))
+    parser.add_argument("--pr-number", default=os.getenv("PR_NUMBER", ""))
+    parser.add_argument("--token", default=os.getenv("GITHUB_TOKEN", ""))
+    parser.add_argument("--timeout", type=float, default=_DEFAULT_TIMEOUT)
+
+    args, unknown = parser.parse_known_args(argv)
+    if unknown:
+        raise ValueError("Неизвестные аргументы: " + " ".join(unknown))
+    return args
+
+
+def _fetch_pull_request(url: str, token: str, timeout: float) -> Any:
+    """Return decoded JSON payload for the GitHub pull request API."""
+
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "gptoss-review-workflow/1.0 (+https://github.com/averinaleks/bot)",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    request = Request(url, headers=headers)
+    opener = build_opener(HTTPSHandler(context=ssl.create_default_context()))
+
+    try:
+        with opener.open(request, timeout=timeout) as response:
+            payload = response.read()
+    except HTTPError as exc:
+        status = int(getattr(exc, "code", 0) or 0)
+        reason = getattr(exc, "reason", "") or ""
+        raise RuntimeError(
+            f"HTTP запрос {url} завершился ошибкой: {status} {reason}"
+        ) from exc
+    except URLError as exc:
+        message = getattr(exc.reason, "strerror", None) or getattr(exc.reason, "args", [None])[0]
+        message = message or exc.reason or exc
+        raise RuntimeError(f"HTTP запрос {url} завершился ошибкой: {message}") from exc
+
+    try:
+        return json.loads(payload.decode("utf-8"))
+    except ValueError as exc:  # pragma: no cover - defensive guard
+        raise RuntimeError("GitHub API вернул некорректный JSON") from exc
+
+
+def _evaluate_payload(payload: Any, repository: str) -> PRStatus:
+    """Inspect GitHub API payload and determine whether to skip the review."""
+
+    notices: list[str] = []
+    head_sha = ""
+
+    if not isinstance(payload, dict):
+        return PRStatus(skip=True, head_sha="", notices=["Ответ GitHub API имеет неожиданный формат"])
+
+    state = str(payload.get("state") or "").strip()
+
+    head_repo = ""
+    head_block = payload.get("head") or {}
+    if isinstance(head_block, dict):
+        repo_block = head_block.get("repo") or {}
+        if isinstance(repo_block, dict):
+            head_repo = str(repo_block.get("full_name") or "").strip()
+        sha_value = head_block.get("sha")
+        if isinstance(sha_value, str):
+            head_sha = sha_value.strip()
+
+    skip = False
+
+    if state != "open":
+        skip = True
+        if state:
+            notices.append(f"PR находится в состоянии {state!r}")
+        else:
+            notices.append("GitHub API не вернул статус PR")
+
+    if not head_repo:
+        skip = True
+        notices.append("head-репозиторий недоступен (ветка могла быть удалена)")
+    elif repository and head_repo != repository:
+        skip = True
+        notices.append(f"PR создан из репозитория {head_repo}, ожидается {repository}")
+
+    if not head_sha:
+        skip = True
+        notices.append("Не удалось получить SHA head-коммита PR")
+
+    return PRStatus(skip=skip, head_sha=head_sha, notices=notices)
+
+
+def _build_api_url(repo: str, pr_number: str) -> str:
+    if not repo or not pr_number:
+        raise RuntimeError("Не указан номер PR или репозиторий")
+    return f"https://api.github.com/repos/{repo}/pulls/{pr_number}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        args = _parse_args(argv)
+    except ValueError as exc:
+        print(f"::warning::{exc}", file=sys.stderr)
+        _write_github_output(skip=True, head_sha="")
+        return 0
+    except SystemExit as exc:  # pragma: no cover - argparse --help
+        code = getattr(exc, "code", 0)
+        if code not in (0, None):
+            print(
+                f"::warning::Парсер аргументов завершился с кодом {code}",
+                file=sys.stderr,
+            )
+        _write_github_output(skip=True, head_sha="")
+        return 0
+
+    repo = args.repo.strip()
+    pr_number = str(args.pr_number).strip()
+    if not repo or not pr_number:
+        print("::notice::PR не найден – пропускаю запуск обзора.", file=sys.stderr)
+        _write_github_output(skip=True, head_sha="")
+        return 0
+
+    try:
+        url = _build_api_url(repo, pr_number)
+        payload = _fetch_pull_request(url, args.token, args.timeout)
+    except RuntimeError as exc:
+        print(f"::warning::{exc}", file=sys.stderr)
+        _write_github_output(skip=True, head_sha="")
+        return 0
+    except Exception as exc:  # pragma: no cover - defensive guard
+        print(
+            f"::error::Неожиданная ошибка при проверке PR: {exc}",
+            file=sys.stderr,
+        )
+        _write_github_output(skip=True, head_sha="")
+        return 0
+
+    status = _evaluate_payload(payload, repo)
+
+    if status.skip:
+        if status.notices:
+            print(
+                "::notice::" + "; ".join(status.notices) + ". Пропускаю запуск обзора.",
+                file=sys.stderr,
+            )
+        else:
+            print("::notice::PR не подходит для обзора. Пропускаю запуск обзора.", file=sys.stderr)
+    else:
+        print("::debug::PR прошёл проверку статуса и источника.")
+
+    _write_github_output(status.skip, status.head_sha)
+    return 0
+
+
+def cli(argv: list[str] | None = None) -> int:
+    """CLI wrapper that shields the workflow from non-zero exits."""
+
+    try:
+        return main(argv)
+    except SystemExit as exc:  # pragma: no cover - defensive guard
+        code = exc.code
+        if code not in (0, None):
+            print(
+                f"::warning::Скрипт завершился с кодом {code}. Возвращаю 0.",
+                file=sys.stderr,
+            )
+            _write_github_output(skip=True, head_sha="")
+        return 0
+    except BaseException as exc:  # pragma: no cover - defensive guard
+        print(f"::error::Критическое исключение в check_pr_status: {exc}", file=sys.stderr)
+        _write_github_output(skip=True, head_sha="")
+        return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(cli())
+

--- a/tests/test_check_pr_status.py
+++ b/tests/test_check_pr_status.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts import check_pr_status
+
+
+def _build_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "state": "open",
+        "head": {
+            "sha": "deadbeef" * 5,
+            "repo": {"full_name": "owner/repo"},
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_evaluate_payload_happy_path() -> None:
+    status = check_pr_status._evaluate_payload(_build_payload(), "owner/repo")
+    assert status.skip is False
+    assert status.head_sha == "deadbeef" * 5
+    assert status.notices == []
+
+
+def test_evaluate_payload_detects_closed_pr() -> None:
+    payload = _build_payload(state="closed")
+    status = check_pr_status._evaluate_payload(payload, "owner/repo")
+    assert status.skip is True
+    assert any("closed" in notice for notice in status.notices)
+
+
+def test_evaluate_payload_detects_repo_mismatch() -> None:
+    payload = _build_payload()
+    status = check_pr_status._evaluate_payload(payload, "other/repo")
+    assert status.skip is True
+    assert any("other/repo" in notice for notice in status.notices)
+
+
+def test_evaluate_payload_handles_missing_data() -> None:
+    status = check_pr_status._evaluate_payload({}, "owner/repo")
+    assert status.skip is True
+    assert any("SHA" in notice for notice in status.notices)
+
+
+def test_evaluate_payload_handles_unexpected_format() -> None:
+    status = check_pr_status._evaluate_payload([], "owner/repo")  # type: ignore[arg-type]
+    assert status.skip is True
+    assert "неожиданный формат" in status.notices[0]
+
+
+def test_main_writes_outputs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = _build_payload()
+
+    def fake_fetch(url: str, token: str, timeout: float) -> dict[str, object]:
+        assert "3163" in url
+        assert token == "token"
+        assert timeout == 5.0
+        return payload
+
+    monkeypatch.setattr(check_pr_status, "_fetch_pull_request", fake_fetch)
+
+    output_file = tmp_path / "output.txt"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+
+    result = check_pr_status.main([
+        "--repo",
+        "owner/repo",
+        "--pr-number",
+        "3163",
+        "--token",
+        "token",
+        "--timeout",
+        "5.0",
+    ])
+
+    assert result == 0
+    assert output_file.read_text(encoding="utf-8") == "skip=false\nhead_sha={}\n".format("deadbeef" * 5)
+
+
+def test_main_handles_http_error(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    def fake_fetch(url: str, token: str, timeout: float) -> dict[str, object]:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(check_pr_status, "_fetch_pull_request", fake_fetch)
+    monkeypatch.setenv("GITHUB_OUTPUT", "")
+
+    result = check_pr_status.main([
+        "--repo",
+        "owner/repo",
+        "--pr-number",
+        "42",
+        "--token",
+        "",
+    ])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "::warning::boom" in captured.err
+
+
+def test_cli_swallows_system_exit(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setattr(check_pr_status, "main", lambda argv=None: (_ for _ in ()).throw(SystemExit(3)))
+    monkeypatch.setenv("GITHUB_OUTPUT", "")
+
+    result = check_pr_status.cli([])
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "кодом 3" in captured.err
+


### PR DESCRIPTION
## Summary
- replace the inline pull-request status check in the GPT-OSS workflow with a call to a dedicated Python helper
- add `scripts/check_pr_status.py` to safely validate PR metadata and export workflow outputs without failing the job
- cover the new helper with unit tests so regression scenarios are easier to exercise locally

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d59df67d6c832d936d092f8e5bf262