### PR TITLE
Refactor exchange lifecycle and trade manager context

### DIFF
--- a/services/data_handler_service.py
+++ b/services/data_handler_service.py
@@ -4,7 +4,7 @@ import hmac
 import logging
 import os
 import tempfile
-import threading
+from contextvars import ContextVar
 from types import SimpleNamespace
 from typing import Any
 
@@ -13,6 +13,7 @@ from flask import Flask, jsonify, request
 from bot.dotenv_utils import load_dotenv
 from bot.host_utils import validate_host
 from services.logging_utils import sanitize_log_value
+from services.exchange_provider import ExchangeProvider
 
 load_dotenv()
 
@@ -79,7 +80,8 @@ app = Flask(__name__)
 if hasattr(app, "config"):
     app.config["MAX_CONTENT_LENGTH"] = 1 * 1024 * 1024  # 1 MB limit
 
-exchange = None
+_exchange_ctx: ContextVar[Any | None] = ContextVar("data_handler_exchange", default=None)
+exchange_provider: ExchangeProvider[Any] | None = None
 
 
 def _require_api_key() -> "ResponseReturnValue | None":
@@ -140,12 +142,11 @@ def _create_history_cache() -> "HistoricalDataCache | None":
 history_cache = _create_history_cache()
 if os.getenv("TEST_MODE") == "1":
     history_cache = None
-_init_lock = threading.Lock()
 
 
-def _load_initial_history() -> None:
+def _load_initial_history(exchange: Any) -> None:
     """Fetch and cache initial OHLCV history for configured symbols."""
-    if exchange is None or history_cache is None or pd is None:
+    if history_cache is None or pd is None:
         return
     symbols = [
         s.strip()
@@ -175,40 +176,61 @@ def _load_initial_history() -> None:
             logging.exception("Failed to prefetch history for %s: %s", sym, exc)
 
 
+def _close_exchange_instance(instance: Any) -> None:
+    close_method = getattr(instance, "close", None)
+    if callable(close_method):
+        close_method()
+
+
+def _create_exchange() -> Any:
+    exchange = ccxt.bybit(
+        {
+            'apiKey': os.getenv('BYBIT_API_KEY', ''),
+            'secret': os.getenv('BYBIT_API_SECRET', ''),
+        }
+    )
+    _load_initial_history(exchange)
+    return exchange
+
+
+exchange_provider = ExchangeProvider(_create_exchange, close=_close_exchange_instance)
+
+
+def _current_exchange() -> Any | None:
+    exchange = _exchange_ctx.get()
+    if exchange is not None:
+        return exchange
+    cached = exchange_provider.peek()
+    if cached is not None:
+        _exchange_ctx.set(cached)
+    return cached
+
+
 def init_exchange() -> None:
-    """Initialize the global ccxt Bybit exchange instance."""
-    global exchange
+    """Ensure the exchange is initialized before serving requests."""
+
     try:
-        exchange = ccxt.bybit(
-            {
-                'apiKey': os.getenv('BYBIT_API_KEY', ''),
-                'secret': os.getenv('BYBIT_API_SECRET', ''),
-            }
-        )
-        _load_initial_history()
+        exchange = exchange_provider.get()
     except Exception as exc:  # pragma: no cover - config errors
         logging.exception("Failed to initialize Bybit client: %s", exc)
         raise RuntimeError("Invalid Bybit configuration") from exc
+    else:
+        _exchange_ctx.set(exchange)
 
 
 if hasattr(app, "before_first_request"):
     app.before_first_request(init_exchange)
-else:
-    @app.before_request
-    def _ensure_exchange() -> None:
-        if exchange is None:
-            with _init_lock:
-                if exchange is None:
-                    init_exchange()
+
+
+@app.before_request
+def _bind_exchange() -> None:
+    exchange = exchange_provider.get()
+    _exchange_ctx.set(exchange)
+
 
 def close_exchange(_: BaseException | None = None) -> None:
     """Закрыть соединение с биржей при завершении контекста приложения."""
-    global exchange
-    if exchange is not None:
-        close_method = getattr(exchange, "close", None)
-        if callable(close_method):
-            close_method()
-        exchange = None
+    exchange_provider.close()
 
 if hasattr(app, "teardown_appcontext"):
     app.teardown_appcontext(close_exchange)
@@ -222,6 +244,7 @@ def price(symbol: str) -> ResponseReturnValue:
     auth_error = _require_api_key()
     if auth_error is not None:
         return auth_error
+    exchange = _current_exchange()
     if exchange is None:
         return jsonify({'error': 'exchange not initialized'}), 503
     try:
@@ -256,6 +279,7 @@ def history(symbol: str) -> ResponseReturnValue:
     auth_error = _require_api_key()
     if auth_error is not None:
         return auth_error
+    exchange = _current_exchange()
     if exchange is None:
         return jsonify({'error': 'exchange not initialized'}), 503
     timeframe = request.args.get('timeframe', '1m')

--- a/services/exchange_provider.py
+++ b/services/exchange_provider.py
@@ -1,0 +1,91 @@
+"""Thread-safe lazy provider for exchange-like singletons."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from threading import RLock
+from typing import Callable, Generator, Generic, TypeVar
+
+__all__ = ["ExchangeProvider"]
+
+T = TypeVar("T")
+
+
+class ExchangeProvider(Generic[T]):
+    """Provide a lazily constructed singleton instance with safe reuse.
+
+    The provider wraps a ``factory`` callable that creates the underlying
+    exchange instance on demand. The resulting object is cached until
+    :meth:`close` is called, at which point an optional ``close`` callback is
+    invoked and the cached instance is discarded.
+
+    The implementation is intentionally minimal yet thread-safe so it can be
+    reused both in Flask's multithreaded environment and in unit tests that
+    spawn concurrent requests.
+    """
+
+    def __init__(
+        self,
+        factory: Callable[[], T],
+        *,
+        close: Callable[[T], None] | None = None,
+    ) -> None:
+        self._factory = factory
+        self._close_cb = close
+        self._instance: T | None = None
+        self._lock = RLock()
+
+    def get(self) -> T:
+        """Return the cached instance, creating it on first access."""
+
+        instance = self._instance
+        if instance is not None:
+            return instance
+
+        with self._lock:
+            if self._instance is None:
+                self._instance = self._factory()
+            return self._instance
+
+    def peek(self) -> T | None:
+        """Return the cached instance without triggering initialization."""
+
+        return self._instance
+
+    def close(self) -> None:
+        """Dispose of the cached instance if present."""
+
+        instance: T | None
+        with self._lock:
+            instance = self._instance
+            self._instance = None
+
+        if instance is not None and self._close_cb is not None:
+            self._close_cb(instance)
+
+    @contextmanager
+    def lifespan(self) -> Generator[T, None, None]:
+        """Context manager that yields the active instance.
+
+        Upon exiting the context the cached instance is automatically
+        discarded. This helper is mainly used in tests to verify that the
+        provider cleans up correctly.
+        """
+
+        instance = self.get()
+        try:
+            yield instance
+        finally:
+            self.close()
+
+    def override(self, instance: T | None) -> None:
+        """Manually set the cached instance for tests.
+
+        Passing ``None`` clears the provider without executing the close
+        callback. This method is intentionally lightweight and is only used
+        inside unit tests that monkeypatch service dependencies.
+        """
+
+        with self._lock:
+            self._instance = instance
+

--- a/tests/test_exchange_provider.py
+++ b/tests/test_exchange_provider.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from services.exchange_provider import ExchangeProvider
+
+
+def test_exchange_provider_lazy_initialization_and_close():
+    created = []
+    closed = []
+
+    def factory():
+        obj = object()
+        created.append(obj)
+        return obj
+
+    provider: ExchangeProvider[object] = ExchangeProvider(factory, close=closed.append)
+
+    first = provider.get()
+    second = provider.get()
+
+    assert first is second
+    assert len(created) == 1
+
+    provider.close()
+    assert closed == [first]
+
+    third = provider.get()
+    assert third is not first
+    assert len(created) == 2
+
+
+def test_exchange_provider_thread_safe_initialization():
+    barrier = threading.Barrier(5)
+    created = []
+
+    def factory():
+        obj = object()
+        created.append(obj)
+        return obj
+
+    provider: ExchangeProvider[object] = ExchangeProvider(factory)
+    results: list[object] = []
+
+    def worker():
+        barrier.wait()
+        results.append(provider.get())
+
+    threads = [threading.Thread(target=worker) for _ in range(5)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(created) == 1
+    assert len(set(id(result) for result in results)) == 1
+
+
+def test_exchange_provider_override_for_tests():
+    provider: ExchangeProvider[object] = ExchangeProvider(object)
+
+    fake = object()
+    provider.override(fake)
+    assert provider.get() is fake
+
+    provider.override(None)
+    new_obj = provider.get()
+    assert new_obj is not fake

--- a/tests/test_trade_manager_routes.py
+++ b/tests/test_trade_manager_routes.py
@@ -69,7 +69,8 @@ def _setup_module(monkeypatch):
         run=dummy_coroutine,
         get_stats=lambda: {"win_rate": 1.0},
     )
-    tm.trade_manager = stub
+    tm.trade_manager_factory.reset()
+    tm.trade_manager_factory.set(stub, loop=loop)
     tm._ready_event.set()
     monkeypatch.delenv("TEST_MODE", raising=False)
     return tm, loop, stub

--- a/tests/test_trade_manager_service_api.py
+++ b/tests/test_trade_manager_service_api.py
@@ -11,7 +11,9 @@ def _reset_positions(tmp_path, monkeypatch):
     monkeypatch.setattr(tms, 'POSITIONS_FILE', cache_file)
     monkeypatch.setattr(tms, 'POSITIONS', [])
     monkeypatch.setattr(tms, 'API_TOKEN', 'test-token')
+    tms.exchange_provider.override(None)
     yield
+    tms.exchange_provider.close()
 
 
 def _post_open_position(client, payload):
@@ -47,7 +49,7 @@ def test_open_position_records_even_when_stop_loss_fails(monkeypatch):
             return {'id': order_id}
 
     exchange = ExchangeWithCancel()
-    monkeypatch.setattr(tms, 'exchange', exchange)
+    tms.exchange_provider.override(exchange)
 
     with tms.app.test_client() as client:
         response = _post_open_position(
@@ -89,7 +91,7 @@ def test_open_position_emergency_close_when_cancel_unavailable(monkeypatch):
             return {'id': 'other'}
 
     exchange = ExchangeWithoutCancel()
-    monkeypatch.setattr(tms, 'exchange', exchange)
+    tms.exchange_provider.override(exchange)
 
     with tms.app.test_client() as client:
         response = _post_open_position(

--- a/tests/test_trade_manager_service_sync.py
+++ b/tests/test_trade_manager_service_sync.py
@@ -16,7 +16,7 @@ def _reload_service(monkeypatch, tmp_path, exchange):
     service = importlib.reload(importlib.import_module('services.trade_manager_service'))
     service.POSITIONS_FILE = tmp_path / 'positions.json'
     service.POSITIONS[:] = []
-    service.exchange = exchange
+    service.exchange_provider.override(exchange)
     # Bandit: a placeholder token is used solely for fixture initialisation.
     service.API_TOKEN = 'token'  # nosec
     return service
@@ -41,7 +41,7 @@ def test_sync_removes_closed_positions(monkeypatch, tmp_path):
     ]
     service._save_positions()
 
-    service._sync_positions_with_exchange()
+    service._sync_positions_with_exchange(exchange)
 
     assert [pos['id'] for pos in service.POSITIONS] == ['2']
     with service.POSITIONS_FILE.open('r', encoding='utf-8') as fh:


### PR DESCRIPTION
## Summary
- add a reusable ExchangeProvider for lazily initializing exchange clients and adopt it in the data handler and trade manager services
- refactor the trade manager service to manage its singleton instance through a thread-safe factory and update routes to rely on injected dependencies
- extend tests to cover the new provider behaviour and adapt existing service tests to the non-global interfaces

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d59f5e2f88832da0831501701eae26