### PR TITLE
Add offline trade manager integration tests and update CI filters

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Run pytest
         run: |
           set -o pipefail
-          timeout 25m pytest -ra | tee pytest.log || code=$?
+          timeout 25m pytest -ra -m "not integration" | tee pytest.log || code=$?
           exit $code
       - name: Upload pytest log
         if: always()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,4 @@
 [pytest]
-addopts = -m "not integration"
 asyncio_mode = auto
 markers =
     integration: marks tests that require external services or slower integration steps

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+# Integration test package for offline service scenarios.

--- a/tests/integration/test_offline_trade_manager_service.py
+++ b/tests/integration/test_offline_trade_manager_service.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("flask")
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture()
+def offline_trade_manager(monkeypatch, tmp_path):
+    """Provide a TradeManager service configured for offline integration tests."""
+
+    # Ensure offline stubs are enabled and clean credentials are generated.
+    monkeypatch.setenv("OFFLINE_MODE", "1")
+    monkeypatch.setenv("TEST_MODE", "1")
+    monkeypatch.delenv("TRADE_MANAGER_TOKEN", raising=False)
+
+    module_name = "services.trade_manager_service"
+    original_module = sys.modules.pop(module_name, None)
+    try:
+        module = importlib.import_module(module_name)
+        module = importlib.reload(module)
+
+        offline_mod = importlib.import_module("services.offline")
+        monkeypatch.setattr(module.ccxt, "bybit", offline_mod.OfflineBybit)
+
+        # Normalise ccxt exception hierarchy for the stub environment.
+        class NetworkError(Exception):
+            pass
+
+        class BadRequestError(Exception):
+            pass
+
+        monkeypatch.setattr(module, "CCXT_BASE_ERROR", Exception)
+        monkeypatch.setattr(module, "CCXT_NETWORK_ERROR", NetworkError)
+        monkeypatch.setattr(module, "CCXT_BAD_REQUEST", BadRequestError)
+
+        cache_file = tmp_path / "positions.json"
+        monkeypatch.setattr(module, "POSITIONS_FILE", cache_file)
+        module.POSITIONS.clear()
+        if cache_file.exists():
+            cache_file.unlink()
+        module._load_positions()
+
+        module.init_exchange()
+
+        with module.app.test_client() as client:
+            yield module, client, NetworkError
+    finally:
+        module = sys.modules.pop(module_name, None)
+        if original_module is not None:
+            sys.modules[module_name] = original_module
+        if module is not None:
+            module.exchange = None
+
+
+def test_offline_open_close_cycle(offline_trade_manager):
+    module, client, _ = offline_trade_manager
+
+    open_payload = {
+        "symbol": "BTCUSDT",
+        "side": "buy",
+        "amount": 1,
+        "price": 25_000.0,
+    }
+    response = client.post("/open_position", json=open_payload)
+    assert response.status_code == 200
+
+    payload = response.get_json()
+    assert payload["status"] == "ok"
+    order_id = payload["order_id"]
+
+    positions_path = Path(module.POSITIONS_FILE)
+    assert positions_path.exists(), "position cache should be created"
+    cache_data = json.loads(positions_path.read_text("utf-8"))
+    assert cache_data and cache_data[0]["id"] == order_id
+
+    close_payload = {"order_id": order_id, "side": "sell"}
+    close_response = client.post("/close_position", json=close_payload)
+    assert close_response.status_code == 200
+    close_data = close_response.get_json()
+    assert close_data["status"] == "ok"
+
+    # Positions should be cleared after the successful close request.
+    assert module.POSITIONS == []
+
+
+def test_offline_open_position_network_degradation(monkeypatch, offline_trade_manager):
+    module, client, network_error = offline_trade_manager
+
+    original_create_order = module.exchange.create_order
+
+    def flaky_create_order(*args, **kwargs):
+        raise network_error("temporary outage")
+
+    monkeypatch.setattr(module.exchange, "create_order", flaky_create_order)
+
+    response = client.post(
+        "/open_position",
+        json={"symbol": "ETHUSDT", "side": "buy", "amount": 1, "price": 1_500.0},
+    )
+    assert response.status_code == 503
+    payload = response.get_json()
+    assert payload["error"] == "network error contacting exchange"
+    assert module.POSITIONS == []
+
+    # Restore the original implementation so subsequent tests can reuse the fixture safely.
+    monkeypatch.setattr(module.exchange, "create_order", original_create_order)
+
+
+def test_offline_close_position_network_degradation(monkeypatch, offline_trade_manager):
+    module, client, network_error = offline_trade_manager
+
+    open_response = client.post(
+        "/open_position",
+        json={"symbol": "SOLUSDT", "side": "buy", "amount": 2, "price": 40.0},
+    )
+    order_id = open_response.get_json()["order_id"]
+    assert module.POSITIONS and module.POSITIONS[0]["id"] == order_id
+
+    original_create_order = module.exchange.create_order
+
+    def failing_close(symbol, order_type, side, amount, price=None, params=None):
+        raise network_error("connection reset")
+
+    monkeypatch.setattr(module.exchange, "create_order", failing_close)
+
+    close_response = client.post(
+        "/close_position", json={"order_id": order_id, "side": "sell"}
+    )
+    assert close_response.status_code == 503
+    payload = close_response.get_json()
+    assert payload["error"] == "network error contacting exchange"
+
+    # Original position should remain intact so operators can retry.
+    assert module.POSITIONS and module.POSITIONS[0]["id"] == order_id
+
+    monkeypatch.setattr(module.exchange, "create_order", original_create_order)
+
+
+def test_offline_recovers_from_corrupted_cache(offline_trade_manager):
+    module, client, _ = offline_trade_manager
+
+    module.POSITIONS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    module.POSITIONS_FILE.write_text("{not-valid-json", encoding="utf-8")
+
+    # Corrupted cache should be ignored when reloading state.
+    module._load_positions()
+    assert module.POSITIONS == []
+
+    response = client.post(
+        "/open_position",
+        json={"symbol": "XRPUSDT", "side": "buy", "amount": 3, "price": 0.5},
+    )
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["status"] == "ok"
+
+    # The cache file must now contain valid JSON describing the new position.
+    cache_data = json.loads(module.POSITIONS_FILE.read_text("utf-8"))
+    assert cache_data and cache_data[0]["id"] == payload["order_id"]


### PR DESCRIPTION
## Summary
- add offline integration tests for the trade manager service covering offline success paths and failure scenarios
- allow pytest to collect integration tests by default and only exclude them in the slow CPU CI job

## Testing
- pytest tests/integration/test_offline_trade_manager_service.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d59f74a614832d8d608c91b7f97bb0