### PR TITLE
Refactor trade manager services to share server bootstrap logic

### DIFF
--- a/bot/trade_manager/server_common.py
+++ b/bot/trade_manager/server_common.py
@@ -1,0 +1,174 @@
+"""Shared helpers for TradeManager services and package entrypoints."""
+
+from __future__ import annotations
+
+import hmac
+import logging
+import os
+from contextvars import ContextVar
+from types import SimpleNamespace
+from typing import Any, Callable, Mapping
+
+from bot.config import load_config
+from bot.dotenv_utils import load_dotenv
+from services.exchange_provider import ExchangeProvider
+
+__all__ = [
+    "load_environment",
+    "get_api_token",
+    "extract_request_token",
+    "validate_token",
+    "load_trade_manager_config",
+    "ExchangeRuntime",
+]
+
+logger = logging.getLogger(__name__)
+
+
+def load_environment() -> None:
+    """Load environment variables from ``.env`` when available."""
+
+    load_dotenv()
+
+
+def get_api_token() -> str | None:
+    """Return the configured TradeManager API token if present."""
+
+    token = os.getenv("TRADE_MANAGER_TOKEN")
+    if token is None:
+        return None
+    token = token.strip()
+    return token or None
+
+
+def extract_request_token(headers: Mapping[str, str]) -> str:
+    """Extract the bearer token value from common header names."""
+
+    token = headers.get("Authorization", "")
+    if token.lower().startswith("bearer "):
+        token = token[7:]
+    else:
+        token = headers.get("X-API-KEY", token)
+    return token.strip()
+
+
+def validate_token(headers: Mapping[str, str], expected: str | None) -> str | None:
+    """Return a rejection reason when a request token is invalid."""
+
+    if not expected:
+        return None
+    token = extract_request_token(headers)
+    if not token:
+        return "missing token"
+    if not hmac.compare_digest(token, expected):
+        return "token mismatch"
+    return None
+
+
+def load_trade_manager_config(path: str = "config.json") -> Any:
+    """Load the TradeManager configuration using the shared loader."""
+
+    return load_config(path)
+
+
+def _allow_offline_mode() -> bool:
+    return (
+        os.getenv("OFFLINE_MODE") == "1"
+        or os.getenv("TEST_MODE") == "1"
+        or os.getenv("TRADE_MANAGER_USE_STUB") == "1"
+    )
+
+
+def _close_exchange_instance(instance: Any) -> None:
+    close_method = getattr(instance, "close", None)
+    if callable(close_method):
+        close_method()
+
+
+class ExchangeRuntime:
+    """Manage initialization and reuse of a single Bybit exchange instance."""
+
+    def __init__(
+        self,
+        *,
+        service_name: str,
+        context_name: str,
+        after_create: Callable[[Any], None] | None = None,
+    ) -> None:
+        self._logger = logging.getLogger(service_name)
+        self._context: ContextVar[Any | None] = ContextVar(context_name, default=None)
+        self._after_create = after_create
+        self._ccxt = self._ensure_ccxt(service_name)
+        self.ccxt_base_error = getattr(self._ccxt, "BaseError", Exception)
+        self.ccxt_network_error = getattr(
+            self._ccxt, "NetworkError", self.ccxt_base_error
+        )
+        self.ccxt_bad_request = getattr(
+            self._ccxt, "BadRequest", self.ccxt_base_error
+        )
+        self.provider = ExchangeProvider(self._create_exchange, close=_close_exchange_instance)
+
+    def _ensure_ccxt(self, service_name: str):
+        try:  # optional dependency
+            import ccxt  # type: ignore
+        except ImportError as exc:  # pragma: no cover - optional in offline mode
+            if _allow_offline_mode():
+                self._logger.warning(
+                    "`ccxt` не найден: %s использует OfflineBybit. "
+                    "Для работы с реальной биржей установите `pip install ccxt`.",
+                    service_name,
+                )
+                from services.offline import OfflineBybit
+
+                return SimpleNamespace(  # type: ignore[return-value]
+                    bybit=OfflineBybit,
+                    BaseError=Exception,
+                    NetworkError=Exception,
+                    BadRequest=Exception,
+                )
+            self._logger.critical(
+                "Библиотека `ccxt` обязательна для %s. Установите её через "
+                "`pip install ccxt` или активируйте OFFLINE_MODE=1.",
+                service_name,
+            )
+            raise ImportError(
+                "TradeManager не может работать без зависимости `ccxt`."
+            ) from exc
+        return ccxt
+
+    def _create_exchange(self) -> Any:
+        exchange = self._ccxt.bybit(
+            {
+                "apiKey": os.getenv("BYBIT_API_KEY", ""),
+                "secret": os.getenv("BYBIT_API_SECRET", ""),
+            }
+        )
+        if self._after_create is not None:
+            self._after_create(exchange)
+        return exchange
+
+    def current(self) -> Any | None:
+        exchange = self._context.get()
+        if exchange is not None:
+            return exchange
+        cached = self.provider.peek()
+        if cached is not None:
+            self._context.set(cached)
+        return cached
+
+    def bind(self) -> Any:
+        exchange = self.provider.get()
+        self._context.set(exchange)
+        return exchange
+
+    def init(self) -> Any:
+        try:
+            exchange = self.provider.get()
+        except Exception as exc:  # pragma: no cover - config errors
+            logging.exception("Failed to initialize Bybit client: %s", exc)
+            raise RuntimeError("Invalid Bybit configuration") from exc
+        self._context.set(exchange)
+        return exchange
+
+    def reset_context(self) -> None:
+        self._context.set(None)

--- a/tests/test_trade_manager_server_common.py
+++ b/tests/test_trade_manager_server_common.py
@@ -1,0 +1,127 @@
+import asyncio
+import importlib
+import sys
+import types
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_create_trade_manager_uses_shared_config(monkeypatch):
+    import bot.trade_manager
+
+    module = importlib.reload(bot.trade_manager.service)
+    from bot.trade_manager import server_common
+
+    sentinel_cfg = {"ray_num_cpus": 1}
+    called = {}
+
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "")
+
+    def fake_load(path="config.json"):
+        called["path"] = path
+        return sentinel_cfg
+
+    monkeypatch.setattr(server_common, "load_trade_manager_config", fake_load)
+
+    class DummyDataHandler:
+        def __init__(self, cfg, telegram_bot, chat_id):
+            assert cfg is sentinel_cfg
+            self.feature_callback = None
+            self.usdt_pairs = []
+
+        async def load_initial(self):
+            return None
+
+        async def stop(self):
+            return None
+
+        async def subscribe_to_klines(self, pairs):
+            return None
+
+    class DummyModelBuilder:
+        def __init__(self, cfg, data_handler, trade_manager):
+            assert cfg is sentinel_cfg
+            self.precompute_features = lambda *_, **__: None
+
+        async def train(self):
+            return None
+
+        async def backtest_loop(self):
+            return None
+
+    class DummyTradeManager:
+        def __init__(self, cfg, dh, mb, bot, chat_id):
+            assert cfg is sentinel_cfg
+            self.loop = asyncio.get_event_loop()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "bot.data_handler",
+        types.SimpleNamespace(DataHandler=DummyDataHandler),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "bot.model_builder",
+        types.SimpleNamespace(ModelBuilder=DummyModelBuilder),
+    )
+    monkeypatch.setattr(module, "TradeManager", DummyTradeManager)
+    monkeypatch.setattr(module.ray, "is_initialized", lambda: True)
+
+    module.trade_manager_factory.reset()
+    try:
+        manager = await module.create_trade_manager()
+    finally:
+        module.trade_manager_factory.reset()
+
+    assert manager is not None
+    assert called["path"] == "config.json"
+
+
+def test_package_service_uses_common_token_validator(monkeypatch):
+    import bot.trade_manager
+
+    module = importlib.reload(bot.trade_manager.service)
+    from bot.trade_manager import server_common
+
+    calls: list[tuple[dict, str | None]] = []
+
+    def fake_validate(headers, expected):
+        calls.append((dict(headers), expected))
+        return "missing token"
+
+    monkeypatch.setattr(server_common, "validate_token", fake_validate)
+    module.TRADE_MANAGER_TOKEN = "token"
+    module.IS_TEST_MODE = False
+
+    with module.api_app.test_request_context(
+        "/open_position", method="POST", json={"symbol": "BTC"}
+    ):
+        response = module._require_token()
+
+    assert calls
+    assert response[1] == 401
+
+
+def test_flask_service_uses_common_token_validator(monkeypatch):
+    module = importlib.reload(importlib.import_module("services.trade_manager_service"))
+    from bot.trade_manager import server_common
+
+    calls: list[tuple[dict, str | None]] = []
+
+    def fake_validate(headers, expected):
+        calls.append((dict(headers), expected))
+        return "token mismatch"
+
+    monkeypatch.setattr(server_common, "validate_token", fake_validate)
+    module.API_TOKEN = "token"
+    module.IS_TEST_MODE = False
+
+    with module.app.test_request_context(
+        "/open_position", method="POST", json={"symbol": "BTC"}
+    ):
+        response = module._require_api_token()
+
+    assert calls
+    assert response[1] == 401


### PR DESCRIPTION
## Summary
- extract shared TradeManager server helpers for environment loading, token validation, configuration and exchange lifecycle
- update the Flask service and bot.trade_manager package to call the shared helpers instead of duplicating logic
- add regression tests that exercise both entrypoints through the shared implementation

## Testing
- pytest tests/test_trade_manager_server_common.py
- pytest tests/test_trade_manager_service_api.py tests/test_trade_manager_service_sync.py

------
https://chatgpt.com/codex/tasks/task_e_68d5a5408af4832daf6bd6e7e8a795a3