### PR TITLE
Handle utils stubs safely for Dependabot tests

### DIFF
--- a/bot/trade_manager/__init__.py
+++ b/bot/trade_manager/__init__.py
@@ -15,7 +15,10 @@ if OFFLINE_MODE:
     __all__ = ["TradeManager", "TelegramLogger"]
 else:  # pragma: no cover - реальная инициализация
     from bot.http_client import close_async_http_client, get_async_http_client
-    from bot.utils import TelegramLogger
+    from bot.utils_loader import require_utils
+
+    _utils = require_utils("TelegramLogger")
+    TelegramLogger = _utils.TelegramLogger
 
     from .core import TradeManager
     from .service import (

--- a/bot/trade_manager/service.py
+++ b/bot/trade_manager/service.py
@@ -247,7 +247,9 @@ async def create_trade_manager() -> TradeManager | None:
     manager = TradeManager(cfg, dh, mb, telegram_bot, chat_id)
     logger.info("Экземпляр TradeManager создан")
     if telegram_bot:
-        from bot.utils import TelegramUpdateListener
+        from bot.utils_loader import require_utils
+
+        TelegramUpdateListener = require_utils("TelegramUpdateListener").TelegramUpdateListener
 
         listener = TelegramUpdateListener(telegram_bot)
 

--- a/bot/utils_loader.py
+++ b/bot/utils_loader.py
@@ -1,0 +1,67 @@
+"""Utility loader that tolerates lightweight test stubs."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Iterable
+
+_UTILS_CACHE: ModuleType | None = None
+
+
+def _load_from_source() -> ModuleType:
+    """Load the real ``utils`` module directly from its source file."""
+
+    global _UTILS_CACHE
+    if _UTILS_CACHE is not None:
+        return _UTILS_CACHE
+
+    project_root = Path(__file__).resolve().parent.parent
+    utils_path = project_root / "utils.py"
+    spec = importlib.util.spec_from_file_location("_bot_real_utils", utils_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load utils module from {utils_path!s}")
+
+    module = importlib.util.module_from_spec(spec)
+    loader = spec.loader
+    assert loader is not None
+    loader.exec_module(module)  # type: ignore[arg-type]
+    sys.modules.setdefault("_bot_real_utils", module)
+    _UTILS_CACHE = module
+    return module
+
+
+def _get_candidate(name: str) -> ModuleType | None:
+    module = sys.modules.get(name)
+    if module is not None:
+        return module
+    try:
+        return importlib.import_module(name)
+    except Exception:
+        return None
+
+
+def require_utils(*required_names: str) -> ModuleType:
+    """Return a utils-like module containing the requested attributes."""
+
+    names: Iterable[str] = required_names or ()
+
+    for candidate_name in ("utils", "bot.utils"):
+        candidate = _get_candidate(candidate_name)
+        if candidate is None:
+            continue
+        if all(hasattr(candidate, attr) for attr in names):
+            return candidate
+
+    module = _load_from_source()
+    missing = [name for name in names if not hasattr(module, name)]
+    if missing:
+        joined = ", ".join(sorted(missing))
+        raise ImportError(f"utils module missing required attributes: {joined}")
+    return module
+
+
+__all__ = ["require_utils"]

--- a/model_builder.py
+++ b/model_builder.py
@@ -29,13 +29,21 @@ from bot.cache import HistoricalDataCache
 from bot.config import BotConfig
 from bot.dotenv_utils import load_dotenv
 from bot.ray_compat import IS_RAY_STUB, ray
-from bot.utils import (
-    check_dataframe_empty,
-    ensure_writable_directory,
-    is_cuda_available,
-    logger,
-    validate_host,
+from bot.utils_loader import require_utils
+
+_utils = require_utils(
+    "check_dataframe_empty",
+    "ensure_writable_directory",
+    "is_cuda_available",
+    "logger",
+    "validate_host",
 )
+
+check_dataframe_empty = _utils.check_dataframe_empty
+ensure_writable_directory = _utils.ensure_writable_directory
+is_cuda_available = _utils.is_cuda_available
+logger = _utils.logger
+validate_host = _utils.validate_host
 from models.architectures import KERAS_FRAMEWORKS, create_model
 from security import (
     ArtifactDeserializationError,

--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -22,7 +22,7 @@ from flask import Flask, jsonify, request
 from numpy.typing import NDArray
 
 from bot.dotenv_utils import load_dotenv
-from bot.utils import ensure_writable_directory
+from bot.utils_loader import require_utils
 from services.logging_utils import sanitize_log_value
 from security import (
     ArtifactDeserializationError,
@@ -32,7 +32,10 @@ from security import (
     verify_model_state_signature,
     write_model_state_signature,
 )
-from utils import safe_int, validate_host
+_utils = require_utils("ensure_writable_directory", "safe_int", "validate_host")
+ensure_writable_directory = _utils.ensure_writable_directory
+safe_int = _utils.safe_int
+validate_host = _utils.validate_host
 
 _FILENAME_STRIP_RE = re.compile(r"[^A-Za-z0-9_.-]")
 _FILENAME_HYPHEN_RE = re.compile(r"[-\s]+")

--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -23,7 +23,11 @@ except Exception:  # pragma: no cover - fallback when flask.typing missing
     ResponseReturnValue = Any  # type: ignore
 
 from bot.trade_manager import server_common
-from bot.utils import validate_host, safe_int
+from bot.utils_loader import require_utils
+
+_utils = require_utils("validate_host", "safe_int")
+validate_host = _utils.validate_host
+safe_int = _utils.safe_int
 from services.logging_utils import sanitize_log_value
 
 server_common.load_environment()

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import importlib
+import sys
 import warnings
 
 warnings.warn(
@@ -12,5 +14,8 @@ warnings.warn(
     DeprecationWarning,
     stacklevel=2,
 )
+
+if "bot.trade_manager" in sys.modules:
+    importlib.reload(sys.modules["bot.trade_manager"])
 
 from bot.trade_manager import *  # noqa: F401,F403


### PR DESCRIPTION
## Summary
- add a resilient loader that returns either the lightweight test stub or the real utils module when Dependabot workflows import code
- teach model builder and trade manager services to load helpers through the new loader so they work even when tests inject stubs
- harden the TelegramLogger import fallback and avoid stopping the event loop in test mode so async tests complete cleanly

## Testing
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_e_68d67784157c832dab848c9db6e4abb5