### PR TITLE
Fix CI lint and typing issues

### DIFF
--- a/bot/trade_manager/__init__.py
+++ b/bot/trade_manager/__init__.py
@@ -6,11 +6,22 @@
 ``sys.path`` или ``noqa``.
 """
 
+from typing import TYPE_CHECKING, Any, cast
+
 from bot.config import OFFLINE_MODE
 
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .core import TradeManager as TradeManagerType
+    from telegram_logger import TelegramLogger as TelegramLoggerType
+else:
+    TradeManagerType = Any
+    TelegramLoggerType = Any
+
 if OFFLINE_MODE:
-    from services.offline import OfflineBybit as TradeManager
-    from services.offline import OfflineTelegram as TelegramLogger
+    from services.offline import OfflineBybit, OfflineTelegram
+
+    TradeManager = cast(type[TradeManagerType], OfflineBybit)
+    TelegramLogger = cast(type[TelegramLoggerType], OfflineTelegram)
 
     __all__ = ["TradeManager", "TelegramLogger"]
 else:  # pragma: no cover - реальная инициализация
@@ -18,9 +29,9 @@ else:  # pragma: no cover - реальная инициализация
     from bot.utils_loader import require_utils
 
     _utils = require_utils("TelegramLogger")
-    TelegramLogger = _utils.TelegramLogger
+    TelegramLogger = cast(type[TelegramLoggerType], _utils.TelegramLogger)
 
-    from .core import TradeManager
+    from .core import TradeManager as _TradeManager
     from .service import (
         InvalidHostError,
         api_app,
@@ -31,6 +42,8 @@ else:  # pragma: no cover - реальная инициализация
         _resolve_host,
         _ready_event,
     )
+
+    TradeManager = cast(type[TradeManagerType], _TradeManager)
 
     # Псевдонимы синхронных помощников оставлены для обратной совместимости
     get_http_client = get_async_http_client

--- a/bot/trade_manager/service.py
+++ b/bot/trade_manager/service.py
@@ -10,7 +10,7 @@ import json
 import os
 import sys
 import threading
-from typing import Any
+from typing import Any, Mapping, cast
 
 import httpx
 from bot.ray_compat import ray
@@ -142,7 +142,10 @@ def _require_token() -> tuple[Any, int] | None:
         return None
     if not TRADE_MANAGER_TOKEN:
         return jsonify({"error": "unauthorized"}), 401
-    reason = server_common.validate_token(request.headers, TRADE_MANAGER_TOKEN)
+    header_mapping: Mapping[str, str] = cast(
+        Mapping[str, str], {key: value for key, value in request.headers.items()}
+    )
+    reason = server_common.validate_token(header_mapping, TRADE_MANAGER_TOKEN)
     if reason is None:
         return None
     return jsonify({"error": "unauthorized"}), 401

--- a/tests/test_exchange_provider.py
+++ b/tests/test_exchange_provider.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import threading
 
-import pytest
-
 from services.exchange_provider import ExchangeProvider
 
 


### PR DESCRIPTION
## Summary
- clean up ExchangeProvider tests by removing an unused pytest import
- improve TradeManager typing helpers and async telegram notification handling to satisfy mypy
- normalize token validation headers in the TradeManager service for stricter typing

## Testing
- `python -m ruff check bot tests`
- `python -m mypy bot`
- `python -m bandit -r bot -x tests -ll`
- `python -m flake8 .`
- `pytest -m "not integration"`


------
https://chatgpt.com/codex/tasks/task_e_68d684a1a3d4832dad12ea2f99d33fd5