### PR TITLE
Fix health check script import path

### DIFF
--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -4,7 +4,12 @@ import logging
 import os
 import re
 import sys
+from pathlib import Path
 from typing import Iterable, Set
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
 
 from ipaddress import ip_address
 from urllib.parse import urlparse, urlunparse


### PR DESCRIPTION
## Summary
- ensure the health check script prepends the repository root to sys.path
- keep health check imports working when executed as a standalone script

## Testing
- TEST_MODE=1 python scripts/health_check.py

------
https://chatgpt.com/codex/tasks/task_e_68d6925b1bac832d8f81bef8c84acef2