### PR TITLE
Fix data handler auth flow and offline exchange hooks

### DIFF
--- a/bot/trade_manager/server_common.py
+++ b/bot/trade_manager/server_common.py
@@ -108,6 +108,12 @@ class ExchangeRuntime:
         )
         self.provider = ExchangeProvider(self._create_exchange, close=_close_exchange_instance)
 
+    @property
+    def ccxt(self) -> Any:
+        """Expose the loaded ``ccxt`` module for consumers and tests."""
+
+        return self._ccxt
+
     def _ensure_ccxt(self, service_name: str):
         try:  # optional dependency
             import ccxt  # type: ignore


### PR DESCRIPTION
## Summary
- expose the ccxt module from ExchangeRuntime and make the trade manager service retain the active exchange for tests
- relax data handler authentication only when the development server is running in offline or test mode while keeping Flask shims compatible
- gate anonymous access logging to avoid interfering with unit tests and ensure Flask imports succeed with minimal stubs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8110dfc68832da9a76a17d2886a71