### PR TITLE
Fix data handler provider typing and header validation

### DIFF
--- a/services/data_handler_service.py
+++ b/services/data_handler_service.py
@@ -223,7 +223,10 @@ def _current_exchange() -> Any | None:
     exchange = _exchange_ctx.get()
     if exchange is not None:
         return exchange
-    cached = exchange_provider.peek()
+    provider = exchange_provider
+    if provider is None:
+        return None
+    cached = provider.peek()
     if cached is not None:
         _exchange_ctx.set(cached)
     return cached
@@ -232,8 +235,11 @@ def _current_exchange() -> Any | None:
 def init_exchange() -> None:
     """Ensure the exchange is initialized before serving requests."""
 
+    provider = exchange_provider
+    if provider is None:
+        raise RuntimeError("Exchange provider is not configured")
     try:
-        exchange = exchange_provider.get()
+        exchange = provider.get()
     except Exception as exc:  # pragma: no cover - config errors
         logging.exception("Failed to initialize Bybit client: %s", exc)
         raise RuntimeError("Invalid Bybit configuration") from exc
@@ -247,13 +253,19 @@ if hasattr(app, "before_first_request"):
 
 @app.before_request
 def _bind_exchange() -> None:
-    exchange = exchange_provider.get()
+    provider = exchange_provider
+    if provider is None:
+        raise RuntimeError("Exchange provider is not configured")
+    exchange = provider.get()
     _exchange_ctx.set(exchange)
 
 
 def close_exchange(_: BaseException | None = None) -> None:
     """Закрыть соединение с биржей при завершении контекста приложения."""
-    exchange_provider.close()
+    provider = exchange_provider
+    if provider is None:
+        return
+    provider.close()
 
 if hasattr(app, "teardown_appcontext"):
     app.teardown_appcontext(close_exchange)

--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -7,7 +7,7 @@ environment variables.
 
 from flask import Flask, request, jsonify
 from werkzeug.exceptions import BadRequest
-from typing import Any
+from typing import Any, Mapping, cast
 from pathlib import Path
 import json
 import logging
@@ -84,7 +84,8 @@ def _require_api_token() -> ResponseReturnValue | None:
     if not expected:
         return None
 
-    reason = server_common.validate_token(request.headers, expected)
+    headers: Mapping[str, str] = cast(Mapping[str, str], request.headers)
+    reason = server_common.validate_token(headers, expected)
 
     if reason is not None:
         remote = request.headers.get('X-Forwarded-For') or request.remote_addr or 'unknown'


### PR DESCRIPTION
## Summary
- guard access to the exchange provider in the data handler service so optional configurations are handled safely
- cast Flask headers to a mapping before token validation in the trade manager service to satisfy type checking

## Testing
- python -m mypy --exclude venv .
- python -m flake8 --exclude venv .
- pytest -ra -m 'not integration'


------
https://chatgpt.com/codex/tasks/task_e_68d8111add58832d94d778ddc66bd9cf