### PR TITLE
Fix data handler auto allow when Flask current_app missing

### DIFF
--- a/services/data_handler_service.py
+++ b/services/data_handler_service.py
@@ -139,10 +139,12 @@ def _require_api_key() -> "ResponseReturnValue | None":
 
         if auto_allow_reason is not None:
             is_testing_client = False
-            try:
-                flask_app = current_app._get_current_object()
-            except Exception:
-                flask_app = app
+            flask_app: Any = app
+            if current_app is not None:
+                try:
+                    flask_app = current_app._get_current_object()
+                except Exception:
+                    flask_app = app
             if getattr(flask_app, "testing", False):
                 is_testing_client = True
             elif request.environ.get("werkzeug.test"):


### PR DESCRIPTION
## Summary
- guard access to the Flask `current_app` proxy before dereferencing in the data handler service to avoid mypy errors when it is absent

## Testing
- python -m mypy --exclude venv .
- pytest -ra -m "not integration"


------
https://chatgpt.com/codex/tasks/task_e_68d81ab478f4832d88ce4cb8550c5740