### PR TITLE
Fix Dependabot workflow conditionals

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -79,7 +79,9 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
       - name: Install dependencies
-        if: ${{ steps.metadata.outputs['package-ecosystem'] == 'pip' && github.event.pull_request.head.repo.full_name == github.repository }}
+        if: >-
+          steps.metadata.outputs['package-ecosystem'] == 'pip' &&
+          github.event.pull_request.head.repo.full_name == github.repository
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements-ci.txt
@@ -92,7 +94,9 @@ jobs:
       # resolving the entire environment from scratch, keeping the job fast
       # while still validating the new packages.
       - name: Install Dependabot updates
-        if: ${{ steps.metadata.outputs['package-ecosystem'] == 'pip' && github.event.pull_request.head.repo.full_name == github.repository }}
+        if: >-
+          steps.metadata.outputs['package-ecosystem'] == 'pip' &&
+          github.event.pull_request.head.repo.full_name == github.repository
         env:
           DEPENDENCIES_JSON: ${{ steps.metadata.outputs['updated-dependencies-json'] }}
         run: |
@@ -141,7 +145,9 @@ jobs:
       # the main CI.  If any test fails this step will surface the
       # error and prevent automatic merging of the pull request.
       - name: Run unit tests
-        if: ${{ steps.metadata.outputs['package-ecosystem'] == 'pip' && github.event.pull_request.head.repo.full_name == github.repository }}
+        if: >-
+          steps.metadata.outputs['package-ecosystem'] == 'pip' &&
+          github.event.pull_request.head.repo.full_name == github.repository
         run: pytest -m "not integration" -q
 
       - name: Check auto-merge availability


### PR DESCRIPTION
## Summary
- fix the pip-specific steps in the Dependabot workflow so the repository ownership check no longer breaks across line continuations
- format the conditional with a folded multi-line expression to keep the automation readable and functional

## Testing
- n/a (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d841ee902c832dbc24a96d84662da7