### PR TITLE
Ensure dependency graph workflow filters ccxtpro case-insensitively

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -171,9 +171,10 @@ jobs:
                   filtered: list[str] = []
                   for line in lines:
                       stripped = line.lstrip()
-                      if stripped.startswith("ccxtpro"):
+                      stripped_lower = stripped.lower()
+                      if stripped_lower.startswith("ccxtpro"):
                           continue
-                      if stripped.startswith("#") and "ccxtpro" in stripped:
+                      if stripped_lower.startswith("#") and "ccxtpro" in stripped_lower:
                           continue
                       filtered.append(line)
                   if filtered != lines:

--- a/tests/test_dependency_graph_workflow.py
+++ b/tests/test_dependency_graph_workflow.py
@@ -67,5 +67,6 @@ def test_dependency_graph_filters_ccxtpro_lines_before_snapshot() -> None:
     workflow = Path(".github/workflows/dependency-graph.yml").read_text(encoding="utf-8")
 
     assert "Prepare requirements" in workflow
-    assert 'if stripped.startswith("ccxtpro")' in workflow
-    assert 'if stripped.startswith("#") and "ccxtpro" in stripped' in workflow
+    assert 'stripped_lower = stripped.lower()' in workflow
+    assert 'if stripped_lower.startswith("ccxtpro")' in workflow
+    assert 'if stripped_lower.startswith("#") and "ccxtpro" in stripped_lower' in workflow


### PR DESCRIPTION
## Summary
- make the dependency graph workflow strip ccxtpro entries regardless of casing before submitting snapshots
- update the workflow regression test to assert the new case-insensitive filtering logic

## Testing
- pytest tests/test_dependency_graph_workflow.py -q
- pytest tests/test_dependency_snapshot.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d842679e08832d9cb7d37610865b3f