### PR TITLE
Guard health_check path fix for direct execution

### DIFF
--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -7,9 +7,11 @@ import sys
 from pathlib import Path
 from typing import Iterable, Set
 
-_PROJECT_ROOT = Path(__file__).resolve().parents[1]
-if str(_PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(_PROJECT_ROOT))
+if __package__ in (None, ""):
+    project_root = Path(__file__).resolve().parents[1]
+    project_root_str = str(project_root)
+    if project_root_str not in sys.path:
+        sys.path.insert(0, project_root_str)
 
 from ipaddress import ip_address
 from urllib.parse import urlparse, urlunparse


### PR DESCRIPTION
## Summary
- avoid mutating sys.path when scripts.health_check is imported as a package
- keep the project root injection only when the health check script is executed directly

## Testing
- pytest tests/test_health_check.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d842d7fed0832dac721a6d0f39274d