### PR TITLE
Prevent CodeQL from reading Git log artifacts

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,9 +34,12 @@ jobs:
           # branches can therefore surface as false positives. A simple rm -rf
           # is more reliable than a complex find expression and avoids
           # corner-case syntax issues that previously left the directories in
-          # place.
+          # place. As an extra safeguard we also prune any stray *.py files
+          # that may remain in Git reference logs should a runner cache or
+          # filesystem quirk prevent the directories from being removed.
           rm -rf .git
           find "$PWD" -type d -name ".git" -prune -exec rm -rf {} +
+          find "$PWD" -path '*/.git/logs/*' -name '*.py' -delete
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- ensure the CodeQL workflow removes Git metadata and deletes any stray *.py log files so parse errors cannot occur

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d842ed08c0832da4d5e86325c4daaf