### PR TITLE
Fix Release Drafter concurrency configuration

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -23,7 +23,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: release-drafter-${{ github.event.pull_request.number || github.ref }}
+  group: release-drafter-${{ github.event_name == 'pull_request_target' && format('pr-{0}', github.event.number) || github.ref }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary
- ensure the Release Drafter workflow concurrency group does not reference pull request fields on push events

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d90fa3fc04832da0e0b12d25d1a1d7