### PR TITLE
Improve docker publish health check resiliency

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -235,6 +235,8 @@ jobs:
         if: ${{ steps.start_service.outputs.service_running == 'true' }}
         env:
           TEST_MODE: "1"
+          HEALTH_CHECK_MAX_ATTEMPTS: "10"
+          HEALTH_CHECK_DELAY_SECONDS: "3"
         run: python scripts/health_check.py
       - name: Cleanup
         if: ${{ always() && steps.start_service.outputs.service_running == 'true' }}


### PR DESCRIPTION
## Summary
- allow the health check helper to read base URL, endpoints, retry count, and delay from environment variables
- extend the docker-publish workflow health check step to retry longer using the new environment variables

## Testing
- TEST_MODE=1 HEALTH_CHECK_MAX_ATTEMPTS=10 HEALTH_CHECK_DELAY_SECONDS=0.1 python scripts/health_check.py

------
https://chatgpt.com/codex/tasks/task_e_68d90f4d0dd0832da39ecd894c7b9a05