### PR TITLE
Fix pip cache dir detection in setup action

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -60,7 +60,9 @@ runs:
     - name: Get pip cache dir
       id: pip-cache
       shell: bash
-      run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+      run: |
+        dir=$(python -m pip cache dir)
+        echo "dir=$dir" >> "$GITHUB_OUTPUT"
     - name: Cache pip wheels
       uses: actions/cache@638ed79f9dc94c1de1baef91bcab5edaa19451f4
       with:


### PR DESCRIPTION
## Summary
- ensure the setup-env composite action derives the pip cache directory via `python -m pip cache dir` so the step works even when the `pip` shim is missing

## Testing
- not run (CI action change only)


------
https://chatgpt.com/codex/tasks/task_e_68d90f584180832d9df26c87d55b709f