### PR TITLE
Checkout workflow helpers before GPT-OSS status check

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -154,6 +154,13 @@ jobs:
           fi
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
+      - name: Checkout workflow helpers
+        if: ${{ steps.validate_event.outputs.skip != 'true' }}
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+        with:
+          fetch-depth: 1
+          ref: ${{ github.event.repository.default_branch }}
+
       - name: Проверка статуса PR
         if: ${{ steps.validate_event.outputs.skip != 'true' }}
         id: ensure_pr_ready


### PR DESCRIPTION
## Summary
- check out the repository's default branch before running GPT-OSS helper scripts so they are available on fresh runners

## Testing
- pytest tests/test_gptoss_workflow_python3.py
- pytest tests/test_check_pr_status.py

------
https://chatgpt.com/codex/tasks/task_e_68d90f9a1334832d94467487b6a9b89f