### PR TITLE
Configure Dependabot to use PyTorch CPU index

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,20 @@
 ---
 version: 2
+
+registries:
+  pytorch-cpu:
+    type: python-index
+    url: https://download.pytorch.org/whl/cpu
+    replaces-base: false
+
 updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "daily"
     insecure-external-code-execution: allow
+    registries:
+      - pytorch-cpu
     ignore:
       # Heavy ML packages routinely fail to resolve in Dependabot's
       # constrained execution environment.  Skip them so the scheduled


### PR DESCRIPTION
## Summary
- allow Dependabot pip updates to resolve torch's CPU wheels by configuring the PyTorch index

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68d90f833180832db06209b557a88cb8