### PR TITLE
Clarify dependency graph workflow permissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -8,7 +8,8 @@ on:
 
 permissions:
   contents: read
-  # Required by the dependency submission API; avoid granting broader dependency-graph scope.
+  # GitHub rejects the legacy `dependency-graph` scope for this workflow; grant `security-events`
+  # instead to satisfy the dependency submission API while keeping permissions minimal.
   security-events: write
 
 jobs:

--- a/tests/test_dependency_graph_workflow.py
+++ b/tests/test_dependency_graph_workflow.py
@@ -39,6 +39,8 @@ def test_dependency_graph_permissions_are_valid() -> None:
     permissions = _extract_permissions(workflow)
 
     assert permissions, "permissions block must be present"
+    assert workflow.count("permissions:") == 1, "workflow must not define nested permission blocks"
+    assert "dependency-graph:" not in workflow, "GitHub rejects the dependency-graph permission scope"
 
     allowed_keys = {"contents", "security-events"}
     assert set(permissions) <= allowed_keys


### PR DESCRIPTION
## Summary
- document why the dependency graph workflow uses the `security-events` permission instead of the deprecated `dependency-graph` scope
- harden the permissions test to forbid nested permission blocks and the invalid `dependency-graph` key

## Testing
- pytest tests/test_dependency_graph_workflow.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d90f8eecac832d89c186f613494393