### PR TITLE
Fix lint failures triggered by import ordering

### DIFF
--- a/model_builder.py
+++ b/model_builder.py
@@ -30,6 +30,17 @@ from bot.config import BotConfig
 from bot.dotenv_utils import load_dotenv
 from bot.ray_compat import IS_RAY_STUB, ray
 from bot.utils_loader import require_utils
+from models.architectures import KERAS_FRAMEWORKS, create_model
+from security import (
+    ArtifactDeserializationError,
+    create_joblib_stub,
+    harden_mlflow,
+    safe_joblib_load,
+    set_model_dir,
+    verify_model_state_signature,
+    write_model_state_signature,
+)
+from services.logging_utils import sanitize_log_value
 
 _utils = require_utils(
     "check_dataframe_empty",
@@ -44,17 +55,6 @@ ensure_writable_directory = _utils.ensure_writable_directory
 is_cuda_available = _utils.is_cuda_available
 logger = _utils.logger
 validate_host = _utils.validate_host
-from models.architectures import KERAS_FRAMEWORKS, create_model
-from security import (
-    ArtifactDeserializationError,
-    create_joblib_stub,
-    harden_mlflow,
-    safe_joblib_load,
-    set_model_dir,
-    verify_model_state_signature,
-    write_model_state_signature,
-)
-from services.logging_utils import sanitize_log_value
 
 MODEL_DIR = ensure_writable_directory(
     Path(os.getenv("MODEL_DIR", ".")),

--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -5,10 +5,6 @@ Bybit. API keys are taken from ``BYBIT_API_KEY`` and ``BYBIT_API_SECRET``
 environment variables.
 """
 
-from flask import Flask, request, jsonify
-from werkzeug.exceptions import BadRequest
-from typing import Any, Mapping, cast
-from pathlib import Path
 import json
 import logging
 import math
@@ -17,6 +13,11 @@ import stat
 import tempfile
 import threading
 import time
+from pathlib import Path
+from typing import Any, Mapping, cast
+
+from flask import Flask, jsonify, request
+from werkzeug.exceptions import BadRequest
 try:  # optional dependency
     from flask.typing import ResponseReturnValue
 except Exception:  # pragma: no cover - fallback when flask.typing missing
@@ -24,11 +25,11 @@ except Exception:  # pragma: no cover - fallback when flask.typing missing
 
 from bot.trade_manager import server_common
 from bot.utils_loader import require_utils
+from services.logging_utils import sanitize_log_value
 
 _utils = require_utils("validate_host", "safe_int")
 validate_host = _utils.validate_host
 safe_int = _utils.safe_int
-from services.logging_utils import sanitize_log_value
 
 server_common.load_environment()
 

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -8,6 +8,24 @@ from __future__ import annotations
 import importlib
 import sys
 import warnings
+from types import ModuleType
+from typing import Iterable
+
+MODULE_NAME = "bot.trade_manager"
+
+
+def _load_trade_manager_module() -> ModuleType:
+    if MODULE_NAME in sys.modules:
+        return importlib.reload(sys.modules[MODULE_NAME])
+    return importlib.import_module(MODULE_NAME)
+
+
+def _exported_names(module: ModuleType) -> Iterable[str]:
+    exported = getattr(module, "__all__", None)
+    if exported is not None:
+        return tuple(exported)
+    return tuple(name for name in vars(module) if not name.startswith("_"))
+
 
 warnings.warn(
     "`import trade_manager` устарел, используйте `from bot.trade_manager import TradeManager`",
@@ -15,7 +33,6 @@ warnings.warn(
     stacklevel=2,
 )
 
-if "bot.trade_manager" in sys.modules:
-    importlib.reload(sys.modules["bot.trade_manager"])
-
-from bot.trade_manager import *  # noqa: F401,F403
+_trade_manager_module = _load_trade_manager_module()
+__all__ = list(_exported_names(_trade_manager_module))
+globals().update({name: getattr(_trade_manager_module, name) for name in __all__})


### PR DESCRIPTION
## Summary
- reorder imports in model_builder and trade_manager_service so static analyzers run before runtime setup code
- reimplement the legacy trade_manager wrapper using explicit module re-exporting to satisfy lint checks without losing behaviour

## Testing
- pytest -q --maxfail=1 --disable-warnings
- ruff check
- flake8 .
- bandit -r . -ll -x ./tests,./scripts,./gptoss_check

------
https://chatgpt.com/codex/tasks/task_e_68d90fbb14f8832d824c8da110c93036