### PR TITLE
Upgrade setuptools in CI Docker image to satisfy Trivy scan

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -8,10 +8,20 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Обновление linux-libc-dev устраняет CVE-2025-21976, а libgcrypt20 — CVE-2024-2236.
 # Дополнительно выполняем upgrade, чтобы подтянуть свежие патчи безопасности из Ubuntu.
+# После создания виртуального окружения обновляем pip и setuptools до версий,
+# закрывающих CVE-2024-6345 и CVE-2025-47273, иначе Trivy обнаруживает
+# уязвимые копии setuptools внутри образа.
 RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y \
     python3 python3-venv build-essential linux-libc-dev libgcrypt20 git patch \
     && apt-get install -y --no-install-recommends gnupg dirmngr \
     && python3 -m venv /venv \
+    && /venv/bin/python -m ensurepip --upgrade \
+    && /venv/bin/pip install --no-cache-dir \
+        'pip>=24.0' \
+        'setuptools>=78.1.1,<81' \
+        wheel \
+    && /venv/bin/pip cache purge \
+    && rm -rf /root/.cache/pip \
     && apt-get purge -y --auto-remove build-essential \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && ldconfig \


### PR DESCRIPTION
## Summary
- upgrade the virtualenv created in Dockerfile.ci so that pip and setuptools are bumped to the patched range that fixes CVE-2024-6345 and CVE-2025-47273
- clean the pip cache so the hardened CI image no longer ships a vulnerable setuptools copy that triggers the Trivy workflow

## Testing
- trivy fs --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed --file-patterns 'pip:requirements[-_A-Za-z0-9]*\\.txt' --format table .


------
https://chatgpt.com/codex/tasks/task_e_68d90fc727bc832db7f4cadab8d11676