### PR TITLE
Clean dependency lists and align CI framework versions

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,6 +1,6 @@
 # Minimal requirements for running tests in CI
-aiohttp>=3.9.4
-bcrypt>=4.1.2
+aiohttp==3.12.15
+bcrypt==5.0.0
 flake8==7.3.0
 bandit==1.8.6
 ruff==0.13.2
@@ -8,24 +8,24 @@ pytest==8.4.2
 pytest-asyncio==1.2.0
 fastapi==0.117.1
 fastapi-csrf-protect==1.0.7
-flask>=3.0.3,<4
+flask==3.1.2
 pydantic==2.11.9
 # gymnasium and scikit-learn are unavailable on some Python versions
 gymnasium==1.2.0; python_version<'3.12'
 # Pin pandas to stay compatible with the numpy version used across builds
 pandas==2.3.2
-polars>=1.6.0
-pyarrow>=15.0.0
-python-dotenv>=1.0.0
-psutil>=5.9.0
-werkzeug>=3.0.2,<4
-requests>=2.31.0
-httpx>=0.27.0
+polars==1.33.1
+pyarrow==21.0.0
+python-dotenv==1.1.1
+psutil==7.1.0
+werkzeug==3.1.3
+requests==2.32.5
+httpx==0.28.1
 ccxt==4.5.5
 # Newer scikit-learn releases pull in SciPy builds incompatible with our
 # pinned numpy; keep everything aligned with the Docker images.
 scikit-learn==1.7.2; python_version<'3.12'
-joblib>=1.3
+joblib==1.5.2
 setuptools>=78.1.1
 types-requests
 mypy==1.18.2
@@ -33,5 +33,5 @@ hypothesis>=6.90.0
 # Keep numpy aligned with requirements-core.txt and Docker builds
 numpy==2.2.6
 pip-audit==2.9.0
-pybit>=5.7.0
+pybit==5.11.0
 

--- a/requirements-core.in
+++ b/requirements-core.in
@@ -22,8 +22,9 @@ stable-baselines3==2.7.0
 gymnasium>=0.29.1
 pytorch-lightning>=2.5.2
 transformers==4.56.2
+fastapi>=0.116.1
 fastapi-csrf-protect>=1.0.7
-flask>=3.0.2
+flask>=3.1.2
 pybit>=5.11.0
 gunicorn>=23.0.0
 a2wsgi>=1.4

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -19,7 +19,6 @@ aiohttp==3.12.15
     #   fsspec
 aiosignal==1.4.0
     # via aiohttp
-alembic==1.16.4
 annotated-types==0.7.0
     # via pydantic
 anyio==4.10.0
@@ -36,12 +35,7 @@ bcrypt==4.3.0
     # via -r requirements-core.in
 blinker==1.9.0
     # via flask
-cachetools==5.5.2
-    # via
-    #   google-auth
 ccxt==4.5.5
-    # via -r requirements-core.in
-# ccxtpro==1.0.1  # install manually if you have a commercial license
     # via -r requirements-core.in
 certifi==2025.8.3
     # via
@@ -56,9 +50,7 @@ cffi==2.0.0
 charset-normalizer==3.4.3
     # via requests
 click==8.2.1
-    # via
-    #   flask
-    #   uvicorn
+    # via flask
 cloudpickle==3.1.1
     # via
     #   gymnasium
@@ -72,14 +64,12 @@ cryptography==46.0.1
     #   ccxt
 cycler==0.12.1
     # via matplotlib
-databricks-sdk==0.64.0
-    # via
 distro==1.9.0
     # via openai
-docker==7.1.0
 farama-notifications==0.0.4
     # via gymnasium
-fastapi==0.116.1
+fastapi==0.117.1
+    # via -r requirements-core.in
 fastapi-csrf-protect==1.0.7
     # via -r requirements-core.in
 filelock==3.19.1
@@ -88,8 +78,7 @@ filelock==3.19.1
     #   torch
     #   transformers
 flask==3.1.2
-    # via
-    #   -r requirements-core.in
+    # via -r requirements-core.in
 fonttools==4.59.1
     # via matplotlib
 frozenlist==1.7.0
@@ -101,31 +90,14 @@ fsspec==2025.7.0
     #   huggingface-hub
     #   pytorch-lightning
     #   torch
-gitdb==4.0.12
-    # via gitpython
-gitpython==3.1.45
-google-auth==2.40.3
-    # via databricks-sdk
-graphene==3.4.3
-graphql-core==3.2.6
-    # via
-    #   graphene
-    #   graphql-relay
-graphql-relay==3.2.0
-    # via graphene
-greenlet==3.2.4
-    # via sqlalchemy
 gunicorn==23.0.0
-    # via
-    #   -r requirements-core.in
+    # via -r requirements-core.in
 gymnasium==1.2.0
     # via
     #   -r requirements-core.in
     #   stable-baselines3
 h11==0.16.0
-    # via
-    #   httpcore
-    #   uvicorn
+    # via httpcore
 hf-xet==1.1.8
     # via huggingface-hub
 httpcore==1.0.9
@@ -147,9 +119,6 @@ idna==3.10
     #   yarl
 imbalanced-learn==0.14.0
     # via -r requirements-core.in
-importlib-metadata==8.7.0
-    # via
-    #   opentelemetry-api
 iniconfig==2.1.0
     # via pytest
 itsdangerous==2.2.0
@@ -168,8 +137,7 @@ joblib==1.5.1
     #   imbalanced-learn
     #   scikit-learn
 jsonschema==4.25.1
-    # via
-    #   -r requirements-core.in
+    # via -r requirements-core.in
 jsonschema-specifications==2025.4.1
     # via jsonschema
 kiwisolver==1.4.9
@@ -180,21 +148,15 @@ lightning-utilities==0.15.2
     #   torchmetrics
 llvmlite==0.45.0
     # via numba
-mako==1.3.10
-    # via alembic
 markupsafe==3.0.2
     # via
     #   flask
     #   jinja2
-    #   mako
     #   werkzeug
 matplotlib==3.10.5
-    # via
-    #   stable-baselines3
-    # via -r requirements-core.in
+    # via stable-baselines3
 mpmath==1.3.0
     # via sympy
-msgpack==1.1.1
 multidict==6.6.4
     # via
     #   aiohttp
@@ -223,16 +185,8 @@ numpy==2.2.6
     #   ta
     #   torchmetrics
     #   transformers
-openai==1.109.0
+openai==1.109.1
     # via -r requirements-core.in
-opentelemetry-api==1.36.0
-    # via
-    #   opentelemetry-sdk
-    #   opentelemetry-semantic-conventions
-opentelemetry-sdk==1.36.0
-    # via
-opentelemetry-semantic-conventions==0.57b0
-    # via opentelemetry-sdk
 packaging==25.0
     # via
     #   gunicorn
@@ -264,19 +218,10 @@ propcache==0.3.2
     # via
     #   aiohttp
     #   yarl
-protobuf==6.32.0
-    # via
 psutil==7.1.0
     # via -r requirements-core.in
 pyarrow==21.0.0
-    # via
-    #   -r requirements-core.in
-pyasn1==0.6.1
-    # via
-    #   pyasn1-modules
-    #   rsa
-pyasn1-modules==0.4.2
-    # via google-auth
+    # via -r requirements-core.in
 pybit==5.11.0
     # via -r requirements-core.in
 pycares==4.10.0
@@ -305,7 +250,6 @@ pytest-asyncio==1.1.0
     # via -r requirements-core.in
 python-dateutil==2.9.0.post0
     # via
-    #   graphene
     #   matplotlib
     #   pandas
 python-dotenv==1.1.1
@@ -323,7 +267,6 @@ pyyaml==6.0.2
     #   huggingface-hub
     #   pytorch-lightning
     #   transformers
-    # via -r requirements-core.in
 referencing==0.36.2
     # via
     #   jsonschema
@@ -333,8 +276,6 @@ regex==2025.7.34
 requests==2.32.5
     # via
     #   ccxt
-    #   databricks-sdk
-    #   docker
     #   huggingface-hub
     #   pybit
     #   transformers
@@ -342,8 +283,6 @@ rpds-py==0.27.0
     # via
     #   jsonschema
     #   referencing
-rsa==4.9.1
-    # via google-auth
 safetensors==0.6.2
     # via transformers
 scikit-learn==1.7.2
@@ -364,16 +303,10 @@ six==1.17.0
     # via python-dateutil
 slicer==0.0.8
     # via shap
-smmap==5.0.2
-    # via gitdb
 sniffio==1.3.1
     # via
     #   anyio
     #   openai
-sqlalchemy==2.0.43
-    # via
-    #   alembic
-sqlparse==0.5.3
 stable-baselines3==2.7.0
     # via -r requirements-core.in
 starlette==0.47.3
@@ -406,29 +339,23 @@ tqdm==4.67.1
     #   pytorch-lightning
     #   shap
     #   transformers
-transformers==4.56.1
+transformers==4.56.2
     # via -r requirements-core.in
 typing-extensions==4.14.1
     # via
     #   aiosignal
-    #   alembic
     #   anyio
     #   ccxt
     #   fastapi
-    #   graphene
     #   gymnasium
     #   huggingface-hub
     #   lightning-utilities
     #   openai
-    #   opentelemetry-api
-    #   opentelemetry-sdk
-    #   opentelemetry-semantic-conventions
     #   pydantic
     #   pydantic-core
     #   pytorch-lightning
     #   referencing
     #   shap
-    #   sqlalchemy
     #   starlette
     #   torch
     #   typing-inspection
@@ -439,10 +366,7 @@ typing-inspection==0.4.1
 tzdata==2025.2
     # via pandas
 urllib3==2.5.0
-    # via
-    #   docker
-    #   requests
-uvicorn==0.35.0
+    # via requests
 websocket-client==1.8.0
     # via pybit
 websockets==15.0.1
@@ -453,9 +377,6 @@ yarl==1.20.1
     # via
     #   aiohttp
     #   ccxt
-zipp==3.23.0
-    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools>=78.1.1,<81
-    # via -r requirements-core.in
+# setuptools

--- a/requirements.out
+++ b/requirements.out
@@ -23,9 +23,6 @@ aiosignal==1.4.0
     # via
     #   -r requirements.txt
     #   aiohttp
-alembic==1.16.4
-    # via
-    #   -r requirements.txt
 annotated-types==0.7.0
     # via
     #   -r requirements.txt
@@ -36,28 +33,19 @@ anyio==4.10.0
     #   httpx
     #   openai
     #   starlette
-async-timeout==5.0.1
-    # via -r requirements.txt
 attrs==25.3.0
     # via
     #   -r requirements.txt
     #   aiohttp
     #   jsonschema
     #   referencing
-bcrypt==4.3.0
+bcrypt==5.0.0
     # via -r requirements.txt
 blinker==1.9.0
     # via
     #   -r requirements.txt
     #   flask
-cachetools==5.5.2
-    # via
-    #   -r requirements.txt
-    #   google-auth
-    # via -r requirements.txt
 ccxt==4.5.5
-    # via -r requirements.txt
-# ccxtpro==1.0.1  # install manually if you have a commercial license
     # via -r requirements.txt
 certifi==2025.8.3
     # via
@@ -79,15 +67,12 @@ click==8.2.1
     # via
     #   -r requirements.txt
     #   flask
-    #   uvicorn
 cloudpickle==3.1.1
     # via
     #   -r requirements.txt
     #   gymnasium
     #   shap
     #   stable-baselines3
-    # via
-    #   -r requirements.txt
 contourpy==1.3.2
     # via
     #   -r requirements.txt
@@ -100,25 +85,16 @@ cycler==0.12.1
     # via
     #   -r requirements.txt
     #   matplotlib
-databricks-sdk==0.63.0
-    # via
-    #   -r requirements.txt
 distro==1.9.0
     # via
     #   -r requirements.txt
     #   openai
-docker==7.1.0
-    # via
-    #   -r requirements.txt
-exceptiongroup==1.3.0
-    # via -r requirements.txt
 farama-notifications==0.0.4
     # via
     #   -r requirements.txt
     #   gymnasium
-fastapi==0.116.1
-    # via
-    #   -r requirements.txt
+fastapi==0.117.1
+    # via -r requirements.txt
 fastapi-csrf-protect==1.0.7
     # via -r requirements.txt
 filelock==3.19.1
@@ -128,8 +104,7 @@ filelock==3.19.1
     #   torch
     #   transformers
 flask==3.1.2
-    # via
-    #   -r requirements.txt
+    # via -r requirements.txt
 fonttools==4.59.1
     # via
     #   -r requirements.txt
@@ -145,36 +120,8 @@ fsspec==2025.7.0
     #   huggingface-hub
     #   pytorch-lightning
     #   torch
-gitdb==4.0.12
-    # via
-    #   -r requirements.txt
-    #   gitpython
-gitpython==3.1.45
-    # via
-    #   -r requirements.txt
-google-auth==2.40.3
-    # via
-    #   -r requirements.txt
-    #   databricks-sdk
-graphene==3.4.3
-    # via
-    #   -r requirements.txt
-graphql-core==3.2.6
-    # via
-    #   -r requirements.txt
-    #   graphene
-    #   graphql-relay
-graphql-relay==3.2.0
-    # via
-    #   -r requirements.txt
-    #   graphene
-greenlet==3.2.4
-    # via
-    #   -r requirements.txt
-    #   sqlalchemy
 gunicorn==23.0.0
-    # via
-    #   -r requirements.txt
+    # via -r requirements.txt
 gymnasium==1.2.0
     # via
     #   -r requirements.txt
@@ -183,7 +130,6 @@ h11==0.16.0
     # via
     #   -r requirements.txt
     #   httpcore
-    #   uvicorn
 hf-xet==1.1.8
     # via
     #   -r requirements.txt
@@ -211,10 +157,6 @@ idna==3.10
     #   yarl
 imbalanced-learn==0.14.0
     # via -r requirements.txt
-importlib-metadata==8.7.0
-    # via
-    #   -r requirements.txt
-    #   opentelemetry-api
 iniconfig==2.1.0
     # via
     #   -r requirements.txt
@@ -233,14 +175,13 @@ jiter==0.10.0
     # via
     #   -r requirements.txt
     #   openai
-joblib==1.5.1
+joblib==1.5.2
     # via
     #   -r requirements.txt
     #   imbalanced-learn
     #   scikit-learn
 jsonschema==4.25.1
-    # via
-    #   -r requirements.txt
+    # via -r requirements.txt
 jsonschema-specifications==2025.4.1
     # via
     #   -r requirements.txt
@@ -258,33 +199,20 @@ llvmlite==0.45.0
     # via
     #   -r requirements.txt
     #   numba
-mako==1.3.10
-    # via
-    #   -r requirements.txt
-    #   alembic
 markupsafe==3.0.2
     # via
     #   -r requirements.txt
     #   flask
     #   jinja2
-    #   mako
     #   werkzeug
 matplotlib==3.10.5
     # via
     #   -r requirements.txt
     #   stable-baselines3
-    # via -r requirements.txt
-    # via
-    #   -r requirements.txt
-    # via
-    #   -r requirements.txt
 mpmath==1.3.0
     # via
     #   -r requirements.txt
     #   sympy
-msgpack==1.1.1
-    # via
-    #   -r requirements.txt
 multidict==6.6.4
     # via
     #   -r requirements.txt
@@ -314,26 +242,71 @@ numpy==2.2.6
     #   stable-baselines3
     #   statsmodels
     #   ta
-    #   tensorboardx
     #   torchmetrics
     #   transformers
+nvidia-cublas-cu12==12.8.4.1
+    # via
+    #   -r requirements.txt
+    #   nvidia-cudnn-cu12
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-cuda-cupti-cu12==12.8.90
     # via
     #   -r requirements.txt
     #   torch
-openai==1.109.0
-    # via -r requirements.txt
-opentelemetry-api==1.36.0
+nvidia-cuda-nvrtc-cu12==12.8.93
     # via
     #   -r requirements.txt
-    #   opentelemetry-sdk
-    #   opentelemetry-semantic-conventions
-opentelemetry-sdk==1.36.0
+    #   torch
+nvidia-cuda-runtime-cu12==12.8.90
     # via
     #   -r requirements.txt
-opentelemetry-semantic-conventions==0.57b0
+    #   torch
+nvidia-cudnn-cu12==9.10.2.21
     # via
     #   -r requirements.txt
-    #   opentelemetry-sdk
+    #   torch
+nvidia-cufft-cu12==11.3.3.83
+    # via
+    #   -r requirements.txt
+    #   torch
+nvidia-cufile-cu12==1.13.1.3
+    # via
+    #   -r requirements.txt
+    #   torch
+nvidia-curand-cu12==10.3.9.90
+    # via
+    #   -r requirements.txt
+    #   torch
+nvidia-cusolver-cu12==11.7.3.90
+    # via
+    #   -r requirements.txt
+    #   torch
+nvidia-cusparse-cu12==12.5.8.93
+    # via
+    #   -r requirements.txt
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-cusparselt-cu12==0.7.1
+    # via
+    #   -r requirements.txt
+    #   torch
+nvidia-nccl-cu12==2.27.3
+    # via
+    #   -r requirements.txt
+    #   torch
+nvidia-nvjitlink-cu12==12.8.93
+    # via
+    #   -r requirements.txt
+    #   nvidia-cufft-cu12
+    #   nvidia-cusolver-cu12
+    #   nvidia-cusparse-cu12
+    #   torch
+nvidia-nvtx-cu12==12.8.90
+    # via
+    #   -r requirements.txt
+    #   torch
+openai==1.109.1
     # via -r requirements.txt
 packaging==25.0
     # via
@@ -346,7 +319,6 @@ packaging==25.0
     #   pytorch-lightning
     #   shap
     #   statsmodels
-    #   tensorboardx
     #   torchmetrics
     #   transformers
 pandas==2.3.2
@@ -368,31 +340,17 @@ pluggy==1.6.0
     # via
     #   -r requirements.txt
     #   pytest
-polars==1.32.3
+polars==1.33.1
     # via -r requirements.txt
 propcache==0.3.2
     # via
     #   -r requirements.txt
     #   aiohttp
     #   yarl
-protobuf==6.32.0
-    # via
-    #   -r requirements.txt
-    #   tensorboardx
 psutil==7.1.0
     # via -r requirements.txt
 pyarrow==21.0.0
-    # via
-    #   -r requirements.txt
-pyasn1==0.6.1
-    # via
-    #   -r requirements.txt
-    #   pyasn1-modules
-    #   rsa
-pyasn1-modules==0.4.2
-    # via
-    #   -r requirements.txt
-    #   google-auth
+    # via -r requirements.txt
 pybit==5.11.0
     # via -r requirements.txt
 pycares==4.10.0
@@ -407,7 +365,7 @@ pycryptodome==3.23.0
     # via
     #   -r requirements.txt
     #   pybit
-pydantic==2.11.7
+pydantic==2.11.9
     # via
     #   -r requirements.txt
     #   fastapi
@@ -430,16 +388,15 @@ pyparsing==3.2.3
     # via
     #   -r requirements.txt
     #   matplotlib
-pytest==8.4.1
+pytest==8.4.2
     # via
     #   -r requirements.txt
     #   pytest-asyncio
-pytest-asyncio==1.1.0
+pytest-asyncio==1.2.0
     # via -r requirements.txt
 python-dateutil==2.9.0.post0
     # via
     #   -r requirements.txt
-    #   graphene
     #   matplotlib
     #   pandas
 python-dotenv==1.1.1
@@ -460,7 +417,6 @@ pyyaml==6.0.2
     #   huggingface-hub
     #   pytorch-lightning
     #   transformers
-    # via -r requirements.txt
 referencing==0.36.2
     # via
     #   -r requirements.txt
@@ -474,8 +430,6 @@ requests==2.32.5
     # via
     #   -r requirements.txt
     #   ccxt
-    #   databricks-sdk
-    #   docker
     #   huggingface-hub
     #   pybit
     #   transformers
@@ -484,10 +438,6 @@ rpds-py==0.27.0
     #   -r requirements.txt
     #   jsonschema
     #   referencing
-rsa==4.9.1
-    # via
-    #   -r requirements.txt
-    #   google-auth
 safetensors==0.6.2
     # via
     #   -r requirements.txt
@@ -497,7 +447,7 @@ scikit-learn==1.7.2
     #   -r requirements.txt
     #   imbalanced-learn
     #   shap
-scipy==1.16.1
+scipy==1.15.3
     # via
     #   -r requirements.txt
     #   imbalanced-learn
@@ -514,23 +464,12 @@ slicer==0.0.8
     # via
     #   -r requirements.txt
     #   shap
-smmap==5.0.2
-    # via
-    #   -r requirements.txt
-    #   gitdb
 sniffio==1.3.1
     # via
     #   -r requirements.txt
     #   anyio
     #   openai
-sqlalchemy==2.0.43
-    # via
-    #   -r requirements.txt
-    #   alembic
-sqlparse==0.5.3
-    # via
-    #   -r requirements.txt
-stable-baselines3==1.7.0
+stable-baselines3==2.7.0
     # via -r requirements.txt
 starlette==0.47.3
     # via
@@ -545,21 +484,15 @@ sympy==1.14.0
     #   torch
 ta==0.11.0
     # via -r requirements.txt
-    # via -r requirements.txt
-tensorboardx==2.6.4
-    # via
-    #   -r requirements.txt
 threadpoolctl==3.6.0
     # via
     #   -r requirements.txt
     #   imbalanced-learn
     #   scikit-learn
-tokenizers==0.21.4
+tokenizers==0.22.0
     # via
     #   -r requirements.txt
     #   transformers
-tomli==2.2.1
-    # via -r requirements.txt
 torch==2.8.0
     # via
     #   -r requirements.txt
@@ -578,7 +511,7 @@ tqdm==4.67.1
     #   pytorch-lightning
     #   shap
     #   transformers
-transformers==4.55.4
+transformers==4.56.2
     # via -r requirements.txt
 triton==3.4.0
     # via
@@ -588,25 +521,19 @@ typing-extensions==4.14.1
     # via
     #   -r requirements.txt
     #   aiosignal
-    #   alembic
     #   anyio
     #   ccxt
-    #   exceptiongroup
     #   fastapi
-    #   graphene
     #   gymnasium
     #   huggingface-hub
     #   lightning-utilities
     #   openai
-    #   opentelemetry-api
-    #   opentelemetry-sdk
-    #   opentelemetry-semantic-conventions
     #   pydantic
     #   pydantic-core
+    #   pytest-asyncio
     #   pytorch-lightning
     #   referencing
     #   shap
-    #   sqlalchemy
     #   starlette
     #   torch
     #   typing-inspection
@@ -622,11 +549,7 @@ tzdata==2025.2
 urllib3==2.5.0
     # via
     #   -r requirements.txt
-    #   docker
     #   requests
-uvicorn==0.35.0
-    # via
-    #   -r requirements.txt
 websocket-client==1.8.0
     # via
     #   -r requirements.txt
@@ -642,13 +565,6 @@ yarl==1.20.1
     #   -r requirements.txt
     #   aiohttp
     #   ccxt
-zipp==3.23.0
-    # via
-    #   -r requirements.txt
-    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools>=78.1.1,<81
-    # via
-    #   -r requirements-core.in
-    #   -r requirements-gpu.in
+# setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,17 +24,11 @@ anyio==4.10.0
     #   httpx
     #   openai
     #   starlette
-async-timeout==5.0.1
-    # via aiohttp
 attrs==25.3.0
     # via
     #   aiohttp
     #   jsonschema
     #   referencing
-backports-asyncio-runner==1.2.0 ; python_version < "3.11"
-    # via
-    #   -r requirements-core.in
-    #   pytest-asyncio
 bcrypt==5.0.0
     # via -r requirements-core.in
 blinker==1.9.0
@@ -70,12 +64,10 @@ cycler==0.12.1
     # via matplotlib
 distro==1.9.0
     # via openai
-exceptiongroup==1.3.0
-    # via
-    #   anyio
-    #   pytest
 farama-notifications==0.0.4
     # via gymnasium
+fastapi==0.117.1
+    # via -r requirements-core.in
 fastapi-csrf-protect==1.0.7
     # via -r requirements-core.in
 filelock==3.19.1
@@ -275,6 +267,7 @@ pycryptodome==3.23.0
     # via pybit
 pydantic==2.11.9
     # via
+    #   fastapi
     #   fastapi-csrf-protect
     #   openai
     #   pydantic-settings
@@ -352,7 +345,9 @@ sniffio==1.3.1
 stable-baselines3==2.7.0
     # via -r requirements-core.in
 starlette==0.47.3
-    # via fastapi-csrf-protect
+    # via
+    #   fastapi
+    #   fastapi-csrf-protect
 statsmodels==0.14.5
     # via -r requirements-core.in
 sympy==1.14.0
@@ -365,8 +360,6 @@ threadpoolctl==3.6.0
     #   scikit-learn
 tokenizers==0.22.0
     # via transformers
-tomli==2.2.1
-    # via pytest
 torch==2.8.0
     # via
     #   pytorch-lightning
@@ -387,16 +380,13 @@ triton==3.4.0
     # via torch
 typing-extensions==4.14.1
     # via
-    #   a2wsgi
     #   aiosignal
     #   anyio
     #   ccxt
-    #   cryptography
-    #   exceptiongroup
+    #   fastapi
     #   gymnasium
     #   huggingface-hub
     #   lightning-utilities
-    #   multidict
     #   openai
     #   pydantic
     #   pydantic-core


### PR DESCRIPTION
## Summary
- drop unused direct dependencies (docker, databricks-sdk, graphene, etc.) from the compiled lockfiles and pin FastAPI in requirements-core
- sync requirements-ci.txt with the freshly generated lockfiles so FastAPI, Flask, aiohttp, httpx and other core libraries share the same versions
- regenerate requirements.txt and requirements.out via pip-compile to reflect the cleaned inputs

## Testing
- pytest
- python -m ruff check bot tests
- python -m flake8 .
- python -m mypy bot
- python -m bandit -r bot -x tests -ll
- python -m pip_audit --strict -f json -o pip-audit.json

------
https://chatgpt.com/codex/tasks/task_e_68d918ee0130832daa8ebb0f68a735c0