### PR TITLE
Remove B101 skip and harden utils loader

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,3 +1,4 @@
-[bandit]
-exclude_dirs = tests,scripts,gptoss_check
-skips = B101
+exclude_dirs:
+  - tests
+  - scripts
+  - gptoss_check

--- a/bot/utils_loader.py
+++ b/bot/utils_loader.py
@@ -22,12 +22,14 @@ def _load_from_source() -> ModuleType:
     project_root = Path(__file__).resolve().parent.parent
     utils_path = project_root / "utils.py"
     spec = importlib.util.spec_from_file_location("_bot_real_utils", utils_path)
-    if spec is None or spec.loader is None:
+    if spec is None:
+        raise ImportError(f"Unable to load utils module from {utils_path!s}")
+
+    loader = spec.loader
+    if loader is None:
         raise ImportError(f"Unable to load utils module from {utils_path!s}")
 
     module = importlib.util.module_from_spec(spec)
-    loader = spec.loader
-    assert loader is not None
     loader.exec_module(module)  # type: ignore[arg-type]
     sys.modules.setdefault("_bot_real_utils", module)
     _UTILS_CACHE = module


### PR DESCRIPTION
## Summary
- convert the Bandit configuration to YAML while dropping the B101 skip entry
- replace the assertion in `bot/utils_loader.py` with explicit ImportError handling

## Testing
- bandit -c .bandit -r .

------
https://chatgpt.com/codex/tasks/task_e_68d918d6e654832d82eb3f0665c36631