### PR TITLE
Refactor service wiring to use configurable factories

### DIFF
--- a/bot/trade_manager/__init__.py
+++ b/bot/trade_manager/__init__.py
@@ -8,8 +8,6 @@
 
 from typing import TYPE_CHECKING, Any, cast
 
-from bot.config import OFFLINE_MODE
-
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from .core import TradeManager as TradeManagerType
     from telegram_logger import TelegramLogger as TelegramLoggerType
@@ -17,49 +15,41 @@ else:
     TradeManagerType = Any
     TelegramLoggerType = Any
 
-if OFFLINE_MODE:
-    from services.offline import OfflineBybit, OfflineTelegram
+from bot.http_client import close_async_http_client, get_async_http_client
+from bot.utils_loader import require_utils
 
-    TradeManager = cast(type[TradeManagerType], OfflineBybit)
-    TelegramLogger = cast(type[TelegramLoggerType], OfflineTelegram)
+_utils = require_utils("TelegramLogger")
+TelegramLogger = cast(type[TelegramLoggerType], _utils.TelegramLogger)
 
-    __all__ = ["TradeManager", "TelegramLogger"]
-else:  # pragma: no cover - реальная инициализация
-    from bot.http_client import close_async_http_client, get_async_http_client
-    from bot.utils_loader import require_utils
+from .core import TradeManager as _TradeManager
+from .service import (
+    InvalidHostError,
+    api_app,
+    asgi_app,
+    create_trade_manager,
+    trade_manager,
+    main,
+    _resolve_host,
+    _ready_event,
+)
 
-    _utils = require_utils("TelegramLogger")
-    TelegramLogger = cast(type[TelegramLoggerType], _utils.TelegramLogger)
+TradeManager = cast(type[TradeManagerType], _TradeManager)
 
-    from .core import TradeManager as _TradeManager
-    from .service import (
-        InvalidHostError,
-        api_app,
-        asgi_app,
-        create_trade_manager,
-        trade_manager,
-        main,
-        _resolve_host,
-        _ready_event,
-    )
+# Псевдонимы синхронных помощников оставлены для обратной совместимости
+get_http_client = get_async_http_client
+close_http_client = close_async_http_client
 
-    TradeManager = cast(type[TradeManagerType], _TradeManager)
-
-    # Псевдонимы синхронных помощников оставлены для обратной совместимости
-    get_http_client = get_async_http_client
-    close_http_client = close_async_http_client
-
-    __all__ = [
-        "TradeManager",
-        "TelegramLogger",
-        "api_app",
-        "asgi_app",
-        "create_trade_manager",
-        "trade_manager",
-        "main",
-        "InvalidHostError",
-        "_resolve_host",
-        "_ready_event",
-        "get_http_client",
-        "close_http_client",
-    ]
+__all__ = [
+    "TradeManager",
+    "TelegramLogger",
+    "api_app",
+    "asgi_app",
+    "create_trade_manager",
+    "trade_manager",
+    "main",
+    "InvalidHostError",
+    "_resolve_host",
+    "_ready_event",
+    "get_http_client",
+    "close_http_client",
+]

--- a/config.py
+++ b/config.py
@@ -333,6 +333,9 @@ class BotConfig:
     enable_notifications: bool = _get_default("enable_notifications", True)
     save_unsent_telegram: bool = _get_default("save_unsent_telegram", False)
     unsent_telegram_path: str = _get_default("unsent_telegram_path", "unsent_telegram.log")
+    service_factories: Dict[str, str] = field(
+        default_factory=lambda: _get_default("service_factories", {})
+    )
 
     def __post_init__(self) -> None:
         if self.ws_subscription_batch_size is None:

--- a/model_builder.py
+++ b/model_builder.py
@@ -948,10 +948,17 @@ def _train_model_remote(
 class ModelBuilder:
     """Simplified model builder used for training LSTM models."""
 
-    def __init__(self, config: BotConfig, data_handler, trade_manager):
+    def __init__(
+        self,
+        config: BotConfig,
+        data_handler,
+        trade_manager,
+        gpt_client=None,
+    ):
         self.config = config
         self.data_handler = data_handler
         self.trade_manager = trade_manager
+        self.gpt_client = gpt_client
         self.model_type = config.get("model_type", "transformer")
         self.nn_framework = config.get("nn_framework", "pytorch").lower()
         # Predictive models for each trading symbol

--- a/services/offline.py
+++ b/services/offline.py
@@ -16,6 +16,22 @@ logger = logging.getLogger("TradingBot")
 
 _PlaceholderValue = str | Callable[[], str]
 
+# Default dotted-path mappings allowing configuration-driven selection of
+# offline service implementations.  The values intentionally reference
+# concrete classes so configuration files can opt-in to the same shims without
+# relying on monkeypatching.
+OFFLINE_SERVICE_FACTORY_PATHS: dict[str, str] = {
+    "exchange": "services.offline:OfflineBybit",
+    "telegram_logger": "services.offline:OfflineTelegram",
+    "gpt_client": "services.offline:OfflineGPT",
+}
+
+
+def get_offline_service_factories() -> dict[str, str]:
+    """Return a copy of the default offline service factory mapping."""
+
+    return dict(OFFLINE_SERVICE_FACTORY_PATHS)
+
 
 def generate_placeholder_credential(name: str, *, entropy_bytes: int = 32) -> str:
     """Return a high-entropy placeholder credential for offline usage.


### PR DESCRIPTION
## Summary
- add a `service_factories` config option and expose offline defaults for exchange, telegram logger, and GPT client
- replace run_bot monkeypatching with a service bundle that injects the selected implementations into DataHandler, ModelBuilder, and TradeManager
- update the trade_manager package to honour injected factories while always exporting the real implementation

## Testing
- pytest tests/test_offline_mode_stubs.py tests/test_trading_bot.py


------
https://chatgpt.com/codex/tasks/task_e_68d918b862b4832d8a1cb4a69c743977