### PR TITLE
Refactor model_builder into package

### DIFF
--- a/model_builder/__init__.py
+++ b/model_builder/__init__.py
@@ -1,0 +1,122 @@
+"""Backward compatible facade for the :mod:`model_builder` package."""
+
+from __future__ import annotations
+
+from .core import (
+    IS_RAY_STUB,
+    DQN,
+    DummyVecEnv,
+    ModelBuilder,
+    PPO,
+    RLAgent,
+    SB3_AVAILABLE,
+    TradingEnv,
+    _freeze_keras_base_layers,
+    _freeze_torch_base_layers,
+    _get_torch_modules,
+    _train_model_keras,
+    _train_model_lightning,
+    _train_model_remote,
+    check_dataframe_empty,
+    ensure_writable_directory,
+    fit_scaler,
+    generate_time_series_splits,
+    gym,
+    is_cuda_available,
+    logger,
+    prepare_features,
+    ray,
+    shap,
+    spaces,
+    validate_host,
+)
+import sys
+import types
+
+from . import api as _api
+from .storage import (
+    JOBLIB_AVAILABLE,
+    MODEL_DIR,
+    MODEL_FILE,
+    joblib,
+    save_artifacts,
+    _is_within_directory,
+    _resolve_model_artifact,
+    _safe_model_file_path,
+)
+
+api_app = _api.api_app
+configure_logging = _api.configure_logging
+api_main = _api.main
+ping = _api.ping
+predict_route = _api.predict_route
+train_route = _api.train_route
+
+
+def _load_model() -> None:
+    """Reload the cached scikit-learn model via :mod:`model_builder.api`."""
+
+    _api._load_model()
+
+
+class _ModelBuilderModule(types.ModuleType):
+    """Module wrapper syncing ``_model`` with :mod:`model_builder.api`."""
+
+    def __getattr__(self, name: str):  # type: ignore[override]
+        if name == "_model":
+            return _api._model
+        return super().__getattr__(name)
+
+    def __setattr__(self, name: str, value) -> None:  # type: ignore[override]
+        if name == "_model":
+            _api._model = value
+        else:
+            super().__setattr__(name, value)
+
+
+sys.modules[__name__].__class__ = _ModelBuilderModule
+
+__all__ = [
+    "IS_RAY_STUB",
+    "DQN",
+    "DummyVecEnv",
+    "ModelBuilder",
+    "PPO",
+    "RLAgent",
+    "SB3_AVAILABLE",
+    "TradingEnv",
+    "_freeze_keras_base_layers",
+    "_freeze_torch_base_layers",
+    "_get_torch_modules",
+    "_train_model_keras",
+    "_train_model_lightning",
+    "_train_model_remote",
+    "check_dataframe_empty",
+    "ensure_writable_directory",
+    "fit_scaler",
+    "generate_time_series_splits",
+    "gym",
+    "is_cuda_available",
+    "logger",
+    "prepare_features",
+    "ray",
+    "shap",
+    "spaces",
+    "validate_host",
+    "JOBLIB_AVAILABLE",
+    "MODEL_DIR",
+    "MODEL_FILE",
+    "joblib",
+    "save_artifacts",
+    "_is_within_directory",
+    "_resolve_model_artifact",
+    "_safe_model_file_path",
+    "api_app",
+    "configure_logging",
+    "api_main",
+    "ping",
+    "predict_route",
+    "train_route",
+    "_load_model",
+    "_model",
+]

--- a/model_builder/api.py
+++ b/model_builder/api.py
@@ -1,0 +1,204 @@
+"""REST API surface for the lightweight model builder service."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import numpy as np
+from flask import Flask, jsonify, request
+
+from bot.dotenv_utils import load_dotenv
+from services.logging_utils import sanitize_log_value
+from security import (
+    ArtifactDeserializationError,
+    safe_joblib_load,
+    verify_model_state_signature,
+    write_model_state_signature,
+)
+
+from .core import fit_scaler, logger, prepare_features, validate_host
+from .storage import JOBLIB_AVAILABLE, _safe_model_file_path, joblib
+
+api_app = Flask(__name__)
+_model: Any | None = None
+
+
+def _load_model() -> None:
+    """Load the persisted scikit-learn model if it exists."""
+
+    global _model
+    if not JOBLIB_AVAILABLE:
+        logger.warning("joblib недоступен, REST API пропускает загрузку модели")
+        _model = None
+        return
+    model_path = _safe_model_file_path()
+    if model_path is None:
+        _model = None
+        return
+    if not model_path.exists():
+        return
+    if model_path.is_symlink():
+        logger.warning(
+            "Отказ от загрузки модели из символьной ссылки %s",
+            sanitize_log_value(model_path),
+        )
+        _model = None
+        return
+    if not model_path.is_file():
+        logger.warning(
+            "Отказ от загрузки модели: %s не является обычным файлом",
+            sanitize_log_value(model_path),
+        )
+        _model = None
+        return
+    if not verify_model_state_signature(model_path):
+        logger.warning(
+            "Отказ от загрузки модели %s: подпись не прошла проверку",
+            sanitize_log_value(model_path),
+        )
+        _model = None
+        return
+    try:
+        _model = safe_joblib_load(model_path)
+    except ArtifactDeserializationError:
+        logger.error(
+            "Отказ от загрузки модели %s: обнаружены недоверенные объекты",
+            sanitize_log_value(model_path),
+        )
+        _model = None
+    except (OSError, ValueError) as exc:  # pragma: no cover - model may be corrupted
+        logger.exception("Не удалось загрузить модель: %s", exc)
+        _model = None
+    except Exception as exc:  # pragma: no cover - unexpected joblib failure
+        logger.exception(
+            "Неожиданная ошибка десериализации модели %s: %s",
+            sanitize_log_value(model_path),
+            exc,
+        )
+        _model = None
+
+
+@api_app.route("/train", methods=["POST"])
+def train_route():
+    data = request.get_json(force=True)
+    features, labels = prepare_features(
+        data.get("features", []), data.get("labels", [])
+    )
+    if features.size == 0 or len(features) != len(labels):
+        return jsonify({"error": "invalid training data"}), 400
+    if len(np.unique(labels)) < 2:
+        return jsonify({"error": "labels must contain at least two classes"}), 400
+    model = fit_scaler(features, labels)
+    if not JOBLIB_AVAILABLE:
+        return jsonify({"error": "joblib unavailable"}), 503
+    model_path = _safe_model_file_path()
+    if model_path is None:
+        return jsonify({"error": "invalid model path"}), 500
+    if model_path.exists():
+        if model_path.is_symlink():
+            logger.warning(
+                "Отказ от сохранения модели: путь %s является символьной ссылкой",
+                sanitize_log_value(model_path),
+            )
+            return jsonify({"error": "model path unavailable"}), 500
+        if not model_path.is_file():
+            logger.warning(
+                "Отказ от сохранения модели: %s не является обычным файлом",
+                sanitize_log_value(model_path),
+            )
+            return jsonify({"error": "model path unavailable"}), 500
+    try:
+        model_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:  # pragma: no cover - filesystem errors are rare
+        logger.exception(
+            "Не удалось подготовить каталог модели %s: %s",
+            sanitize_log_value(model_path),
+            exc,
+        )
+        return jsonify({"error": "model path unavailable"}), 500
+    tmp_path = model_path.with_name(f"{model_path.name}.tmp")
+    try:
+        joblib.dump(model, tmp_path)
+        os.replace(tmp_path, model_path)
+        try:
+            write_model_state_signature(model_path)
+        except OSError as exc:  # pragma: no cover - проблемы с ФС крайне редки
+            logger.warning(
+                "Не удалось сохранить подпись модели %s: %s",
+                sanitize_log_value(model_path),
+                exc,
+            )
+    except Exception as exc:  # pragma: no cover - dump failures are rare
+        logger.exception(
+            "Не удалось сохранить модель в %s: %s",
+            sanitize_log_value(model_path),
+            exc,
+        )
+        try:
+            if tmp_path.exists():
+                tmp_path.unlink()
+        except OSError:
+            logger.debug(
+                "Не удалось удалить временный файл %s",
+                sanitize_log_value(tmp_path),
+            )
+        return jsonify({"error": "model save failed"}), 500
+    global _model
+    _model = model
+    return jsonify({"status": "trained"})
+
+
+@api_app.route("/predict", methods=["POST"])
+def predict_route():
+    data = request.get_json(force=True)
+    features = data.get("features")
+    if features is None:
+        price_val = float(data.get("price", 0.0))
+        features = [price_val]
+    features = np.array(features, dtype=np.float32)
+    if features.ndim == 0:
+        features = np.array([[features]], dtype=np.float32)
+    elif features.ndim == 1:
+        features = features.reshape(1, -1)
+    else:
+        features = features.reshape(1, -1)
+    price = float(features[0, 0]) if features.size else 0.0
+    if _model is None:
+        signal = "buy" if price > 0 else None
+        prob = 1.0 if signal else 0.0
+    else:
+        prob = float(_model.predict_proba(features)[0, 1])
+        signal = "buy" if prob >= 0.5 else "sell"
+    return jsonify({"signal": signal, "prob": prob})
+
+
+@api_app.route("/ping")
+def ping():
+    return jsonify({"status": "ok"})
+
+
+try:  # pragma: no cover - optional in tests
+    from bot.utils import configure_logging
+except ImportError:  # pragma: no cover - stub for test environment
+
+    def configure_logging() -> None:  # type: ignore
+        """Stubbed logging configurator."""
+
+        pass
+
+
+def main() -> None:  # pragma: no cover - convenience CLI hook
+    """Run the API using the same behaviour as ``python -m model_builder.api``."""
+
+    configure_logging()
+    load_dotenv()
+    host = validate_host()
+    port = int(os.getenv("MODEL_BUILDER_PORT", "8001"))
+    _load_model()
+    logger.info("Запуск сервиса ModelBuilder на %s:%s", host, port)
+    api_app.run(host=host, port=port)  # хост проверен выше
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI execution
+    main()

--- a/model_builder/storage.py
+++ b/model_builder/storage.py
@@ -1,0 +1,153 @@
+"""Helpers for persisting and validating ModelBuilder artifacts."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+import os
+import platform
+import sys
+import time
+from pathlib import Path
+
+from bot.utils_loader import require_utils
+from security import create_joblib_stub, set_model_dir
+from services.logging_utils import sanitize_log_value
+
+_utils = require_utils(
+    "ensure_writable_directory",
+    "logger",
+)
+
+ensure_writable_directory = _utils.ensure_writable_directory
+logger = _utils.logger
+
+MODEL_DIR = ensure_writable_directory(
+    Path(os.getenv("MODEL_DIR", ".")),
+    description="моделей",
+    fallback_subdir="trading_bot_models",
+).resolve()
+set_model_dir(MODEL_DIR)
+
+MODEL_FILE: str | Path | None = os.environ.get("MODEL_FILE", "model.pkl")
+
+JOBLIB_AVAILABLE = True
+try:  # pragma: no cover - optional dependency
+    import joblib  # type: ignore
+except Exception as exc:  # pragma: no cover - stub for tests
+    JOBLIB_AVAILABLE = False
+    logger.warning(
+        "Не удалось импортировать joblib: %s. Сериализация моделей будет отключена.",
+        exc,
+    )
+    joblib = create_joblib_stub(
+        "joblib недоступен: установите зависимость для сохранения/загрузки моделей"
+    )
+    sys.modules.setdefault("joblib", joblib)
+
+
+def _is_within_directory(path: Path, directory: Path) -> bool:
+    """Return ``True`` if ``path`` is located within ``directory``."""
+
+    try:
+        path.resolve(strict=False).relative_to(directory.resolve(strict=False))
+    except ValueError:
+        return False
+    return True
+
+
+def _resolve_model_artifact(path_value: str | Path | None) -> Path:
+    """Return a sanitised model path confined to :data:`MODEL_DIR`."""
+
+    if path_value is None:
+        raise ValueError("model path is not set")
+    candidate = Path(path_value)
+    if not candidate.parts or candidate == Path("."):
+        raise ValueError("model path is empty")
+    if candidate.is_absolute():
+        resolved = candidate.resolve(strict=False)
+    else:
+        resolved = (MODEL_DIR / candidate).resolve(strict=False)
+    if not _is_within_directory(resolved, MODEL_DIR):
+        raise ValueError("model path escapes MODEL_DIR")
+    if resolved.exists():
+        if resolved.is_symlink():
+            raise ValueError("model path must not be a symlink")
+        if not resolved.is_file():
+            raise ValueError("model path must reference a regular file")
+    return resolved
+
+
+def _safe_model_file_path() -> Path | None:
+    """Return a validated path for ``MODEL_FILE`` or ``None`` if invalid."""
+
+    try:
+        return _resolve_model_artifact(MODEL_FILE)
+    except ValueError as exc:
+        logger.warning(
+            "Refusing to use MODEL_FILE %s: %s",
+            sanitize_log_value("<unset>" if MODEL_FILE is None else str(MODEL_FILE)),
+            exc,
+        )
+        return None
+
+
+def save_artifacts(model: object, symbol: str, meta: dict) -> Path:
+    """Сохранить модель и метаданные в каталог артефактов."""
+
+    timestamp = str(int(time.time()))
+    target_dir = MODEL_DIR / symbol / timestamp
+    target_dir.mkdir(parents=True, exist_ok=True)
+    model_file = target_dir / "model.pkl"
+    if JOBLIB_AVAILABLE:
+        joblib.dump(model, model_file)
+    else:
+        logger.warning(
+            "joblib недоступен, модель %s не будет сохранена на диск", symbol
+        )
+
+    try:
+        head_file = Path(".git/HEAD")
+        if head_file.is_file():
+            ref = head_file.read_text().strip()
+            if ref.startswith("ref:"):
+                ref_path = Path(".git") / ref.split()[1]
+                code_version = ref_path.read_text().strip()
+            else:
+                code_version = ref
+        else:
+            code_version = "unknown"
+    except Exception:
+        code_version = "unknown"
+
+    try:
+        pip_freeze = sorted(
+            f"{dist.metadata['Name']}=={dist.version}"
+            for dist in importlib.metadata.distributions()
+        )
+    except Exception:
+        pip_freeze = []
+
+    meta_env = {
+        "code_version": code_version,
+        "python_version": platform.python_version(),
+        "pip_freeze": pip_freeze,
+        "platform": platform.platform(),
+    }
+    meta_all = {**meta_env, **(meta or {})}
+    with open(target_dir / "meta.json", "w", encoding="utf-8") as f:
+        json.dump(meta_all, f, ensure_ascii=False, indent=2)
+
+    return target_dir
+
+
+__all__ = [
+    "MODEL_DIR",
+    "MODEL_FILE",
+    "JOBLIB_AVAILABLE",
+    "joblib",
+    "_is_within_directory",
+    "_resolve_model_artifact",
+    "_safe_model_file_path",
+    "save_artifacts",
+]

--- a/tests/test_model_builder_model_dir.py
+++ b/tests/test_model_builder_model_dir.py
@@ -7,9 +7,11 @@ import pytest
 
 
 def _load_model_builder(module_name: str) -> object:
+    package_path = Path(__file__).resolve().parents[1] / "model_builder"
     spec = importlib.util.spec_from_file_location(
         module_name,
-        Path(__file__).resolve().parents[1] / "model_builder.py",
+        package_path / "__init__.py",
+        submodule_search_locations=[str(package_path)],
     )
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
@@ -17,7 +19,9 @@ def _load_model_builder(module_name: str) -> object:
     try:
         spec.loader.exec_module(module)
     finally:
-        sys.modules.pop(module_name, None)
+        for name in list(sys.modules):
+            if name == module_name or name.startswith(f"{module_name}."):
+                sys.modules.pop(name, None)
     return module
 
 


### PR DESCRIPTION
## Summary
- split the monolithic model_builder module into a package with dedicated core, storage, and api modules
- preserve backwards compatibility through a compatibility-focused model_builder/__init__.py facade
- adjust model builder tests to import the new package structure

## Testing
- pytest tests/test_model_builder_import.py
- pytest tests/test_model_builder_model_dir.py tests/test_model_builder_signatures.py

------
https://chatgpt.com/codex/tasks/task_e_68d919018ae0832dad301d1aa235b92c