### PR TITLE
Refactor service wiring for offline mode

### DIFF
--- a/config.py
+++ b/config.py
@@ -333,6 +333,9 @@ class BotConfig:
     enable_notifications: bool = _get_default("enable_notifications", True)
     save_unsent_telegram: bool = _get_default("save_unsent_telegram", False)
     unsent_telegram_path: str = _get_default("unsent_telegram_path", "unsent_telegram.log")
+    service_factories: Dict[str, str] = field(
+        default_factory=lambda: dict(_get_default("service_factories", {}))
+    )
 
     def __post_init__(self) -> None:
         if self.ws_subscription_batch_size is None:

--- a/model_builder/core.py
+++ b/model_builder/core.py
@@ -807,10 +807,17 @@ def _train_model_remote(
 class ModelBuilder:
     """Simplified model builder used for training LSTM models."""
 
-    def __init__(self, config: BotConfig, data_handler, trade_manager):
+    def __init__(
+        self,
+        config: BotConfig,
+        data_handler,
+        trade_manager,
+        gpt_client_factory=None,
+    ):
         self.config = config
         self.data_handler = data_handler
         self.trade_manager = trade_manager
+        self.gpt_client_factory = gpt_client_factory
         self.model_type = config.get("model_type", "transformer")
         self.nn_framework = config.get("nn_framework", "pytorch").lower()
         # Predictive models for each trading symbol

--- a/services/offline.py
+++ b/services/offline.py
@@ -225,3 +225,10 @@ class OfflineGPT:
     @staticmethod
     async def query_json_async(prompt: str) -> dict:
         return {"signal": "hold"}
+
+
+OFFLINE_SERVICE_FACTORIES: dict[str, str] = {
+    "exchange": "services.offline:OfflineBybit",
+    "telegram_logger": "services.offline:OfflineTelegram",
+    "gpt_client": "services.offline:OfflineGPT",
+}


### PR DESCRIPTION
## Summary
- add a configurable `service_factories` mapping to `BotConfig` and expose offline defaults
- update `run_bot` to resolve exchange, Telegram logger, and GPT client via factories rather than monkey patches
- allow `ModelBuilder` and `TradeManager` to accept injected service factories and propagate them during setup

## Testing
- pytest tests/test_offline_mode_stubs.py tests/test_trading_bot.py

------
https://chatgpt.com/codex/tasks/task_e_68d922e87578832d894939b37b438d2f