### PR TITLE
Expose TradeManager positions through service

### DIFF
--- a/tests/test_trade_manager_service_api.py
+++ b/tests/test_trade_manager_service_api.py
@@ -118,6 +118,7 @@ def test_open_position_emergency_close_when_cancel_unavailable(monkeypatch):
 
 def _setup_trade_manager(monkeypatch):
     tm, loop, stub = tm_routes._setup_module(monkeypatch)
+    stub._positions_data = []
     return tm, loop, stub
 
 


### PR DESCRIPTION
## Summary
- add a coroutine on `TradeManager` to produce a JSON-friendly snapshot of open positions
- refactor the service endpoints to await position data from the manager instead of using a global cache
- update the TradeManager route tests to exercise the new positions path and reset the stubbed snapshot in API tests

## Testing
- pytest tests/test_trade_manager_routes.py tests/test_trade_manager_service_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d922f06dac832da6ee9a4ef762da21