### PR TITLE
Fix CodeQL parse errors from Git reference logs

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,11 +1,12 @@
 name: bot CodeQL configuration
 paths-ignore:
-  # Ensure Git metadata created during checkout (including reference logs) is never
-  # analysed by CodeQL. CodeQL interprets any *.py file it discovers as Python
-  # source, so logs for remote refs with names that end in ".py" must be
-  # excluded explicitly. We therefore ignore .git directories (and everything
-  # beneath them) no matter where they appear in the workspace tree to avoid
-  # future false parse errors when CodeQL walks the workspace.
+  # Ignore Git metadata everywhere in the checkout so that CodeQL never walks
+  # into reference logs for remote branches that happen to end with the .py
+  # suffix. Those logs are plain text, but the extractor interprets the file
+  # extension literally and attempts to parse them as Python modules, which
+  # surfaces hundreds of misleading syntax errors. Explicitly excluding all
+  # .git directories (and everything under them) keeps the analysis focused on
+  # real source files while remaining resilient to future branch names.
   - /.git
   - /.git/**
   - .git

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,17 +28,22 @@ jobs:
 
       - name: Remove Git metadata directories that mimic Python files
         run: |
-          # Remove the primary repository metadata directory as well as any
-          # nested ones that may exist after checkout. CodeQL treats any file
-          # ending in .py as Python source, and Git reference logs for remote
-          # branches can therefore surface as false positives. A simple rm -rf
-          # is more reliable than a complex find expression and avoids
-          # corner-case syntax issues that previously left the directories in
-          # place. As an extra safeguard we also prune any stray *.py files
-          # that may remain in Git reference logs should a runner cache or
-          # filesystem quirk prevent the directories from being removed.
-          rm -rf .git
+          # CodeQL interprets any file ending in .py as Python source. Git keeps
+          # reference logs for remote branches inside .git/logs/, and branch
+          # names that end with ".py" therefore look like legitimate modules to
+          # the extractor, even though the files are plaintext Git logs. When a
+          # workflow fetches the entire history (fetch-depth: 0), those logs are
+          # recreated and CodeQL tries to parse them, triggering hundreds of
+          # syntax errors. To eliminate the false positives we proactively scrub
+          # every .git directory that may exist in the workspace.
+          if [ -d ".git" ]; then
+            rm -rf .git
+          fi
+          # Remove any nested .git directories that might be present because of
+          # submodules or cached runner state.
           find "$PWD" -type d -name ".git" -prune -exec rm -rf {} +
+          # As a final safeguard, delete stray Git reference logs that still
+          # match the *.py glob in case a filesystem quirk prevented removal.
           find "$PWD" -path '*/.git/logs/*' -name '*.py' -delete
 
       - name: Set up Python


### PR DESCRIPTION
## Summary
- remove `.git` metadata after checkout so CodeQL cannot scan branch reference logs masquerading as Python files
- document why the CodeQL configuration ignores `.git` directories to keep analysis focused on real source code

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d92360390c832db4adccf12ddec97e