### PR TITLE
Prevent CodeQL from parsing Git reference logs as Python files

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,4 +1,5 @@
 name: bot CodeQL configuration
+
 paths-ignore:
   # Ignore Git metadata everywhere in the checkout so that CodeQL never walks
   # into reference logs for remote branches that happen to end with the .py
@@ -7,10 +8,6 @@ paths-ignore:
   # surfaces hundreds of misleading syntax errors. Explicitly excluding all
   # .git directories (and everything under them) keeps the analysis focused on
   # real source files while remaining resilient to future branch names.
-  - /.git
-  - /.git/**
-  - .git
   - .git/**
-  - '**/.git'
   - '**/.git/**'
   - '**/.git/logs/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Remove Git metadata directories that mimic Python files
+      - name: Purge Python-looking Git reference logs
         run: |
           # CodeQL interprets any file ending in .py as Python source. Git keeps
           # reference logs for remote branches inside .git/logs/, and branch
@@ -34,16 +34,14 @@ jobs:
           # the extractor, even though the files are plaintext Git logs. When a
           # workflow fetches the entire history (fetch-depth: 0), those logs are
           # recreated and CodeQL tries to parse them, triggering hundreds of
-          # syntax errors. To eliminate the false positives we proactively scrub
-          # every .git directory that may exist in the workspace.
-          if [ -d ".git" ]; then
-            rm -rf .git
+          # syntax errors. Rather than deleting the entire .git directory (which
+          # we might want for other tooling), remove only the misleading *.py
+          # files from any Git log directories that exist in the workspace.
+          if [ -d ".git/logs" ]; then
+            find .git/logs -name '*.py' -delete
           fi
-          # Remove any nested .git directories that might be present because of
-          # submodules or cached runner state.
-          find "$PWD" -type d -name ".git" -prune -exec rm -rf {} +
-          # As a final safeguard, delete stray Git reference logs that still
-          # match the *.py glob in case a filesystem quirk prevented removal.
+          # Some actions (such as caching or submodules) can leave additional
+          # .git directories behind, so sweep the whole workspace just in case.
           find "$PWD" -path '*/.git/logs/*' -name '*.py' -delete
 
       - name: Set up Python


### PR DESCRIPTION
## Summary
- simplify the CodeQL configuration to ignore every .git directory and its logs
- prune misleading *.py files from Git reference logs without deleting the repository metadata during analysis

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d92e7ba580832da8df2f1e3504eecf