### PR TITLE
Fix model builder facade attribute access and SHAP dtype fallback

### DIFF
--- a/model_builder/__init__.py
+++ b/model_builder/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from . import core as _core_module
 from .core import (
     IS_RAY_STUB,
     DQN,
@@ -65,13 +66,20 @@ class _ModelBuilderModule(types.ModuleType):
     def __getattr__(self, name: str):  # type: ignore[override]
         if name == "_model":
             return _api._model
-        return super().__getattr__(name)
+        try:
+            return super().__getattribute__(name)
+        except AttributeError:
+            if hasattr(_core_module, name):
+                return getattr(_core_module, name)
+            raise
 
     def __setattr__(self, name: str, value) -> None:  # type: ignore[override]
         if name == "_model":
             _api._model = value
         else:
             super().__setattr__(name, value)
+            if hasattr(_core_module, name):
+                setattr(_core_module, name, value)
 
 
 sys.modules[__name__].__class__ = _ModelBuilderModule


### PR DESCRIPTION
## Summary
- ensure the `model_builder` package facade proxies attribute lookups to the core module so monkeypatching works as expected
- tighten gymnasium import handling to honour `ALLOW_GYM_STUB=0` while still allowing the legacy gym fallback when permitted
- make SHAP tensor creation resilient when the torch stub lacks a `float32` attribute

## Testing
- pytest tests/test_model_builder_cache.py tests/test_model_builder_import.py tests/test_shap_cache.py

------
https://chatgpt.com/codex/tasks/task_e_68d92f0afbc0832d80414980ed4c2341