### PR TITLE
Adjust release drafter concurrency grouping

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -23,7 +23,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: release-drafter-${{ github.event_name == 'pull_request_target' && format('pr-{0}', github.event.number) || github.ref }}
+  group: release-drafter-${{ github.event_name == 'pull_request_target' && format('pr-{0}', github.event.number) || github.ref_name }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary
- normalize the Release Drafter workflow concurrency group by switching to `github.ref_name`
- keep unique grouping for pull_request_target events while avoiding invalid characters for other events

## Testing
- /root/.local/share/mise/installs/go/1.24.3/bin/actionlint .github/workflows/release-drafter.yml

------
https://chatgpt.com/codex/tasks/task_e_68d93c7e22c0832d809a2f2e6d56ac38