### PR TITLE
Fix TradeManager await helper and gym import handling

### DIFF
--- a/bot/trade_manager/service.py
+++ b/bot/trade_manager/service.py
@@ -11,6 +11,7 @@ import math
 import os
 import sys
 import threading
+import concurrent.futures
 from typing import Any, Awaitable, Mapping, TypeVar, cast
 
 import httpx
@@ -126,7 +127,12 @@ def _await_manager_result(
 ) -> _T:
     """Wait for an awaitable to finish on the TradeManager loop."""
 
-    future = asyncio.run_coroutine_threadsafe(awaitable, loop)
+    async def _coerce() -> _T:
+        return await awaitable
+
+    future: concurrent.futures.Future[_T] = asyncio.run_coroutine_threadsafe(
+        _coerce(), loop
+    )
     try:
         return future.result(timeout)
     except Exception:

--- a/model_builder/__init__.py
+++ b/model_builder/__init__.py
@@ -2,7 +2,20 @@
 
 from __future__ import annotations
 
-from . import core as _core_module
+import importlib
+import os
+import sys
+import types
+
+_core_module = importlib.import_module(".core", __name__)
+_allow_stub_env = os.getenv("ALLOW_GYM_STUB", "1").strip().lower() not in {
+    "0",
+    "false",
+    "no",
+}
+if not _allow_stub_env:
+    _core_module = importlib.reload(_core_module)
+
 from .core import (
     IS_RAY_STUB,
     DQN,
@@ -31,8 +44,6 @@ from .core import (
     spaces,
     validate_host,
 )
-import sys
-import types
 
 from . import api as _api
 from .storage import (
@@ -79,7 +90,7 @@ class _ModelBuilderModule(types.ModuleType):
         else:
             super().__setattr__(name, value)
             if hasattr(_core_module, name):
-                setattr(_core_module, name, value)
+                _core_module.__dict__[name] = value
 
 
 sys.modules[__name__].__class__ = _ModelBuilderModule

--- a/model_builder/core.py
+++ b/model_builder/core.py
@@ -90,6 +90,8 @@ def _load_gym() -> tuple[object, object]:
         spaces_mod.Discrete = _Discrete
         spaces_mod.Box = _Box
         gym_mod.spaces = spaces_mod
+        gym_mod.__dict__["__model_builder_stub__"] = True
+        spaces_mod.__dict__["__model_builder_stub__"] = True
         sys.modules.setdefault("gymnasium", gym_mod)
         sys.modules.setdefault("gymnasium.spaces", spaces_mod)
         return gym_mod, spaces_mod
@@ -100,21 +102,34 @@ def _load_gym() -> tuple[object, object]:
     test_mode = os.getenv("TEST_MODE") == "1"
     allow_stub = test_mode and allow_stub_env
 
+    def _record(using_stub: bool) -> None:
+        globals()["_GYM_ALLOW_STUB_ENV"] = allow_stub_env
+        globals()["_GYM_STUB_ALLOWED"] = allow_stub
+        globals()["_GYM_USING_STUB"] = using_stub
+
     try:  # prefer gymnasium if available
         import gymnasium as gym  # type: ignore
         from gymnasium import spaces  # type: ignore
-        return gym, spaces
     except ImportError as gymnasium_error:
         if allow_stub:
-            return _ensure_stub()
+            gym_mod, spaces_mod = _ensure_stub()
+            _record(True)
+            return gym_mod, spaces_mod
         if allow_stub_env:
             try:
                 import gym  # type: ignore
                 from gym import spaces  # type: ignore
+            except ImportError as gym_error:
+                _record(False)
+                raise ImportError("gymnasium package is required") from gym_error
+            else:
+                _record(False)
                 return gym, spaces
-            except ImportError:
-                pass
+        _record(False)
         raise ImportError("gymnasium package is required") from gymnasium_error
+    else:
+        _record(False)
+        return gym, spaces
 
 
 gym, spaces = _load_gym()


### PR DESCRIPTION
## Summary
- wrap the TradeManager service await helper in a coroutine and annotate the concurrent future so mypy accepts run_coroutine_threadsafe
- track gym stub usage inside model_builder.core to record environment flags and mark stub modules
- reload model_builder.core when stubs are disallowed and update attribute mirroring without recursion

## Testing
- python -m ruff check bot tests
- python -m mypy bot
- python -m flake8 .
- python -m bandit -r bot -x tests -ll
- pytest -m "not integration"


------
https://chatgpt.com/codex/tasks/task_e_68d93c1b2008832d8ace0d16944f0951