### PR TITLE
Stop installing requests during dependency snapshot workflow

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -182,11 +182,6 @@ jobs:
                       updated = "".join(filtered)
                       path.write_text(updated, encoding="utf-8")
           PY
-      - name: Install dependency snapshot dependencies
-        if: steps.detect.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install requests
       - name: Submit dependency snapshot
         if: steps.detect.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
         env:

--- a/tests/test_dependency_graph_workflow.py
+++ b/tests/test_dependency_graph_workflow.py
@@ -57,12 +57,11 @@ def test_dependency_graph_detect_step_handles_nested_manifests() -> None:
     assert "fnmatch(filename, pattern)" in workflow
 
 
-def test_dependency_graph_installs_requests_before_submission() -> None:
+def test_dependency_graph_avoids_unnecessary_package_installs() -> None:
     workflow = Path(".github/workflows/dependency-graph.yml").read_text(encoding="utf-8")
 
-    assert "Install dependency snapshot dependencies" in workflow
-    assert "python -m pip install --upgrade pip" in workflow
-    assert "python -m pip install requests" in workflow
+    assert "Install dependency snapshot dependencies" not in workflow
+    assert "pip install" not in workflow
 
 
 def test_dependency_graph_filters_ccxtpro_lines_before_snapshot() -> None:

--- a/tests/test_dependency_snapshot.py
+++ b/tests/test_dependency_snapshot.py
@@ -183,7 +183,7 @@ def test_submit_dependency_snapshot_reports_submission_error(
     assert "HTTP 400" in captured.err
 
 
-def test_submit_dependency_snapshot_reports_missing_requests(
+def test_submit_dependency_snapshot_reports_network_errors(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     monkeypatch.setenv("GITHUB_REPOSITORY", "averinaleks/bot")
@@ -198,9 +198,7 @@ def test_submit_dependency_snapshot_reports_missing_requests(
     }
     monkeypatch.setattr(snapshot, "_build_manifests", lambda _: {"requirements.txt": manifest})
 
-    error = snapshot.DependencySubmissionError(
-        None, "Dependency snapshot submission requires the 'requests' package."
-    )
+    error = snapshot.DependencySubmissionError(None, "network unreachable")
 
     def raise_missing_dependency(*_: object, **__: object) -> None:
         raise error
@@ -211,7 +209,7 @@ def test_submit_dependency_snapshot_reports_missing_requests(
 
     captured = capsys.readouterr()
     assert "Dependency snapshot submission skipped из-за сетевой ошибки." in captured.err
-    assert "Dependency snapshot submission requires the 'requests' package." in captured.err
+    assert "network unreachable" in captured.err
 
 
 def test_submit_dependency_snapshot_uses_string_metadata(


### PR DESCRIPTION
## Summary
- replace the dependency snapshot submission helper with a stdlib HTTPS client that retries transient failures
- drop the pip-install step from the dependency-graph workflow and update tests to reflect the leaner job

## Testing
- pytest tests/test_dependency_snapshot.py tests/test_dependency_snapshot_import.py tests/test_dependency_snapshot_parser.py tests/test_dependency_graph_workflow.py

------
https://chatgpt.com/codex/tasks/task_e_68d93c649e10832dad65b537171d99d0