### PR TITLE
Handle missing httpx metadata in dependency snapshot tests

### DIFF
--- a/tests/test_dependency_snapshot.py
+++ b/tests/test_dependency_snapshot.py
@@ -13,8 +13,14 @@ httpx = pytest.importorskip("httpx")
 
 try:
     HTTPX_VERSION = httpx.__version__
-except AttributeError:  # pragma: no cover - fallback for older releases
-    HTTPX_VERSION = metadata.version("httpx")
+except AttributeError:  # pragma: no cover - fallback for older or metadata-less releases
+    try:
+        HTTPX_VERSION = metadata.version("httpx")
+    except metadata.PackageNotFoundError:  # pragma: no cover - skip when dist metadata absent
+        pytest.skip(
+            "httpx distribution metadata is unavailable",
+            allow_module_level=True,
+        )
 
 HTTPX_REQUIREMENT = f"httpx=={HTTPX_VERSION}"
 HTTPX_PURL = f"pkg:pypi/httpx@{snapshot._encode_version_for_purl(HTTPX_VERSION)}"


### PR DESCRIPTION
## Summary
- make the dependency snapshot tests tolerate environments where httpx no longer exposes __version__ metadata
- fall back to importlib.metadata and skip the module when the distribution metadata is unavailable

## Testing
- pytest tests/test_dependency_snapshot.py -k httpx --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68d9446dd790832da5a0d80f0131ae2e