### PR TITLE
Handle missing httpx metadata in dependency snapshot tests

### DIFF
--- a/tests/test_dependency_snapshot.py
+++ b/tests/test_dependency_snapshot.py
@@ -14,7 +14,10 @@ httpx = pytest.importorskip("httpx")
 try:
     HTTPX_VERSION = httpx.__version__
 except AttributeError:  # pragma: no cover - fallback for older releases
-    HTTPX_VERSION = metadata.version("httpx")
+    try:
+        HTTPX_VERSION = metadata.version("httpx")
+    except metadata.PackageNotFoundError:  # pragma: no cover - optional dependency guard
+        pytest.skip("httpx metadata not available", allow_module_level=True)
 
 HTTPX_REQUIREMENT = f"httpx=={HTTPX_VERSION}"
 HTTPX_PURL = f"pkg:pypi/httpx@{snapshot._encode_version_for_purl(HTTPX_VERSION)}"


### PR DESCRIPTION
## Summary
- allow the dependency snapshot test suite to skip cleanly when httpx metadata is unavailable

## Testing
- pytest tests/test_dependency_snapshot.py -q
- pytest tests/test_dependency_graph_workflow.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d9444afdf4832d9c2a03e9a5a8c85e