### PR TITLE
Handle Telegram API errors in GPT-OSS check

### DIFF
--- a/gptoss_check/check_code.py
+++ b/gptoss_check/check_code.py
@@ -401,7 +401,10 @@ def send_telegram(msg: str) -> None:
                     f"https://api.telegram.org/bot{token}/sendMessage",
                     data={"chat_id": chat_id, "text": msg[:4000]},
                 )
-                response.close()
+                try:
+                    response.raise_for_status()
+                finally:
+                    response.close()
         except HTTPError as err:
             logger.warning("⚠️ Failed to send Telegram message: %s", err)
 


### PR DESCRIPTION
## Summary
- ensure the GPT-OSS Telegram helper raises on non-success HTTP responses so failures are logged
- add a regression test covering the error path and response cleanup

## Testing
- pytest tests/test_gptoss_check.py

------
https://chatgpt.com/codex/tasks/task_e_68d944984324832dbacf4f1fda5688ac