### PR TITLE
Fix Trivy workflow cache directory setup

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -9,9 +9,6 @@ on:
   schedule:
     - cron: "21 10 * * 2"
 
-env:
-  TRIVY_CACHE_DIR: ${{ runner.temp }}/trivy-cache
-
 jobs:
   scan_pull_request:
     name: Scan (pull requests)
@@ -25,6 +22,10 @@ jobs:
         # v4
         with:
           persist-credentials: false
+
+      - name: Set Trivy cache directory
+        run: |
+          echo "TRIVY_CACHE_DIR=${{ runner.temp }}/trivy-cache" >> "$GITHUB_ENV"
 
       - name: Prepare Trivy cache directory
         run: |
@@ -121,6 +122,10 @@ jobs:
         # v4
         with:
           persist-credentials: false
+
+      - name: Set Trivy cache directory
+        run: |
+          echo "TRIVY_CACHE_DIR=${{ runner.temp }}/trivy-cache" >> "$GITHUB_ENV"
 
       - name: Prepare Trivy cache directory
         run: |


### PR DESCRIPTION
## Summary
- export the Trivy cache path from a dedicated step in each job instead of using the runner context at workflow scope
- reuse the exported cache directory for preparatory, cache, and scan steps in both pull request and default jobs

## Testing
- ACTIONLINT_NO_COLOR=1 /tmp/actionlint .github/workflows/trivy.yml

------
https://chatgpt.com/codex/tasks/task_e_68d947693e9c832d96bfa435c39fb526