### PR TITLE
Handle filesystem errors explicitly

### DIFF
--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -149,8 +149,10 @@ def _wrap_tempfile_mkdtemp() -> None:
             if target_dir:
                 try:
                     Path(target_dir).mkdir(parents=True, exist_ok=True)
-                except Exception:
-                    pass
+                except OSError as exc:
+                    raise RuntimeError(
+                        f"Не удалось подготовить каталог временных файлов: {target_dir!s}"
+                    ) from exc
             try:
                 return original(*args, **kwargs)
             except FileNotFoundError:


### PR DESCRIPTION
## Summary
- raise a runtime error when preparing a temporary directory fails in the site customizations hook
- log and surface failures when preparing temp directories and resetting the tempfile cache in the utils helpers

## Testing
- bandit -r . -ll -ii -x ./tests,./scripts,./gptoss_check

------
https://chatgpt.com/codex/tasks/task_e_68d94a5a7cc4832da7a46d9ab7c2bbd9