### PR TITLE
Fix model_builder module wrapper imports

### DIFF
--- a/model_builder/__init__.py
+++ b/model_builder/__init__.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+import os
+import sys
+import types
+
+from . import core as _core_module
 from .core import (
     IS_RAY_STUB,
     DQN,


### PR DESCRIPTION
## Summary
- import the missing stdlib modules used by the model_builder facade and expose the core module for attribute syncing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d94a70e88c832d87c0da23d3b4a3a2