### PR TITLE
Fix model builder module registration imports

### DIFF
--- a/model_builder/__init__.py
+++ b/model_builder/__init__.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+import os
+import sys
+import types
+
+from . import core as _core_module
 from .core import (
     IS_RAY_STUB,
     DQN,
@@ -77,7 +82,6 @@ class _ModelBuilderModule(types.ModuleType):
             super().__setattr__(name, value)
             if hasattr(_core_module, name):
                 _core_module.__dict__[name] = value
-
 
 sys.modules[__name__].__class__ = _ModelBuilderModule
 


### PR DESCRIPTION
## Summary
- import the standard library modules used by the model_builder facade
- alias the core module so the dynamic module wrapper can mirror its attributes for Dependabot checks

## Testing
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_e_68d94a9b4b84832dba02e4bc852aee32