### PR TITLE
Fix model builder module wrapper imports

### DIFF
--- a/model_builder/__init__.py
+++ b/model_builder/__init__.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+import os
+import sys
+import types
+
+from . import core as _core_module
 from .core import (
     IS_RAY_STUB,
     DQN,
@@ -30,6 +35,8 @@ from .core import (
     spaces,
     validate_host,
 )
+
+_current_module = sys.modules[__name__]
 
 from . import api as _api
 from .storage import (
@@ -79,7 +86,7 @@ class _ModelBuilderModule(types.ModuleType):
                 _core_module.__dict__[name] = value
 
 
-sys.modules[__name__].__class__ = _ModelBuilderModule
+_current_module.__class__ = _ModelBuilderModule
 
 if os.getenv("ALLOW_GYM_STUB", "1").strip().lower() in {"0", "false", "no"}:
     if getattr(_core_module.gym, "_BOT_GYM_STUB", False):


### PR DESCRIPTION
## Summary
- import the core module explicitly in `model_builder.__init__` so the facade can forward attributes correctly
- initialize the module wrapper with explicit references to the current module to avoid NameError during Dependabot runs

## Testing
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_e_68d94aaa1fc8832dbf98694fc5645e1d