### PR TITLE
Fix release drafter concurrency expression

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -23,7 +23,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: release-drafter-${{ github.event_name == 'pull_request_target' && format('pr-{0}', github.event.number) || github.ref_name }}
+  group: release-drafter-${{ github.event_name == 'pull_request_target' && format('pr-{0}', github.event.number) || github.ref }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary
- update the Release Drafter workflow concurrency group to use a context that is always available

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d94adec028832d98da47c642bc015e