### PR TITLE
Fix model_builder module wrapper imports

### DIFF
--- a/model_builder/__init__.py
+++ b/model_builder/__init__.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+import os
+import sys
+import types
+
+from . import core as _core_module
 from .core import (
     IS_RAY_STUB,
     DQN,


### PR DESCRIPTION
## Summary
- import the core module alongside existing symbol re-exports
- register missing standard library modules needed by the module wrapper

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d94afbe568832d81e56ec605e275ed