### PR TITLE
Fix CI stubs and expose model builder exports

### DIFF
--- a/model_builder/__init__.py
+++ b/model_builder/__init__.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+import os
+import sys
+import types
+
+from . import core as _core_module
 from .core import (
     IS_RAY_STUB,
     DQN,
@@ -11,6 +16,7 @@ from .core import (
     RLAgent,
     SB3_AVAILABLE,
     TradingEnv,
+    KERAS_FRAMEWORKS,
     _freeze_keras_base_layers,
     _freeze_torch_base_layers,
     _get_torch_modules,
@@ -100,6 +106,7 @@ __all__ = [
     "RLAgent",
     "SB3_AVAILABLE",
     "TradingEnv",
+    "KERAS_FRAMEWORKS",
     "_freeze_keras_base_layers",
     "_freeze_torch_base_layers",
     "_get_torch_modules",

--- a/services/stubs.py
+++ b/services/stubs.py
@@ -186,7 +186,7 @@ def create_httpx_stub() -> SimpleNamespace:
                     close_sync = getattr(self._response, "close", None)
                     if callable(close_sync):
                         close_sync()
-                    return False
+                    return None
 
             return _StreamContext(response)
 

--- a/test_stubs.py
+++ b/test_stubs.py
@@ -310,7 +310,7 @@ def apply() -> None:
                         close = getattr(self._response, "close", None)
                         if callable(close):
                             close()
-                        return False
+                        return None
 
                 return _StreamContext(response)
 


### PR DESCRIPTION
## Summary
- export `KERAS_FRAMEWORKS` from the model_builder facade and tighten its module wrapper imports
- centralize installation of gym, Ray RLlib, and stable-baselines3 stubs with typed fallbacks and dictionary annotations in `model_builder.core`
- ensure prediction history statistics handle typed entries and fix stub HTTP context managers to return `None`

## Testing
- python -m flake8 --exclude venv .
- python -m mypy --exclude venv .
- pytest -ra -m "not integration"


------
https://chatgpt.com/codex/tasks/task_e_68d94a857418832d8db9f63c2cb2978c