### PR TITLE
Fix model_builder module wrapper imports

### DIFF
--- a/model_builder/__init__.py
+++ b/model_builder/__init__.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+import os
+import sys
+import types
+
+from . import core as _core_module
 from .core import (
     IS_RAY_STUB,
     DQN,


### PR DESCRIPTION
## Summary
- ensure the model_builder module wrapper imports the types module and references the core module object so attribute lookups succeed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d94aded474832dbd1bd4431bbe14ca