### PR TITLE
Improve dependency snapshot workflow guidance

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -11,8 +11,9 @@ on:
 
 permissions:
   contents: read
-  # GitHub rejects the legacy `dependency-graph` scope for this workflow; grant `security-events`
-  # instead to satisfy the dependency submission API while keeping permissions minimal.
+  # GitHub rejects the legacy dependency graph permission scope for this workflow; grant
+  # `security-events` instead to satisfy the dependency submission API while keeping
+  # permissions minimal.
   security-events: write
 
 jobs:

--- a/scripts/submit_dependency_snapshot.py
+++ b/scripts/submit_dependency_snapshot.py
@@ -74,7 +74,8 @@ _TOKEN_PREFIXES = ("ghp_", "gho_", "ghu_", "ghs_", "ghr_", "github_pat_")
 
 _SKIPPED_PACKAGES = {"ccxtpro"}
 _REQUESTS_REQUIRED_MESSAGE = (
-    "Dependency snapshot submission requires the 'requests' package."
+    "Dependency snapshot submission requires the 'requests' package. "
+    "Install it with 'pip install requests'."
 )
 
 

--- a/tests/test_dependency_snapshot.py
+++ b/tests/test_dependency_snapshot.py
@@ -205,7 +205,11 @@ def test_submit_dependency_snapshot_reports_missing_requests(
     monkeypatch.setattr(snapshot, "_build_manifests", lambda _: {"requirements.txt": manifest})
 
     error = snapshot.DependencySubmissionError(
-        None, "Dependency snapshot submission requires the 'requests' package."
+        None,
+        (
+            "Dependency snapshot submission requires the 'requests' package. "
+            "Install it with 'pip install requests'."
+        ),
     )
 
     def raise_missing_dependency(*_: object, **__: object) -> None:
@@ -217,7 +221,8 @@ def test_submit_dependency_snapshot_reports_missing_requests(
 
     captured = capsys.readouterr()
     assert "Dependency snapshot submission skipped из-за сетевой ошибки." in captured.err
-    assert "Dependency snapshot submission requires the 'requests' package." in captured.err
+    assert "Dependency snapshot submission requires the 'requests' package" in captured.err
+    assert "Install it with 'pip install requests'." in captured.err
 
 
 def test_submit_dependency_snapshot_uses_repository_dispatch_payload(


### PR DESCRIPTION
## Summary
- clarify the dependency submission workflow comments around the required permission scope
- mention the installation command in the dependency snapshot script when requests is missing
- update the dependency snapshot tests to reflect the improved messaging

## Testing
- pytest tests/test_dependency_graph_workflow.py tests/test_dependency_snapshot.py tests/test_dependency_snapshot_import.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d94aba1db4832d8327a8cfcf0312c4