### PR TITLE
Handle repository dispatch payload SHA fallback

### DIFF
--- a/scripts/submit_dependency_snapshot.py
+++ b/scripts/submit_dependency_snapshot.py
@@ -671,6 +671,11 @@ def submit_dependency_snapshot() -> None:
                 if ref_candidate:
                     ref = ref_candidate
                     payload_used = True
+        if not sha and isinstance(payload, dict):
+            sha_candidate = _extract_payload_value(payload, "after", "sha", "head_sha")
+            if sha_candidate:
+                sha = sha_candidate
+                payload_used = True
         if not ref and isinstance(payload, dict):
             ref_candidate = _extract_payload_value(payload, "ref")
             if ref_candidate:


### PR DESCRIPTION
## Summary
- read repository_dispatch SHA and ref values from the top-level event payload when the client payload is absent
- add a regression test ensuring dependency snapshot submission uses root payload data

## Testing
- pytest tests/test_dependency_snapshot.py -k payload -q


------
https://chatgpt.com/codex/tasks/task_e_68d952c3166c832d9bd4c2cdf3b0e9ae