### PR TITLE
Improve dependency scope detection for dependency snapshot workflow

### DIFF
--- a/scripts/submit_dependency_snapshot.py
+++ b/scripts/submit_dependency_snapshot.py
@@ -181,8 +181,20 @@ def _normalise_name(name: str) -> str:
 
 def _derive_scope(manifest_name: str) -> str:
     lowered = manifest_name.lower()
-    if any(token in lowered for token in ("dev", "test", "ci", "health")):
-        return "development"
+    tokens = [
+        token
+        for token in re.split(r"[^a-z0-9]+", lowered)
+        if token
+    ]
+
+    for token in tokens:
+        if token.startswith("dev") or token.startswith("test"):
+            return "development"
+        if token.startswith("health"):
+            return "development"
+        if token == "ci" or (token.startswith("ci") and len(token) <= 4):
+            return "development"
+
     return "runtime"
 
 

--- a/tests/test_dependency_snapshot_parser.py
+++ b/tests/test_dependency_snapshot_parser.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from scripts.submit_dependency_snapshot import (
     _auth_schemes,
     _build_manifests,
+    _derive_scope,
     _job_metadata,
     _normalise_run_attempt,
     _parse_requirements,
@@ -125,6 +126,17 @@ def test_build_manifests_discovers_nested_requirement_files(tmp_path: Path) -> N
     manifests = _build_manifests(tmp_path)
 
     assert set(manifests) == {"nested/configs/requirements-extra.txt"}
+
+
+def test_derive_scope_uses_token_boundaries() -> None:
+    assert _derive_scope("requirements.txt") == "runtime"
+    assert _derive_scope("requirements-dev.txt") == "development"
+    assert _derive_scope("requirements-test-utils.txt") == "development"
+    assert _derive_scope("requirements-healthcheck.txt") == "development"
+    assert _derive_scope("requirements-ci.txt") == "development"
+    assert _derive_scope("requirements-cicd.txt") == "development"
+    assert _derive_scope("requirements-client.txt") == "runtime"
+    assert _derive_scope("requirements-runtime.txt") == "runtime"
 
 def test_job_metadata_adds_html_url_when_run_id_numeric(monkeypatch) -> None:
     monkeypatch.setenv("GITHUB_SERVER_URL", "https://example.com")


### PR DESCRIPTION
## Summary
- refine dependency scope detection to respect token boundaries while still catching CI, dev, test, and health manifests
- extend parser tests to cover the new scope logic and import the helper explicitly

## Testing
- pytest tests/test_dependency_graph_workflow.py
- pytest tests/test_dependency_snapshot_parser.py

------
https://chatgpt.com/codex/tasks/task_e_68d95324f8f0832d96604a2b04158bd0