### PR TITLE
Fix Dependabot workflow dependency installation

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -84,6 +84,7 @@ jobs:
           github.event.pull_request.head.repo.full_name == github.repository
         run: |
           python -m pip install --upgrade pip
+          python -m pip install -e .
           python -m pip install -r requirements-ci.txt
 
       # Ensure the tests exercise the exact versions proposed by Dependabot


### PR DESCRIPTION
## Summary
- ensure the Dependabot workflow installs the project package in editable mode before running lean CI requirements so runtime dependencies are available during testing

## Testing
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_e_68d953075058832da9676d35a961f69c