### PR TITLE
Fix GPT-OSS workflow checkout ref

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -187,6 +187,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Checkout repository
         if: >-


### PR DESCRIPTION
## Summary
- update the GPT-OSS review workflow to check out the pull request head SHA on pull_request_target events
- ensure the review job diffs against the actual PR changes

## Testing
- pytest tests/test_gptoss_workflow_python3.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d9532ca68c832da1c36591b0083003