### PR TITLE
Fix Trivy cache directory expression

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Set Trivy cache directory
         run: |
-          echo "TRIVY_CACHE_DIR=${{ runner.temp }}/trivy-cache" >> "$GITHUB_ENV"
+          echo "TRIVY_CACHE_DIR=${RUNNER_TEMP}/trivy-cache" >> "$GITHUB_ENV"
 
       - name: Prepare Trivy cache directory
         run: |
@@ -125,7 +125,7 @@ jobs:
 
       - name: Set Trivy cache directory
         run: |
-          echo "TRIVY_CACHE_DIR=${{ runner.temp }}/trivy-cache" >> "$GITHUB_ENV"
+          echo "TRIVY_CACHE_DIR=${RUNNER_TEMP}/trivy-cache" >> "$GITHUB_ENV"
 
       - name: Prepare Trivy cache directory
         run: |


### PR DESCRIPTION
## Summary
- fix the Trivy workflow by using the built-in RUNNER_TEMP environment variable instead of the unavailable runner.temp context

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d95354dddc832d907bd6f63730cd61