### PR TITLE
Refine PyO3 panic handling in password utils

### DIFF
--- a/password_utils.py
+++ b/password_utils.py
@@ -127,9 +127,9 @@ def verify_password(password: str, stored_hash: str) -> bool:
             )
         try:
             return bcrypt.checkpw(password.encode(), stored_hash.encode())
-        except Exception as exc:  # pragma: no cover - bcrypt may raise varied errors
+        except (ValueError, TypeError) as exc:  # pragma: no cover - bcrypt may raise varied errors
             raise ValueError("Повреждён bcrypt-хэш пароля") from exc
-        except BaseException as exc:  # pragma: no cover - handle pyo3 panics
+        except (RuntimeError, SystemError) as exc:  # pragma: no cover - handle PyO3 panics
             if exc.__class__.__module__ == "pyo3_runtime":
                 raise ValueError("Повреждён bcrypt-хэш пароля") from exc
             raise


### PR DESCRIPTION
## Summary
- handle bcrypt PyO3 panics by catching RuntimeError/SystemError instead of BaseException
- extend password utility tests to cover PyO3 panic simulation and ensure system exceptions propagate

## Testing
- pytest tests/test_password_utils.py


------
https://chatgpt.com/codex/tasks/task_e_68d95fcd5fa8832d8c634eaabeacf678