### PR TITLE
Improve trading loop exception handling

### DIFF
--- a/run_bot.py
+++ b/run_bot.py
@@ -348,9 +348,10 @@ async def run_trading_cycle(trade_manager, runtime: float | None) -> None:
         raise
     except Exception as exc:
         if domain_errors and isinstance(exc, domain_errors):
-            message = f"Trading loop aborted after TradeManager error: {exc}"
-            logger.error(message, exc_info=True)
-            raise exc.__class__(message) from exc
+            message = "Trading loop aborted after TradeManager error"
+            logger.error("%s: %s", message, exc, exc_info=True)
+            raise
+        logger.exception("Unexpected error during trading loop")
         raise
     finally:
         stop = getattr(trade_manager, "stop", None)

--- a/tests/test_run_bot.py
+++ b/tests/test_run_bot.py
@@ -1,0 +1,68 @@
+import logging
+import sys
+import traceback
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+if "pandas" not in sys.modules:
+    pandas_stub = ModuleType("pandas")
+    pandas_stub.DataFrame = lambda *args, **kwargs: SimpleNamespace()
+    pandas_stub.to_datetime = lambda *args, **kwargs: SimpleNamespace()
+    sys.modules["pandas"] = pandas_stub
+
+
+from run_bot import run_trading_cycle
+
+
+class DummyDomainError(Exception):
+    """Domain-specific error used to emulate TradeManager failures."""
+
+
+# Mimic trade manager module attributes discovered by ``run_trading_cycle``.
+TradeManagerTaskError = DummyDomainError
+
+
+class _DomainTradeManager:
+    async def run(self):
+        raise DummyDomainError("domain failure")
+
+
+class _UnexpectedTradeManager:
+    async def run(self):
+        raise RuntimeError("unexpected failure")
+
+
+@pytest.mark.asyncio
+async def test_run_trading_cycle_reraises_domain_error(caplog):
+    manager = _DomainTradeManager()
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(DummyDomainError) as excinfo:
+            await run_trading_cycle(manager, runtime=None)
+
+    assert str(excinfo.value) == "domain failure"
+
+    frames = traceback.extract_tb(excinfo.value.__traceback__)
+    assert any(frame.name == "run" for frame in frames)
+
+    record = next(record for record in caplog.records if "Trading loop aborted" in record.message)
+    assert record.exc_info is not None
+
+
+@pytest.mark.asyncio
+async def test_run_trading_cycle_logs_and_reraises_unexpected_error(caplog):
+    manager = _UnexpectedTradeManager()
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(RuntimeError) as excinfo:
+            await run_trading_cycle(manager, runtime=None)
+
+    assert str(excinfo.value) == "unexpected failure"
+
+    frames = traceback.extract_tb(excinfo.value.__traceback__)
+    assert any(frame.name == "run" for frame in frames)
+
+    record = next(record for record in caplog.records if record.message == "Unexpected error during trading loop")
+    assert record.exc_info is not None


### PR DESCRIPTION
## Summary
- update the trading loop to log domain-specific errors before re-raising the original exception and to capture unexpected failures with `logger.exception`
- add unit tests that stub pandas, verify preserved messages/tracebacks, and assert logging for domain and unexpected errors

## Testing
- pytest tests/test_run_bot.py

------
https://chatgpt.com/codex/tasks/task_e_68d95fda4440832dbda02c986ae8dfa4