### PR TITLE
Handle misconfigured run_bot service factories

### DIFF
--- a/tests/test_run_bot_factories.py
+++ b/tests/test_run_bot_factories.py
@@ -1,0 +1,25 @@
+import pytest
+
+pytest.importorskip("pandas")
+
+from config import BotConfig
+
+import run_bot
+
+
+def _base_config(**overrides):
+    cfg = BotConfig(**{"service_factories": {}, **overrides})
+    return cfg
+
+
+def test_build_components_missing_exchange_factory():
+    cfg = _base_config()
+    with pytest.raises(ValueError, match="No service factory configured for 'exchange'"):
+        run_bot._build_components(cfg, offline=False, symbols=None)
+
+
+def test_build_components_invalid_exchange_factory():
+    cfg = _base_config(service_factories={"exchange": "bot:missing"})
+    message = "Failed to load service factory 'exchange' from 'bot:missing'"
+    with pytest.raises(ValueError, match=message):
+        run_bot._build_components(cfg, offline=False, symbols=None)


### PR DESCRIPTION
## Summary
- ensure `run_bot._resolve_factory` only traps import/attribute/value errors and re-raises them after logging
- provide clear errors when required factories are missing or misconfigured and no offline fallback exists
- add regression coverage for exchange factory resolution failures

## Testing
- pytest tests/test_run_bot_factories.py


------
https://chatgpt.com/codex/tasks/task_e_68d95febe5c0832da2bd13a0d10b99ab