### PR TITLE
Remove pytest-based TEST_MODE detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,9 @@ pytest tests/test_password_utils.py
   --app ... run` порт задаётся параметром `--port`.
 - `TEST_MODE` — установка значения `1` включает тестовый режим: сокращаются
   задержки повторных попыток и отключаются тяжёлые операции, например диск и
-  сетевые вызовы.
+  сетевые вызовы. Автоматическое определение запуска через `pytest` больше не
+  используется, поэтому переменную необходимо задавать явно (набор тестов
+  делает это в `tests/conftest.py`).
 - `SERVICE_SCHEME` — схема (`http` или `https`), которую использует `trading_bot`
   для формирования URL сервисов (по умолчанию `http`).
 - `LOG_LEVEL` и `LOG_DIR` — уровень логирования и каталог с логами. Значение
@@ -916,7 +918,8 @@ pytest -m integration
 The `requirements.txt` file already bundles `pytest` and all other
 packages needed by the test suite.
 
-Unit tests automatically set the environment variable `TEST_MODE=1`.
+Unit tests automatically set the environment variable `TEST_MODE=1` via
+`tests/conftest.py`.
 This disables the Telegram logger's background worker thread so tests
 run without spawning extra threads.
 

--- a/config.py
+++ b/config.py
@@ -11,7 +11,6 @@ import importlib.util
 import json
 import logging
 import os
-import sys
 import threading
 from dataclasses import MISSING, asdict, dataclass, field, fields
 from pathlib import Path
@@ -76,10 +75,11 @@ def validate_env(required_keys: list[str]) -> None:
     ----------
     required_keys:
         List of environment variable names that must be defined. The check is
-        skipped during tests (``TEST_MODE=1`` or when ``pytest`` is running).
+        skipped when ``TEST_MODE=1`` so tests can run without configuring the
+        full environment.
     """
 
-    if os.getenv("TEST_MODE") == "1" or "pytest" in sys.modules:
+    if os.getenv("TEST_MODE") == "1":
         return
 
     missing_keys: list[str] = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,11 @@ import secrets
 
 import pytest
 
+# Явно включаем тестовый режим для всех тестов. Ранее конфигурация
+# определяла запуск под ``pytest`` автоматически, но теперь управление
+# осуществляется только через переменную ``TEST_MODE``.
+os.environ.setdefault("TEST_MODE", "1")
+
 from bot import http_client as _http_client
 
 


### PR DESCRIPTION
## Summary
- remove the fallback that inferred TEST_MODE from pytest and rely solely on the environment variable
- set TEST_MODE=1 for the test suite and document the explicit configuration required

## Testing
- pytest tests/test_config_path_validation.py


------
https://chatgpt.com/codex/tasks/task_e_68d95ff63a88832dac0f7669368a9f78