### PR TITLE
Raise configuration errors for invalid server host/port

### DIFF
--- a/tests/test_server_host_port_validation.py
+++ b/tests/test_server_host_port_validation.py
@@ -1,0 +1,36 @@
+import importlib
+import logging
+import sys
+import types
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "env_port, env_host, expected_message",
+    [
+        ("notaport", "127.0.0.1", "Invalid PORT value"),
+        ("8000", "0.0.0.0", "Invalid HOST"),
+    ],
+)
+def test_server_invalid_host_or_port(monkeypatch, caplog, env_port, env_host, expected_message):
+    stub_pydantic = types.SimpleNamespace(
+        BaseModel=object,
+        Field=lambda default=None, *_, **__: default,
+        ValidationError=Exception,
+    )
+    monkeypatch.setitem(sys.modules, "pydantic", stub_pydantic)
+    monkeypatch.setenv("CSRF_SECRET", "unit-test-secret")
+    monkeypatch.setenv("PORT", env_port)
+    monkeypatch.setenv("HOST", env_host)
+    caplog.set_level(logging.ERROR)
+
+    sys.modules.pop("server", None)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        importlib.import_module("server")
+
+    assert expected_message in str(excinfo.value)
+    assert any(expected_message in record.getMessage() for record in caplog.records)
+
+    sys.modules.pop("server", None)


### PR DESCRIPTION
## Summary
- raise a dedicated ServerConfigurationError when HOST or PORT configuration is invalid
- validate HOST immediately so uvicorn startup surfaces clear exceptions and logging
- add regression tests covering invalid HOST and PORT configurations

## Testing
- pytest tests/test_server_host_port_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68d9600e94c4832d81e4ae303aa6ac0a