### PR TITLE
Fix semgrep warning by updating GPT-OSS review workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -4,7 +4,7 @@
 name: GPT-OSS Code Review
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   issue_comment:
     types: [created]
@@ -24,7 +24,7 @@ concurrency:
     ${{ format(
       'gptoss-review-{0}-{1}',
       github.workflow,
-      (github.event_name == 'pull_request_target' && github.event.pull_request.number)
+      (github.event_name == 'pull_request' && github.event.pull_request.number)
         || (github.event_name == 'issue_comment' && github.event.issue.number)
         || github.run_id
     ) }}
@@ -58,7 +58,7 @@ jobs:
           skip_reason=""
 
           case "$EVENT_NAME" in
-            pull_request_target)
+            pull_request)
               pr_number="${PR_NUMBER:-}"
               pr_draft="${PR_DRAFT:-false}"
               pr_head_repo="${PR_HEAD_REPO:-}"
@@ -127,7 +127,7 @@ jobs:
     needs: evaluate
     if: >-
       ${{ needs.evaluate.outputs.run_review == 'true'
-          && (github.event_name != 'pull_request_target'
+          && (github.event_name != 'pull_request'
               || github.event.pull_request.head.repo.full_name == github.repository)
           && (github.event_name != 'issue_comment'
               || github.event.comment.author_association == 'OWNER'
@@ -181,7 +181,7 @@ jobs:
         if: >-
           ${{ steps.validate_event.outputs.skip != 'true'
               && steps.ensure_pr_ready.outputs.skip != 'true'
-              && github.event_name == 'pull_request_target'
+              && github.event_name == 'pull_request'
               && github.event.pull_request.head.repo.full_name == github.repository
               && env.PR_NUMBER != '' }}
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
@@ -193,7 +193,7 @@ jobs:
         if: >-
           ${{ steps.validate_event.outputs.skip != 'true'
               && steps.ensure_pr_ready.outputs.skip != 'true'
-              && github.event_name != 'pull_request_target'
+              && github.event_name != 'pull_request'
               && env.PR_NUMBER != '' }}
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:


### PR DESCRIPTION
## Summary
- switch the GPT-OSS review workflow to use the pull_request event instead of pull_request_target so we no longer check out untrusted code with elevated permissions
- adjust concurrency, evaluation, and checkout conditions to reference the new event name while keeping issue_comment handling intact

## Testing
- ~/.local/bin/semgrep --config p/default --error

------
https://chatgpt.com/codex/tasks/task_e_68d9665800c4832daacedc3dd303245b