### PR TITLE
Fix Dependabot workflow packaging metadata and trade loop error handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "trading-bot-x"
 version = "0.1.1"
 description = "Пример торгового бота на Python."
 readme = "README.md"
-license = { file = "LICENSE" }
+license = "MIT"
 license-files = ["LICENSE"]
 authors = [{ name = "Project Authors" }]
 requires-python = ">=3.10"

--- a/run_bot.py
+++ b/run_bot.py
@@ -331,14 +331,14 @@ async def run_trading_cycle(trade_manager, runtime: float | None) -> None:
         logger.warning("TradeManager has no run() coroutine; nothing to execute")
         return
 
-    domain_errors: tuple[type[BaseException], ...] = ()
+    domain_error_map: dict[type[BaseException], str] = {}
     module_name = getattr(type(trade_manager), "__module__", "")
     module_candidates = [module_name]
     if module_name and "." in module_name:
         module_candidates.append(module_name.rsplit(".", 1)[0])
 
     seen: set[type[BaseException]] = set()
-    collected: list[type[BaseException]] = []
+    collected: list[tuple[type[BaseException], str]] = []
     for candidate in module_candidates:
         module = sys.modules.get(candidate)
         if module is None:
@@ -351,10 +351,10 @@ async def run_trading_cycle(trade_manager, runtime: float | None) -> None:
                 and error_cls not in seen
             ):
                 seen.add(error_cls)
-                collected.append(error_cls)
+                collected.append((error_cls, attr))
 
     if collected:
-        domain_errors = tuple(collected)
+        domain_error_map = {cls: attr for cls, attr in collected}
 
     try:
         if runtime is not None:
@@ -366,9 +366,25 @@ async def run_trading_cycle(trade_manager, runtime: float | None) -> None:
     except asyncio.CancelledError:
         raise
     except Exception as exc:
-        if domain_errors and isinstance(exc, domain_errors):
+        matched_attr: str | None = None
+        matched_cls: type[BaseException] | None = None
+        for cls, attr in domain_error_map.items():
+            if isinstance(exc, cls):
+                matched_attr = attr
+                matched_cls = cls
+                break
+
+        if matched_attr is not None:
             message = "Trading loop aborted after TradeManager error"
             logger.error("%s: %s", message, exc, exc_info=True)
+            should_wrap = (
+                matched_attr == "TradeManagerTaskError"
+                and matched_cls is not None
+                and matched_cls.__name__.endswith("TradeManagerTaskError")
+            )
+            if should_wrap:
+                wrapped_exc = matched_cls(f"{message}: {exc}")
+                raise wrapped_exc from exc
             raise
         logger.exception("Unexpected error during trading loop")
         raise


### PR DESCRIPTION
## Summary
- replace the pyproject license object with a plain MIT string so editable installs work in the Dependabot workflow
- adjust `run_trading_cycle` to classify domain errors and wrap only `TradeManagerTaskError` instances with contextual messaging while preserving other domain error messages

## Testing
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_e_68d965f635dc832d90343cb73f685ca9