### PR TITLE
Fix component detection JSON schema for dependency graph

### DIFF
--- a/component-detection
+++ b/component-detection
@@ -63,7 +63,7 @@ def _build_components(root: Path) -> tuple[list[dict[str, Any]], list[str]]:
                 "dependencyScope": None,
                 "topLevelReferrers": [],
                 "containerDetailIds": [],
-                "containerLayerIds": {},
+                "containerLayerIds": [],
             }
             components.append(component)
 

--- a/tests/test_component_detection.py
+++ b/tests/test_component_detection.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _load_component_detection():
+    path = Path("component-detection")
+    loader = importlib.machinery.SourceFileLoader("component_detection", str(path))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive guard
+        raise RuntimeError("Unable to load component-detection script")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_run_scan_uses_list_for_container_layer_ids(tmp_path: Path) -> None:
+    module = _load_component_detection()
+    manifest = tmp_path / "requirements.txt"
+    manifest.write_text("requests==2.32.5\n", encoding="utf-8")
+
+    output_path = tmp_path / "scan.json"
+    args = SimpleNamespace(
+        SourceDirectory=str(tmp_path),
+        ManifestFile=str(output_path),
+        PrintManifest=False,
+    )
+
+    return_code = module.run_scan(args)  # type: ignore[attr-defined]
+    assert return_code == 0
+
+    result = json.loads(output_path.read_text(encoding="utf-8"))
+    components = result["componentsFound"]
+    assert components, "Expected at least one component in scan results"
+    for component in components:
+        assert component["containerLayerIds"] == []


### PR DESCRIPTION
## Summary
- ensure the component-detection fallback emits `containerLayerIds` as a list rather than an object
- add a regression test that exercises the scanner and asserts the corrected structure

## Testing
- pytest tests/test_dependency_snapshot.py tests/test_dependency_snapshot_parser.py tests/test_dependency_snapshot_import.py tests/test_dependency_graph_workflow.py tests/test_component_detection.py

------
https://chatgpt.com/codex/tasks/task_e_68d96631f1a8832d8c79fd8c0d98a213