### PR TITLE
Harden model builder client endpoint validation

### DIFF
--- a/tests/test_model_builder_client_security.py
+++ b/tests/test_model_builder_client_security.py
@@ -1,0 +1,73 @@
+import model_builder_client
+
+
+def _fake_resolve(hostname: str, addresses: set[str]):
+    def _resolver(_hostname: str) -> set[str]:
+        assert _hostname == hostname
+        return addresses
+
+    return _resolver
+
+
+def test_prepare_endpoint_rejects_credentials(monkeypatch):
+    monkeypatch.setattr(
+        model_builder_client,
+        "_resolve_hostname",
+        _fake_resolve("localhost", {"127.0.0.1"}),
+    )
+
+    endpoint = model_builder_client._prepare_endpoint(  # type: ignore[attr-defined]
+        "http://user:pass@localhost:8000",
+        purpose="тест",
+    )
+
+    assert endpoint is None
+
+
+def test_prepare_endpoint_allows_default_service_hosts(monkeypatch):
+    monkeypatch.setattr(
+        model_builder_client,
+        "_resolve_hostname",
+        _fake_resolve("model_builder", {"127.0.0.1"}),
+    )
+
+    endpoint = model_builder_client._prepare_endpoint(  # type: ignore[attr-defined]
+        "http://model_builder:8001",
+        purpose="тест",
+    )
+
+    assert endpoint is not None
+    assert endpoint.hostname == "model_builder"
+
+
+def test_prepare_endpoint_respects_allowlist_env(monkeypatch):
+    monkeypatch.setenv("MODEL_BUILDER_ALLOWED_HOSTS", "trusted.local")
+    monkeypatch.setattr(
+        model_builder_client,
+        "_resolve_hostname",
+        _fake_resolve("trusted.local", {"198.51.100.5"}),
+    )
+
+    endpoint = model_builder_client._prepare_endpoint(  # type: ignore[attr-defined]
+        "https://trusted.local:8443",
+        purpose="тест",
+    )
+
+    assert endpoint is not None
+    assert endpoint.hostname == "trusted.local"
+
+
+def test_prepare_endpoint_rejects_unlisted_host(monkeypatch):
+    monkeypatch.delenv("MODEL_BUILDER_ALLOWED_HOSTS", raising=False)
+    monkeypatch.setattr(
+        model_builder_client,
+        "_resolve_hostname",
+        _fake_resolve("example.com", {"203.0.113.10"}),
+    )
+
+    endpoint = model_builder_client._prepare_endpoint(  # type: ignore[attr-defined]
+        "https://example.com/api",
+        purpose="тест",
+    )
+
+    assert endpoint is None


### PR DESCRIPTION
## Summary
- enforce host allow-listing when preparing model builder endpoints and support an explicit environment override
- reject model builder URLs containing credentials and add tests that cover the strengthened validation logic

## Testing
- pytest tests/test_model_builder_client_security.py

------
https://chatgpt.com/codex/tasks/task_e_68d9661743d0832d81c712048ec3c455