### PR TITLE
Fix concurrency expression in release drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -23,7 +23,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: release-drafter-${{ github.event_name == 'pull_request_target' && format('pr-{0}', github.event.number) || github.ref }}
+  group: ${{ format('release-drafter-{0}', github.event_name == 'pull_request_target' && format('pr-{0}', github.event.number) || github.ref) }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary
- adjust the release drafter workflow concurrency group to use a single expression for all events

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9686adab0832db4dcd0558a9aa623