### PR TITLE
Prevent GPT-OSS review from failing on unexpected PR status errors

### DIFF
--- a/scripts/check_pr_status.py
+++ b/scripts/check_pr_status.py
@@ -177,7 +177,7 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     except Exception as exc:  # pragma: no cover - defensive guard
         print(
-            f"::error::Неожиданная ошибка при проверке PR: {exc}",
+            f"::warning::Неожиданная ошибка при проверке PR: {exc}",
             file=sys.stderr,
         )
         _write_github_output(skip=True, head_sha="")
@@ -215,7 +215,10 @@ def cli(argv: list[str] | None = None) -> int:
             _write_github_output(skip=True, head_sha="")
         return 0
     except BaseException as exc:  # pragma: no cover - defensive guard
-        print(f"::error::Критическое исключение в check_pr_status: {exc}", file=sys.stderr)
+        print(
+            f"::warning::Критическое исключение в check_pr_status: {exc}",
+            file=sys.stderr,
+        )
         _write_github_output(skip=True, head_sha="")
         return 0
 

--- a/tests/test_check_pr_status.py
+++ b/tests/test_check_pr_status.py
@@ -113,3 +113,16 @@ def test_cli_swallows_system_exit(monkeypatch: pytest.MonkeyPatch, capsys: pytes
     assert result == 0
     assert "кодом 3" in captured.err
 
+
+def test_cli_logs_keyboard_interrupt(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    def _raise(*_args, **_kwargs):
+        raise KeyboardInterrupt("boom")
+
+    monkeypatch.setattr(check_pr_status, "main", _raise)
+    monkeypatch.setenv("GITHUB_OUTPUT", "")
+
+    result = check_pr_status.cli([])
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "::warning::Критическое исключение" in captured.err
+


### PR DESCRIPTION
## Summary
- change the PR status checker to emit warnings instead of errors for unexpected failures so the step no longer causes the workflow to fail
- add coverage ensuring keyboard interrupts are logged as warnings without propagating a failure

## Testing
- `pytest tests/test_check_pr_status.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68d9663beb60832dbbddbda201df2e95