### PR TITLE
Ensure CI installs service test dependencies

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -21,6 +21,7 @@ psutil==7.1.0
 werkzeug==3.1.3
 requests==2.32.5
 httpx==0.28.1
+cloudpickle==3.1.1
 ccxt==4.5.6
 # Newer scikit-learn releases pull in SciPy builds incompatible with our
 # pinned numpy; keep everything aligned with the Docker images.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,17 @@
 pytest
 pytest-timeout
 pytest-cov
+requests
 requests-mock
+httpx
 flask
+numpy
+pandas
+polars
+aiohttp
+pydantic
+joblib
+cloudpickle
 hypothesis>=6.90.0
 pytest-asyncio
 iniconfig


### PR DESCRIPTION
## Summary
- add the core data-science and service client libraries to requirements-dev so pytest can run locally
- include cloudpickle in the CI requirements so service subprocesses start successfully

## Testing
- pytest tests/test_integration_services.py tests/test_service_scripts.py


------
https://chatgpt.com/codex/tasks/task_e_68d96fbac500832d997f797ac53db0ca