### PR TITLE
Adjust exception re-raise in trading cycle

### DIFF
--- a/run_bot.py
+++ b/run_bot.py
@@ -384,7 +384,7 @@ async def run_trading_cycle(trade_manager, runtime: float | None) -> None:
                 exc.args = (f"{message}: {exc}", *exc.args[1:])
             except Exception:  # pragma: no cover - крайне редкие случаи нестандартных args
                 pass
-            raise exc from exc
+            raise
         logger.exception("Unexpected error during trading loop")
         raise
     finally:


### PR DESCRIPTION
## Summary
- stop wrapping enriched exceptions when re-raising domain errors in the trading loop

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dad981e0c88321910a7124e9cfc6a7