### PR TITLE
Handle data errors in process_symbol

### DIFF
--- a/bot/trade_manager/core.py
+++ b/bot/trade_manager/core.py
@@ -2120,6 +2120,8 @@ class TradeManager:
                 httpx.HTTPError,
                 ConnectionError,
                 RuntimeError,
+                ValueError,
+                KeyError,
             ) as e:
                 logger.warning(
                     "Transient error processing %s (%s): %s",


### PR DESCRIPTION
## Summary
- treat ValueError and KeyError as transient issues in `process_symbol` while preserving logging with stack traces
- add coverage to ensure ValueError inputs are retried and keep propagating unexpected exceptions

## Testing
- pytest tests/test_trade_manager.py::test_process_symbol_recovers_from_value_error tests/test_trade_manager.py::test_process_symbol_propagates_unexpected_error -q

------
https://chatgpt.com/codex/tasks/task_b_68dad997218c8321ab3526bb528ab759