### PR TITLE
Add detailed error codes to trade manager open_position

### DIFF
--- a/tests/test_service_scripts.py
+++ b/tests/test_service_scripts.py
@@ -478,7 +478,7 @@ def test_trade_manager_service_invalid_json(ctx):
             headers={**TOKEN_HEADERS, 'Content-Type': 'application/json'},
         )
         assert resp.status_code == 400
-        assert resp.json() == {'error': 'invalid json'}
+        assert resp.json() == {'error': 'invalid json', 'code': 'invalid_json'}
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
- add structured error codes for the trade manager `open_position` handler and log them consistently
- tighten validation for symbol, price, amount, and risk inputs with dedicated responses
- extend API tests to cover the new error responses and update service script expectations

## Testing
- BOT_AUTO_INSTALL_DISABLED=1 pytest tests/test_trade_manager_service_api.py::test_open_position_missing_symbol_returns_code tests/test_trade_manager_service_api.py::test_open_position_invalid_price_returns_code tests/test_trade_manager_service_api.py::test_open_position_negative_risk_returns_code tests/test_service_scripts.py::test_trade_manager_service_invalid_json -q


------
https://chatgpt.com/codex/tasks/task_b_68dad9b1a1f88321b4daa89fcc45583c