### PR TITLE
Remove legacy per-symbol TradeManager loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Remove legacy per-symbol trading loop in favour of the ranked signal workflow.
 - Store TradeManager state in non-executable formats: positions saved as Parquet and returns as JSON.
 - Fix chained assignment in DataHandler to avoid pandas FutureWarning.
 - Bump Requests dependency to >=2.32.4 to address CVE-2024-47081.


### PR DESCRIPTION
## Summary
- remove the obsolete per-symbol TradeManager loop and extend the ranked signal runner to handle transient network errors
- update unit tests to cover the ranked workflow and document the change in the changelog

## Testing
- pytest tests/test_trade_manager_loops.py tests/test_trade_manager.py

------
https://chatgpt.com/codex/tasks/task_b_68dad98e57788321a208dd94714e6aff