### PR TITLE
Prevent CodeQL from parsing Git reference logs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,6 +47,20 @@ jobs:
           # .git directories behind, so sweep the whole workspace just in case
           # and remove any stray log directories those actions may have left.
           find "$PWD" -path '*/.git/logs' -type d -prune -exec rm -rf {} +
+          # A few hosted runners have shown that fetch operations performed by
+          # subsequent steps can still recreate reference logs for remote
+          # branches whose names end in .py. Those branches do not contain source
+          # code needed for analysis, so drop the local references entirely to
+          # prevent Git from regenerating the problematic logs.
+          git for-each-ref --format='%(refname)' 'refs/remotes/*' | \
+            awk '/\.py$/ { print }' | while read -r ref; do
+              git update-ref -d "$ref"
+            done
+          # In the unlikely event that any .py files remain in Git metadata
+          # (for example, because another action created fresh logs after the
+          # loop above ran), delete them so the extractor never attempts to
+          # parse the plaintext Git data as Python modules.
+          find "$PWD" -path '*/.git/logs/*' -type f -name '*.py' -delete
 
       - name: Set up Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
## Summary
- extend the CodeQL workflow cleanup step to drop remote refs whose names end in .py
- ensure any regenerated Git reference logs containing .py files are removed before analysis

## Testing
- not run (workflow-only change)

------
https://chatgpt.com/codex/tasks/task_b_68dae29c89fc8321822daae39e3f19bf