### PR TITLE
Harden Ubuntu packages for Trivy scanning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR /tmp/build
 
 RUN set -eux; \
     apt-get update; \
-    apt-get upgrade -y; \
+    apt-get dist-upgrade -y; \
     apt-get install -y --no-install-recommends \
         tzdata \
         linux-libc-dev \
@@ -156,13 +156,16 @@ COPY --from=builder /tmp/pam-fixed /tmp/pam-fixed
 COPY docker/scripts/harden_gnutar.sh /tmp/security/harden_gnutar.sh
 
 # Установка минимальных пакетов выполнения
-RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y --no-install-recommends \
     python3 \
     libpython3.12-stdlib \
     coreutils \
     zlib1g \
     libpam0g \
     libpam-modules \
+    libssl3t64 \
+    openssl \
+    ca-certificates \
     && python3 -m ensurepip --upgrade \
     && python3 -m pip install --no-cache-dir --break-system-packages 'setuptools>=78.1.1,<81' \
     && dpkg -i /tmp/pam-fixed/*.deb \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -7,12 +7,13 @@ FROM ubuntu:24.04@sha256:985be7c735afdf6f18aaa122c23f87d989c30bba4e9aa24c8278912
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Обновление linux-libc-dev устраняет CVE-2025-21976, а libgcrypt20 — CVE-2024-2236.
-# Дополнительно выполняем upgrade, чтобы подтянуть свежие патчи безопасности из Ubuntu.
+# Дополнительно выполняем dist-upgrade, чтобы подтянуть свежие патчи безопасности из Ubuntu.
 # После создания виртуального окружения обновляем pip и setuptools до версий,
 # закрывающих CVE-2024-6345 и CVE-2025-47273, иначе Trivy обнаруживает
 # уязвимые копии setuptools внутри образа.
-RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y \
+RUN apt-get update && apt-get dist-upgrade -y && apt-get install --no-install-recommends -y \
     python3 python3-venv build-essential linux-libc-dev libgcrypt20 git patch \
+    ca-certificates \
     && apt-get install -y --no-install-recommends gnupg dirmngr \
     && python3 -m venv /venv \
     && /venv/bin/python -m ensurepip --upgrade \
@@ -44,10 +45,12 @@ FROM ubuntu:24.04@sha256:985be7c735afdf6f18aaa122c23f87d989c30bba4e9aa24c8278912
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Устанавливаем только необходимые пакеты выполнения и сразу обновляем базовую систему
-RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y \
+RUN apt-get update && apt-get dist-upgrade -y && apt-get install --no-install-recommends -y \
     libssl3t64 \
     python3.12-minimal \
     openssl \
+    libpam0g \
+    ca-certificates \
     && apt-get purge -y git \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- switch the CI Dockerfile to use `apt-get dist-upgrade` and install missing security packages so Trivy picks up patched libraries
- refresh the runtime Dockerfile to pull in OpenSSL and certificate updates before scanning

## Testing
- trivy fs --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1 .

------
https://chatgpt.com/codex/tasks/task_b_68dae237ad508321b57a1f79b4d25dfb