### PR TITLE
Improve dependency graph dispatch commit detection

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Detect dependency manifest changes
         id: detect
         env:
-          BEFORE: ${{ github.event.before || github.event.client_payload.before || '' }}
-          AFTER: ${{ github.sha || github.event.client_payload.after || github.event.client_payload.sha || '' }}
+          BEFORE: ${{ github.event.before || github.event.client_payload.before || github.event.client_payload.base_sha || '' }}
+          AFTER: ${{ github.sha || github.event.client_payload.after || github.event.client_payload.head_sha || github.event.client_payload.sha || '' }}
         run: |
           python <<'PY'
           from __future__ import annotations

--- a/tests/test_dependency_graph_workflow.py
+++ b/tests/test_dependency_graph_workflow.py
@@ -57,6 +57,13 @@ def test_dependency_graph_detect_step_handles_nested_manifests() -> None:
     assert "fnmatch(filename, pattern)" in workflow
 
 
+def test_dependency_graph_detect_step_uses_dispatch_commit_fallbacks() -> None:
+    workflow = Path(".github/workflows/dependency-graph.yml").read_text(encoding="utf-8")
+
+    assert "github.event.client_payload.base_sha" in workflow
+    assert "github.event.client_payload.head_sha" in workflow
+
+
 def test_dependency_graph_installs_requests_before_submission() -> None:
     workflow = Path(".github/workflows/dependency-graph.yml").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- add repository_dispatch base/head SHA fallbacks to the dependency graph workflow
- extend the workflow test suite to cover the new commit metadata handling

## Testing
- pytest tests/test_dependency_graph_workflow.py -q

------
https://chatgpt.com/codex/tasks/task_b_68dae2ce4378832199b6c8bab41ab715