### PR TITLE
Fix Dependabot workflow regressions

### DIFF
--- a/trade_manager/__init__.py
+++ b/trade_manager/__init__.py
@@ -1,0 +1,51 @@
+"""Compatibility facade for :mod:`bot.trade_manager`.
+
+This repository historically exposed a top-level :mod:`trade_manager`
+module.  Several tests – and, by extension, downstream tooling – import that
+module directly to verify import order hooks.  The project structure has since
+been reorganised around :mod:`bot.trade_manager`, which means the legacy import
+stopped working and the tests started failing with ``ModuleNotFoundError``.
+
+To preserve backwards compatibility we re-export the public interface from the
+current package.  The implementation is intentionally lightweight: it imports
+``bot.trade_manager`` lazily and then mirrors the attributes that package makes
+available via ``__all__``.  Any new public attribute added to
+``bot.trade_manager`` will automatically propagate here without further
+maintenance.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
+
+def _load_target() -> ModuleType:
+    """Import and return the canonical trade manager package."""
+
+    existing = sys.modules.get("bot.trade_manager")
+    if existing is not None:
+        return importlib.reload(existing)
+    return import_module("bot.trade_manager")
+
+
+_TARGET = _load_target()
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - thin forwarding logic
+    return getattr(_TARGET, name)
+
+
+def __dir__() -> list[str]:  # pragma: no cover - mirrors target metadata
+    public = getattr(_TARGET, "__all__", None)
+    if public:
+        return sorted(set(public))
+    return sorted(attr for attr in dir(_TARGET) if not attr.startswith("_"))
+
+
+for _name in getattr(_TARGET, "__all__", []):
+    globals()[_name] = getattr(_TARGET, _name)
+

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -16,10 +16,13 @@ from pathlib import Path
 from bot.config import BotConfig, OFFLINE_MODE
 from bot.dotenv_utils import load_dotenv
 from bot.gpt_client import GPTClientError, GPTClientJSONError, query_gpt_json_async
+from bot.utils_loader import require_utils
 from services.logging_utils import sanitize_log_value
 from services.stubs import create_httpx_stub, create_pydantic_stub, is_offline_env
 from telegram_logger import TelegramLogger, resolve_unsent_path
-from bot.utils import retry, suppress_tf_logs
+_utils_module = require_utils("retry", "suppress_tf_logs")
+retry = _utils_module.retry  # type: ignore[attr-defined]
+suppress_tf_logs = getattr(_utils_module, "suppress_tf_logs", lambda: None)
 
 _OFFLINE_ENV = is_offline_env()
 


### PR DESCRIPTION
## Summary
- add a compatibility shim so `import trade_manager` re-exports `bot.trade_manager` even when tests replace the utils module
- load retry helpers for the trading bot through the utils loader so stubbed environments do not break imports
- re-wrap domain exceptions from `run_trading_cycle` while preserving their type, message, and traceback/cause

## Testing
- `pytest -m "not integration" -q`


------
https://chatgpt.com/codex/tasks/task_b_68dae2b4c90483218c8da855e5caea48