### PR TITLE
Fix Dependabot workflow issues

### DIFF
--- a/bot/trade_manager/__init__.py
+++ b/bot/trade_manager/__init__.py
@@ -11,19 +11,21 @@ from typing import TYPE_CHECKING, Any, cast
 from bot.config import OFFLINE_MODE
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
-    from .core import TradeManager as TradeManagerType
+    from .core import TradeManager as TradeManagerType, TradeManagerTaskError as TradeManagerTaskErrorType
     from telegram_logger import TelegramLogger as TelegramLoggerType
 else:
     TradeManagerType = Any
     TelegramLoggerType = Any
+    TradeManagerTaskErrorType = Any
 
 if OFFLINE_MODE:
     from services.offline import OfflineBybit, OfflineTelegram
 
     TradeManager = cast(type[TradeManagerType], OfflineBybit)
     TelegramLogger = cast(type[TelegramLoggerType], OfflineTelegram)
+    TradeManagerTaskError = RuntimeError
 
-    __all__ = ["TradeManager", "TelegramLogger"]
+    __all__ = ["TradeManager", "TelegramLogger", "TradeManagerTaskError"]
 else:  # pragma: no cover - реальная инициализация
     from bot.http_client import close_async_http_client, get_async_http_client
     from bot.utils_loader import require_utils
@@ -31,7 +33,7 @@ else:  # pragma: no cover - реальная инициализация
     _utils = require_utils("TelegramLogger")
     TelegramLogger = cast(type[TelegramLoggerType], _utils.TelegramLogger)
 
-    from .core import TradeManager as _TradeManager
+    from .core import TradeManager as _TradeManager, TradeManagerTaskError as _TradeManagerTaskError
     from .service import (
         InvalidHostError,
         api_app,
@@ -44,6 +46,7 @@ else:  # pragma: no cover - реальная инициализация
     )
 
     TradeManager = cast(type[TradeManagerType], _TradeManager)
+    TradeManagerTaskError = cast(type[TradeManagerTaskErrorType], _TradeManagerTaskError)
 
     # Псевдонимы синхронных помощников оставлены для обратной совместимости
     get_http_client = get_async_http_client
@@ -62,4 +65,5 @@ else:  # pragma: no cover - реальная инициализация
         "_ready_event",
         "get_http_client",
         "close_http_client",
+        "TradeManagerTaskError",
     ]

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -1,0 +1,37 @@
+"""Compatibility shim exporting the top-level ``utils`` module."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from types import ModuleType
+
+from .utils_loader import require_utils
+
+
+def _load_utils() -> ModuleType:
+    try:
+        module = importlib.import_module("utils")
+    except ModuleNotFoundError:
+        module = require_utils("configure_logging", "logger", "retry", "suppress_tf_logs")
+    else:
+        if not all(
+            hasattr(module, name)
+            for name in ("configure_logging", "logger", "retry", "suppress_tf_logs")
+        ):
+            module = require_utils("configure_logging", "logger", "retry", "suppress_tf_logs")
+
+    if module.__name__ != "utils":
+        proxy = ModuleType("utils")
+        proxy.__dict__.update(module.__dict__)
+        proxy.__name__ = "utils"
+        module = proxy
+    module.__spec__ = importlib.machinery.ModuleSpec("utils", loader=None)
+
+    sys.modules["utils"] = module
+    return module
+
+
+module = _load_utils()
+sys.modules[__name__] = module
+

--- a/trade_manager.py
+++ b/trade_manager.py
@@ -1,0 +1,19 @@
+"""Backwards compatible entry point for :mod:`bot.trade_manager`."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from types import ModuleType
+
+
+def _load_trade_manager() -> ModuleType:
+    sys.modules.pop("bot.trade_manager", None)
+    return importlib.import_module("bot.trade_manager")
+
+
+_MODULE = _load_trade_manager()
+globals().update(_MODULE.__dict__)
+sys.modules[__name__] = _MODULE
+
+


### PR DESCRIPTION
## Summary
- expose the root trade manager module via a thin shim so stubs work in tests
- add a compatibility wrapper for bot.utils that falls back to the real utils module
- surface TradeManagerTaskError from bot.trade_manager and preserve causes in run_trading_cycle

## Testing
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_b_68dae2c1e76c8321a6133b3225578224