### PR TITLE
Fix Release Drafter concurrency expression

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -23,7 +23,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ format('release-drafter-{0}', github.event_name == 'pull_request_target' && format('pr-{0}', github.event.number) || github.ref) }}
+  group: release-drafter-${{ github.event_name == 'pull_request_target' && format('pr-{0}', github.event.number) || github.ref }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary
- replace the invalid release drafter concurrency expression with a valid GitHub Actions expression

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68daed95812483218b40954fcd9cda51