### PR TITLE
Ensure TradeManager enforces API token when unconfigured

### DIFF
--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -85,9 +85,13 @@ API_TOKEN = (server_common.get_api_token() or '').strip()
 def _authentication_optional() -> bool:
     """Return ``True`` when the API token requirement may be skipped."""
 
+    # ``TEST_MODE`` is enabled for the pytest suite where we still want to
+    # exercise the authentication branch.  Only explicit offline or stub modes
+    # should bypass the token requirement to avoid accidentally exposing the
+    # API without protection when running the service locally.
     return any(
         os.getenv(flag) == '1'
-        for flag in ("TEST_MODE", "OFFLINE_MODE", "TRADE_MANAGER_USE_STUB")
+        for flag in ("OFFLINE_MODE", "TRADE_MANAGER_USE_STUB")
     )
 
 


### PR DESCRIPTION
## Summary
- require an explicit offline or stub mode before skipping API authentication in the TradeManager service
- keep the test suite exercising the unauthorized branch when no token is configured

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68daed30f0488321aea5fb68aa401646