### PR TITLE
Fix TradeManager auth enforcement and typing

### DIFF
--- a/run_bot.py
+++ b/run_bot.py
@@ -383,7 +383,7 @@ async def run_trading_cycle(trade_manager, runtime: float | None) -> None:
             if original_args:
                 enriched_args += tuple(original_args[1:])
 
-            new_exc: Exception | None = None
+            new_exc: BaseException | None = None
             if matched_cls is not None:
                 try:
                     new_exc = matched_cls(*original_args)
@@ -392,6 +392,7 @@ async def run_trading_cycle(trade_manager, runtime: float | None) -> None:
 
             if new_exc is None:
                 new_exc = matched_cls(enriched_args[0]) if matched_cls else RuntimeError(enriched_args[0])
+            assert new_exc is not None
             try:
                 new_exc.args = enriched_args
             except Exception:  # pragma: no cover - unusual exception types

--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -87,7 +87,7 @@ def _authentication_optional() -> bool:
 
     return any(
         os.getenv(flag) == '1'
-        for flag in ("TEST_MODE", "OFFLINE_MODE", "TRADE_MANAGER_USE_STUB")
+        for flag in ("OFFLINE_MODE", "TRADE_MANAGER_USE_STUB")
     )
 
 


### PR DESCRIPTION
## Summary
- ensure TradeManager API requests require a token unless offline or stub modes are enabled
- align trading loop exception handling with BaseException typing to satisfy mypy

## Testing
- python -m flake8 --exclude venv .
- python -m mypy --exclude venv .
- pytest -ra -m "not integration"


------
https://chatgpt.com/codex/tasks/task_b_68daed3f29188321bd2075331a49d7c3