### PR TITLE
Fix API token enforcement in trade manager service

### DIFF
--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -112,7 +112,7 @@ def _require_api_token() -> ResponseReturnValue | None:
 
     expected = API_TOKEN
     if not expected:
-        if _authentication_optional():
+        if _authentication_optional() and request.method != 'POST':
             return None
         remote = request.headers.get('X-Forwarded-For') or request.remote_addr or 'unknown'
         logger.warning(


### PR DESCRIPTION
## Summary
- ensure the trade manager service still requires an API token for POST endpoints even when optional auth flags are set

## Testing
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_b_68daed5e17d08321a1c5509f0980b221