### PR TITLE
Fix trade manager auth bypass in test mode

### DIFF
--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -87,7 +87,7 @@ def _authentication_optional() -> bool:
 
     return any(
         os.getenv(flag) == '1'
-        for flag in ("TEST_MODE", "OFFLINE_MODE", "TRADE_MANAGER_USE_STUB")
+        for flag in ("OFFLINE_MODE", "TRADE_MANAGER_USE_STUB")
     )
 
 


### PR DESCRIPTION
## Summary
- require an API token even when TEST_MODE=1 by limiting the authentication bypass to offline/stub modes only

## Testing
- pytest -q --maxfail=1 --disable-warnings

------
https://chatgpt.com/codex/tasks/task_b_68daedaf8ed4832187b003e8fdeefba7