### PR TITLE
Add tests guarding dependency graph dispatch fallbacks

### DIFF
--- a/tests/test_dependency_graph_workflow.py
+++ b/tests/test_dependency_graph_workflow.py
@@ -60,8 +60,11 @@ def test_dependency_graph_detect_step_handles_nested_manifests() -> None:
 def test_dependency_graph_detect_step_uses_dispatch_commit_fallbacks() -> None:
     workflow = Path(".github/workflows/dependency-graph.yml").read_text(encoding="utf-8")
 
+    assert "github.event.client_payload.before" in workflow
     assert "github.event.client_payload.base_sha" in workflow
     assert "github.event.client_payload.head_sha" in workflow
+    assert "github.event.client_payload.after" in workflow
+    assert "github.event.client_payload.sha" in workflow
 
 
 def test_dependency_graph_installs_requests_before_submission() -> None:


### PR DESCRIPTION
## Summary
- ensure the dependency-graph workflow test suite asserts the repository_dispatch commit metadata fallbacks remain present

## Testing
- pytest tests/test_dependency_graph_workflow.py

------
https://chatgpt.com/codex/tasks/task_b_68daed07c0ac8321adf79e61b9dc4db5