### PR TITLE
Fix docker publish workflow failures

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -223,6 +223,7 @@ jobs:
         env:
           TEST_MODE: "1"
           DATA_HANDLER_ALLOW_ANONYMOUS: "1"
+          DATA_HANDLER_USE_STUB: "1"
         run: |
           scripts/run_data_handler_service.sh --bind 0.0.0.0:8000 &
           echo $! > "$GITHUB_WORKSPACE/service.pid"
@@ -240,6 +241,7 @@ jobs:
           HEALTH_CHECK_DELAY_SECONDS: "3"
           HEALTH_CHECK_BASE_URL: "http://127.0.0.1:8000"
           HEALTH_CHECK_ALLOWED_HOSTS: "localhost,127.0.0.1,::1"
+          DATA_HANDLER_USE_STUB: "1"
         run: python scripts/health_check.py
       - name: Cleanup
         if: ${{ always() && steps.start_service.outputs.service_running == 'true' }}

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -5,23 +5,25 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Обновление linux-libc-dev устраняет CVE-2025-21976, а libgcrypt20 — CVE-2024-2236
 # Обновляем систему перед установкой зависимостей
-RUN set -eux; \
-    apt-get update; \
-    apt-get upgrade -y; \
-    apt-get install -y --no-install-recommends \
-        linux-libc-dev \
-        libssl3t64 \
-        python3.12-minimal \
-        build-essential patch \
-        curl \
-        python3 python3-venv python3-dev python3-pip \
-        zlib1g-dev; \
-    python3 -m pip install --no-cache-dir --break-system-packages \
-        'pip>=24.0' \
-        'setuptools>=78.1.1,<81' \
-        wheel; \
-    apt-get clean; \
-    rm -rf /var/lib/apt/lists/*
+RUN <<'EOSHELL'
+set -eux
+apt-get update
+apt-get upgrade -y
+apt-get install -y --no-install-recommends \
+    linux-libc-dev \
+    libssl3t64 \
+    python3.12-minimal \
+    build-essential patch \
+    curl \
+    python3 python3-venv python3-dev python3-pip \
+    zlib1g-dev
+python3 -m pip install --no-cache-dir --break-system-packages \
+    'pip>=24.0' \
+    'setuptools>=78.1.1,<81' \
+    wheel
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+EOSHELL
 
 WORKDIR /app
 
@@ -107,25 +109,27 @@ FROM ubuntu:24.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Обновляем систему перед установкой зависимостей выполнения
-RUN set -eux; \
-    apt-get update; \
-    # Используем upgrade вместо dist-upgrade, чтобы избежать конфликтов зависимостей
-    apt-get upgrade -y; \
-    apt-get install -y --no-install-recommends \
-        libssl3t64 \
-        python3.12-minimal \
-        # Библиотека OpenMP требуется бинарям scikit-learn и NumPy.
-        libgomp1 \
-        curl \
-        python3 \
-        # Исключаем tar, чтобы избежать CVE-2025-45582
-        coreutils libgcrypt20 login passwd; \
-    # ``ensurepip`` отключён в системном Python Ubuntu, а рантайм использует
-    # виртуальное окружение из стадии сборки, поэтому дополнительные операции с pip
-    # не требуются.
-    apt-get clean; \
-    rm -rf /var/lib/apt/lists/*; \
-    python3 --version
+RUN <<'EOSHELL'
+set -eux
+apt-get update
+# Используем upgrade вместо dist-upgrade, чтобы избежать конфликтов зависимостей
+apt-get upgrade -y
+apt-get install -y --no-install-recommends \
+    libssl3t64 \
+    python3.12-minimal \
+    # Библиотека OpenMP требуется бинарям scikit-learn и NumPy.
+    libgomp1 \
+    curl \
+    python3 \
+    # Исключаем tar, чтобы избежать CVE-2025-45582
+    coreutils libgcrypt20 login passwd
+# ``ensurepip`` отключён в системном Python Ubuntu, а рантайм использует
+# виртуальное окружение из стадии сборки, поэтому дополнительные операции с pip
+# не требуются.
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+python3 --version
+EOSHELL
 
 WORKDIR /app
 

--- a/services/data_handler_service.py
+++ b/services/data_handler_service.py
@@ -45,16 +45,24 @@ _ALLOW_OFFLINE = (
     or os.getenv("TEST_MODE") == "1"
     or os.getenv("DATA_HANDLER_USE_STUB") == "1"
 )
+_FORCE_OFFLINE = os.getenv("DATA_HANDLER_USE_STUB") == "1"
 
 try:
+    if _FORCE_OFFLINE:
+        raise ImportError("Offline stub requested via DATA_HANDLER_USE_STUB=1")
     import ccxt  # type: ignore
 except ImportError as exc:  # pragma: no cover - optional in offline mode
     logger = logging.getLogger(__name__)
     if _ALLOW_OFFLINE:
-        logger.warning(
-            "`ccxt` не найден: DataHandlerService использует OfflineBybit. "
-            "Для онлайн-запуска установите зависимость `pip install ccxt`."
-        )
+        if _FORCE_OFFLINE:
+            logger.info(
+                "DATA_HANDLER_USE_STUB=1: DataHandlerService использует OfflineBybit без загрузки ccxt"
+            )
+        else:
+            logger.warning(
+                "`ccxt` не найден: DataHandlerService использует OfflineBybit. "
+                "Для онлайн-запуска установите зависимость `pip install ccxt`."
+            )
         from services.offline import OfflineBybit
 
         ccxt = SimpleNamespace(  # type: ignore[assignment]


### PR DESCRIPTION
## Summary
- rewrite the CPU image Dockerfile setup steps with heredocs to avoid build parser errors during CI builds
- allow forcing the OfflineBybit stub when DATA_HANDLER_USE_STUB=1 and activate it in the docker publish health check workflow
- ensure the docker publish health check always runs the data handler service with the stubbed exchange implementation

## Testing
- python3 -m compileall services/data_handler_service.py

------
https://chatgpt.com/codex/tasks/task_b_68daed242aa483218ac9d254b16d2b43