### PR TITLE
Fix dependency snapshot script imports

### DIFF
--- a/scripts/submit_dependency_snapshot.py
+++ b/scripts/submit_dependency_snapshot.py
@@ -15,6 +15,17 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, Mapping, TypedDict
 
+
+# Ensure the repository root is on ``sys.path`` so that sibling modules can be
+# imported when this script is executed directly via ``python
+# scripts/submit_dependency_snapshot.py``.  GitHub Actions invokes the script in
+# this manner and, without the adjustment, Python would attempt to resolve the
+# ``scripts`` package relative to ``scripts/`` instead of the project root.
+SCRIPT_DIRECTORY = Path(__file__).resolve().parent
+REPOSITORY_ROOT = SCRIPT_DIRECTORY.parent
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
 from urllib.parse import quote, urlparse
 
 from scripts.github_paths import resolve_github_path


### PR DESCRIPTION
## Summary
- ensure the dependency snapshot script can import sibling modules when executed directly

## Testing
- python scripts/submit_dependency_snapshot.py

------
https://chatgpt.com/codex/tasks/task_b_68db798ea0b08321be9a1054ddac2538