### PR TITLE
Refactor Dockerfile commons-lang3 update for Semgrep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ COPY docker/patches/linux-pam-CVE-2024-10963.patch /tmp/security/linux-pam-CVE-2
 COPY docker/patches/linux-pam-CVE-2024-10041.patch /tmp/security/linux-pam-CVE-2024-10041.patch
 COPY docker/scripts/update_pam_changelog.py /tmp/security/update_pam_changelog.py
 COPY docker/scripts/setup_zlib_and_pam.sh /tmp/security/setup_zlib_and_pam.sh
+COPY docker/scripts/update_commons_lang3.py /tmp/security/update_commons_lang3.py
 
 WORKDIR /tmp/build
 
@@ -89,49 +90,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 # Устанавливаем зависимости (pip >=24.0 устраняет CVE-2023-32681, setuptools>=78.1.1 закрывает свежие уязвимости)
 RUN pip install --no-compile --no-cache-dir 'pip>=24.0' 'setuptools>=78.1.1,<81' wheel && \
     pip install --no-compile --no-cache-dir -r requirements-core.txt -r requirements-gpu.txt && \
-    $VIRTUAL_ENV/bin/python - <<'PY'
-from __future__ import annotations
-import os
-from pathlib import Path
-import hashlib
-from urllib.request import urlopen
-
-try:
-    import ray  # type: ignore
-except Exception:
-    print("Ray отсутствует, пропускаем обновление commons-lang3")
-else:
-    jars_dir = Path(ray.__file__).resolve().parent / "jars"
-    jars_dir.mkdir(parents=True, exist_ok=True)
-    for jar in jars_dir.glob("commons-lang3-*.jar"):
-        jar.unlink()
-
-    commons_lang3_url = (
-        "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.18.0/"
-        "commons-lang3-3.18.0.jar"
-    )
-    commons_lang3_sha256 = (
-        "4eeeae8d20c078abb64b015ec158add383ac581571cddc45c68f0c9ae0230720"
-    )
-    destination = jars_dir / "commons-lang3-3.18.0.jar"
-
-    hasher = hashlib.sha256()
-    with urlopen(commons_lang3_url) as response, destination.open("wb") as fh:
-        while True:
-            chunk = response.read(8192)
-            if not chunk:
-                break
-            fh.write(chunk)
-            hasher.update(chunk)
-
-    digest = hasher.hexdigest()
-    if digest != commons_lang3_sha256:
-        destination.unlink(missing_ok=True)
-        raise RuntimeError(
-            "SHA256 mismatch while downloading commons-lang3: expected "
-            f"{commons_lang3_sha256}, got {digest}"
-        )
-PY
+    $VIRTUAL_ENV/bin/python /tmp/security/update_commons_lang3.py
 
 RUN find /app/venv -type d -name '__pycache__' -exec rm -rf {} + && \
     find /app/venv -type f -name '*.pyc' -delete && \

--- a/docker/scripts/update_commons_lang3.py
+++ b/docker/scripts/update_commons_lang3.py
@@ -1,0 +1,55 @@
+"""Update the Ray commons-lang3 dependency to a vetted release."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import hashlib
+from urllib.request import urlopen
+
+
+COMMONS_LANG3_URL = (
+    "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.18.0/"
+    "commons-lang3-3.18.0.jar"
+)
+COMMONS_LANG3_SHA256 = "4eeeae8d20c078abb64b015ec158add383ac581571cddc45c68f0c9ae0230720"
+
+
+def update_commons_lang3() -> None:
+    """Download and verify commons-lang3 for the Ray runtime jars directory."""
+
+    try:
+        import ray  # type: ignore
+    except Exception:
+        print("Ray отсутствует, пропускаем обновление commons-lang3")
+        return
+
+    jars_dir = Path(ray.__file__).resolve().parent / "jars"
+    jars_dir.mkdir(parents=True, exist_ok=True)
+
+    for jar in jars_dir.glob("commons-lang3-*.jar"):
+        jar.unlink()
+
+    destination = jars_dir / "commons-lang3-3.18.0.jar"
+    hasher = hashlib.sha256()
+
+    with urlopen(COMMONS_LANG3_URL) as response, destination.open("wb") as fh:
+        for chunk in iter(lambda: response.read(8192), b""):
+            fh.write(chunk)
+            hasher.update(chunk)
+
+    digest = hasher.hexdigest()
+    if digest != COMMONS_LANG3_SHA256:
+        destination.unlink(missing_ok=True)
+        raise RuntimeError(
+            "SHA256 mismatch while downloading commons-lang3: expected "
+            f"{COMMONS_LANG3_SHA256}, got {digest}"
+        )
+
+
+def main() -> int:
+    update_commons_lang3()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a standalone helper script to refresh Ray's commons-lang3 dependency during the build stage
- invoke the helper from the Dockerfile to replace the inline heredoc Python snippet that Semgrep could not parse

## Testing
- semgrep --config p/ci --error --skip-unknown-extensions
- semgrep --config p/ci --error --sarif --output semgrep.sarif --skip-unknown-extensions
- jq '.runs[0].results | length' semgrep.sarif

------
https://chatgpt.com/codex/tasks/task_b_68db7a2b421c8321b2ea30e1c98f21cf