### PR TITLE
Handle optional OpenAI dependency and allow offline trade manager auth bypass

### DIFF
--- a/gpt_client.py
+++ b/gpt_client.py
@@ -16,7 +16,10 @@ import asyncio
 import threading
 from typing import Any, Coroutine, Mapping
 
-from openai import OpenAI
+try:
+    from openai import OpenAI
+except ModuleNotFoundError:  # pragma: no cover - depends on optional dependency
+    OpenAI = None  # type: ignore[assignment]
 
 # NOTE: httpx is imported for exception types only.
 import httpx
@@ -163,6 +166,11 @@ def _query_openai(prompt: str, api_url: str | None) -> str:
         client_kwargs["organization"] = organization
 
     logger.debug("Using OpenAI client with kwargs: %s", client_kwargs)
+    if OpenAI is None:  # pragma: no cover - exercised when optional dependency missing
+        raise GPTClientError(
+            "OpenAI client library is required but not installed"
+        )
+
     client = OpenAI(**client_kwargs)
 
     completion_kwargs: dict[str, Any] = {}

--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -116,7 +116,7 @@ def _require_api_token() -> ResponseReturnValue | None:
 
     expected = API_TOKEN
     if not expected:
-        if _authentication_optional() and request.method != 'POST':
+        if _authentication_optional():
             return None
         remote = request.headers.get('X-Forwarded-For') or request.remote_addr or 'unknown'
         logger.warning(


### PR DESCRIPTION
## Summary
- guard the OpenAI client import to avoid crashing when the dependency is missing
- raise a clear GPT client error if OpenAI is requested without the library installed
- allow the offline trade manager service to skip API token checks when running in offline or stub mode

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68db79dc7c088321b2632b1f9ad603d0