### PR TITLE
Fix dependency snapshot script import path resolution

### DIFF
--- a/scripts/submit_dependency_snapshot.py
+++ b/scripts/submit_dependency_snapshot.py
@@ -17,6 +17,13 @@ from typing import Any, Dict, Iterable, Mapping, TypedDict
 
 from urllib.parse import quote, urlparse
 
+if __package__ in {None, ""}:
+    # Allow absolute ``scripts`` imports when the module is executed as a
+    # script (``python scripts/submit_dependency_snapshot.py``).  Without this
+    # adjustment only the ``scripts`` directory is on ``sys.path`` which makes
+    # ``import scripts`` fail.
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
 from scripts.github_paths import resolve_github_path
 
 _REQUESTS_IMPORT_ERROR: ImportError | None = None


### PR DESCRIPTION
## Summary
- ensure the dependency snapshot script can import shared helpers when executed directly by adding the repository root to sys.path

## Testing
- python scripts/submit_dependency_snapshot.py

------
https://chatgpt.com/codex/tasks/task_b_68db7a05d450832199737f14a1996eaa