### PR TITLE
Fix offline trade manager auth and ensure OpenAI dependency

### DIFF
--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -116,7 +116,7 @@ def _require_api_token() -> ResponseReturnValue | None:
 
     expected = API_TOKEN
     if not expected:
-        if _authentication_optional() and request.method != 'POST':
+        if _authentication_optional():
             return None
         remote = request.headers.get('X-Forwarded-For') or request.remote_addr or 'unknown'
         logger.warning(

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -122,6 +122,7 @@ _required_packages: list[tuple[str, str]] = [
     ("requests", "requests>=2.32.3"),
     ("httpx", "httpx>=0.27.0"),
     ("aiohttp", "aiohttp>=3.10.10"),
+    ("openai", "openai==1.109.1"),
     ("bcrypt", "bcrypt>=4.1.3"),
     ("psutil", "psutil>=5.9.0"),
     ("polars", "polars>=1.6.0"),


### PR DESCRIPTION
## Summary
- ensure the sitecustomize auto-installer also provides the pinned OpenAI client used by the GPT integrations
- allow the trade manager service to bypass API token checks in explicit offline or stub modes so integration tests can exercise endpoints

## Testing
- pytest tests/integration/test_offline_trade_manager_service.py

------
https://chatgpt.com/codex/tasks/task_b_68db79fc52b8832196fb73ad55c20ab2