### PR TITLE
Allow offline trade manager to skip token

### DIFF
--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -116,7 +116,7 @@ def _require_api_token() -> ResponseReturnValue | None:
 
     expected = API_TOKEN
     if not expected:
-        if _authentication_optional() and request.method != 'POST':
+        if _authentication_optional():
             return None
         remote = request.headers.get('X-Forwarded-For') or request.remote_addr or 'unknown'
         logger.warning(


### PR DESCRIPTION
## Summary
- allow the trade manager service to bypass API token enforcement when running in offline or stubbed modes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68db7a35cff8832189ece2aa42a45839