### PR TITLE
Fix Dependabot workflow auto-merge condition

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -174,7 +174,9 @@ jobs:
 
       - name: Enable auto-merge for Dependabot PRs
         id: enable_automerge
-        if: ${{ steps.auto_merge.outputs.allowed == 'true' && steps.metadata.outputs.update-type != 'version-update:semver-major' }}
+        if: >-
+          steps.auto_merge.outputs.allowed == 'true' &&
+          steps.metadata.outputs.update-type != 'version-update:semver-major'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}


### PR DESCRIPTION
## Summary
- update the Dependabot auto-merge step to use a multi-line condition that parses correctly

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_b_68dbb0a666188321a6beec28f8c13ea5