### PR TITLE
Relax auth for read-only trade manager requests

### DIFF
--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -111,7 +111,7 @@ def _bind_exchange() -> None:
 def _require_api_token() -> ResponseReturnValue | None:
     """Simple token-based authentication middleware."""
 
-    if request.method != 'POST' and request.path != '/positions':
+    if request.method in {'GET', 'HEAD', 'OPTIONS'}:
         return None
 
     expected = API_TOKEN


### PR DESCRIPTION
## Summary
- allow safe HTTP methods to bypass TradeManager token validation so read-only endpoints remain accessible

## Testing
- pytest tests/test_trade_manager_service_sync.py

------
https://chatgpt.com/codex/tasks/task_b_68dbb08b9be483218c8dc64253637da5