### PR TITLE
Fix Trivy workflow execution

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -40,24 +40,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-trivy-db-
 
-      - name: Install Trivy CLI
-        uses: aquasecurity/setup-trivy@e6c2c5e321ed9123bda567646e2f96565e34abe1
-        # v0.2.4
-        with:
-          trivy-version: v0.66.0
-
       - id: trivy
         name: Run Trivy scan
-        run: |
-          set -euo pipefail
-          trivy fs \
-            --scanners vuln \
-            --format sarif \
-            --output trivy-results.sarif \
-            --severity CRITICAL,HIGH \
-            --ignore-unfixed \
-            --exit-code 0 \
-            .
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
+        # v0.33.1
+        continue-on-error: true
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          format: sarif
+          output: trivy-results.sarif
+          exit-code: '1'
+          cache-dir: ${{ env.TRIVY_CACHE_DIR }}
 
       - name: Ensure jq is available
         if: ${{ always() && steps.trivy.conclusion != 'skipped' }}
@@ -78,7 +75,7 @@ jobs:
             echo "parsing_failed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if ! count=$(jq '[.runs[]?.results[]?] | length' trivy-results.sarif); then
+          if ! count=$(jq -r '[.runs[]?.results[]?] | length' trivy-results.sarif); then
             echo "::error::Failed to parse trivy-results.sarif with jq." >&2
             echo "sarif_exists=false" >> "$GITHUB_OUTPUT"
             echo "vulnerability_count=0" >> "$GITHUB_OUTPUT"
@@ -110,7 +107,7 @@ jobs:
           sarif_file: trivy-results.sarif
 
       - name: Warn when SARIF upload is unavailable
-        if: ${{ steps.upload_trivy_sarif.outcome == 'failure' }}
+        if: ${{ always() && steps.upload_trivy_sarif.outcome == 'failure' }}
         run: |
           echo "::warning::Не удалось загрузить отчёт Trivy в раздел безопасности GitHub."
           echo "* SARIF upload failed due to missing permissions." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- replace the manual Trivy CLI invocation with the maintained aquasecurity/trivy-action
- preserve SARIF parsing, summaries, and artifact uploads while ensuring failures are still reported
- tighten jq parsing and guard conditions for warning and failure steps

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_b_68dbb064c43c8321afb8e564b73d7163