### PR TITLE
Fix Docker CPU image build by installing Python 3.11

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -4,23 +4,36 @@ FROM ubuntu:24.04 AS builder
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Обновление linux-libc-dev устраняет CVE-2025-21976, а libgcrypt20 — CVE-2024-2236
-# Обновляем систему перед установкой зависимостей
+# Дополнительно подключаем PPA deadsnakes для установки Python 3.11, поскольку
+# часть зависимостей проекта ещё не поддерживает Python 3.12. Без этого pip
+# пытается собирать тяжёлые пакеты из исходников и шаг сборки в CI завершается
+# с ошибкой.
 RUN <<'EOSHELL'
 set -eux
 apt-get update
 apt-get upgrade -y
 apt-get install -y --no-install-recommends \
+    software-properties-common \
+    gnupg \
+    ca-certificates \
     linux-libc-dev \
     libssl3t64 \
-    python3.12-minimal \
     build-essential patch \
     curl \
-    python3 python3-venv python3-dev python3-pip \
     zlib1g-dev
-python3 -m pip install --no-cache-dir --break-system-packages \
+add-apt-repository -y ppa:deadsnakes/ppa
+apt-get update
+apt-get install -y --no-install-recommends \
+    python3.11 \
+    python3.11-dev \
+    python3.11-venv \
+    python3.11-distutils
+python3.11 -m ensurepip --upgrade
+python3.11 -m pip install --no-cache-dir --break-system-packages \
     'pip>=24.0' \
     'setuptools>=78.1.1,<81' \
     wheel
+apt-get purge -y --auto-remove software-properties-common gnupg || true
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 EOSHELL
@@ -32,7 +45,9 @@ COPY requirements-core.txt .
 ENV VIRTUAL_ENV=/app/venv
 # pip >=24.0 устраняет CVE-2023-32681, setuptools>=78.1.1 закрывает актуальные уязвимости
 # и подходит для сборки gymnasium.
-RUN python3 -m venv "$VIRTUAL_ENV"
+RUN python3.11 -m venv "$VIRTUAL_ENV"
+
+RUN "$VIRTUAL_ENV"/bin/python -m ensurepip --upgrade
 
 RUN "$VIRTUAL_ENV"/bin/pip install --no-cache-dir \
         'pip>=24.0' \
@@ -108,34 +123,38 @@ RUN /bin/bash -euo pipefail -c "\
 FROM ubuntu:24.04
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Обновляем систему перед установкой зависимостей выполнения
+# Обновляем систему перед установкой зависимостей выполнения и добавляем Python 3.11
+# из PPA deadsnakes, чтобы среда рантайма совпадала с окружением сборки.
 RUN <<'EOSHELL'
 set -eux
 apt-get update
-# Используем upgrade вместо dist-upgrade, чтобы избежать конфликтов зависимостей
 apt-get upgrade -y
 apt-get install -y --no-install-recommends \
+    software-properties-common \
+    gnupg \
+    ca-certificates \
     libssl3t64 \
-    python3.12-minimal \
-    python3-minimal \
     # Библиотека OpenMP требуется бинарям scikit-learn и NumPy.
     libgomp1 \
     curl \
-    python3 \
     # Исключаем tar, чтобы избежать CVE-2025-45582
     coreutils libgcrypt20 login passwd
-# ``ensurepip`` отключён в системном Python Ubuntu, а рантайм использует
-# виртуальное окружение из стадии сборки, поэтому дополнительные операции с pip
-# не требуются.
+add-apt-repository -y ppa:deadsnakes/ppa
+apt-get update
+apt-get install -y --no-install-recommends \
+    python3.11 \
+    python3.11-minimal \
+    python3.11-distutils
+apt-get purge -y --auto-remove software-properties-common gnupg || true
 apt-get clean
 rm -rf /var/lib/apt/lists/*
-if command -v python3 >/dev/null 2>&1; then
-    python3 --version
-elif command -v python3.12 >/dev/null 2>&1; then
-    ln -sfn /usr/bin/python3.12 /usr/local/bin/python3
-    /usr/bin/python3.12 --version
+if command -v python3.11 >/dev/null 2>&1; then
+    if [ ! -e /usr/local/bin/python3 ]; then
+        ln -s /usr/bin/python3.11 /usr/local/bin/python3
+    fi
+    /usr/bin/python3.11 --version
 else
-    echo 'python3 binary missing after installation' >&2
+    echo 'python3.11 binary missing after installation' >&2
     exit 1
 fi
 EOSHELL


### PR DESCRIPTION
## Summary
- install Python 3.11 from the deadsnakes PPA in Dockerfile.cpu to match project dependency support
- build the virtual environment and runtime layers with Python 3.11 so pip installs succeed during the docker-publish workflow

## Testing
- not run (not available in container environment)


------
https://chatgpt.com/codex/tasks/task_b_68dbd08369ac83219dd842f5868b7704