### PR TITLE
Align pinned dependencies across requirement sets

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -31,7 +31,7 @@ attrs==25.3.0
     #   aiohttp
     #   jsonschema
     #   referencing
-bcrypt==4.3.0
+bcrypt==5.0.0
     # via -r requirements-core.in
 blinker==1.9.0
     # via flask
@@ -68,7 +68,7 @@ distro==1.9.0
     # via openai
 farama-notifications==0.0.4
     # via gymnasium
-fastapi==0.117.1
+fastapi==0.118.0
     # via -r requirements-core.in
 fastapi-csrf-protect==1.0.7
     # via -r requirements-core.in
@@ -131,7 +131,7 @@ jinja2==3.1.6
     #   torch
 jiter==0.11.0
     # via openai
-joblib==1.5.1
+joblib==1.5.2
     # via
     #   -r requirements-core.in
     #   imbalanced-learn
@@ -163,7 +163,7 @@ multidict==6.6.4
     #   yarl
 networkx==3.5
     # via torch
-numba==0.62.0
+numba==0.62.1
     # via
     #   -r requirements-core.in
     #   shap
@@ -199,7 +199,7 @@ packaging==25.0
     #   statsmodels
     #   torchmetrics
     #   transformers
-pandas==2.3.2
+pandas==2.3.3
     # via
     #   -r requirements-core.in
     #   shap
@@ -212,7 +212,7 @@ pillow==11.3.0
     # via matplotlib
 pluggy==1.6.0
     # via pytest
-polars==1.32.3
+polars==1.33.1
     # via -r requirements-core.in
 propcache==0.3.2
     # via
@@ -222,7 +222,7 @@ psutil==7.1.0
     # via -r requirements-core.in
 pyarrow==21.0.0
     # via -r requirements-core.in
-pybit==5.11.0
+pybit==5.12.0
     # via -r requirements-core.in
 pycares==4.10.0
     # via aiodns
@@ -230,7 +230,7 @@ pycparser==2.22
     # via cffi
 pycryptodome==3.23.0
     # via pybit
-pydantic==2.11.7
+pydantic==2.11.9
     # via
     #   fastapi
     #   fastapi-csrf-protect
@@ -244,9 +244,9 @@ pygments==2.19.2
     # via pytest
 pyparsing==3.2.3
     # via matplotlib
-pytest==8.4.1
+pytest==8.4.2
     # via pytest-asyncio
-pytest-asyncio==1.1.0
+pytest-asyncio==1.2.0
     # via -r requirements-core.in
 python-dateutil==2.9.0.post0
     # via
@@ -256,7 +256,7 @@ python-dotenv==1.1.1
     # via
     #   -r requirements-core.in
     #   pydantic-settings
-python-telegram-bot==22.4
+python-telegram-bot==22.5
     # via -r requirements-core.in
 pytorch-lightning==2.5.5
     # via -r requirements-core.in

--- a/requirements.out
+++ b/requirements.out
@@ -75,7 +75,7 @@ cloudpickle==3.1.1
     #   gymnasium
     #   shap
     #   stable-baselines3
-contourpy==1.3.2
+contourpy==1.3.3
     # via
     #   -r requirements.txt
     #   matplotlib
@@ -95,7 +95,7 @@ farama-notifications==0.0.4
     # via
     #   -r requirements.txt
     #   gymnasium
-fastapi==0.117.1
+fastapi==0.118.0
     # via -r requirements.txt
 fastapi-csrf-protect==1.0.7
     # via -r requirements.txt
@@ -220,11 +220,11 @@ multidict==6.6.4
     #   -r requirements.txt
     #   aiohttp
     #   yarl
-networkx==3.4.2
+networkx==3.5
     # via
     #   -r requirements.txt
     #   torch
-numba==0.62.0
+numba==0.62.1
     # via
     #   -r requirements.txt
     #   shap
@@ -261,7 +261,7 @@ packaging==25.0
     #   statsmodels
     #   torchmetrics
     #   transformers
-pandas==2.3.2
+pandas==2.3.3
     # via
     #   -r requirements.txt
     #   shap
@@ -291,7 +291,7 @@ psutil==7.1.0
     # via -r requirements.txt
 pyarrow==21.0.0
     # via -r requirements.txt
-pybit==5.11.0
+pybit==5.12.0
     # via -r requirements.txt
 pycares==4.10.0
     # via
@@ -387,7 +387,7 @@ scikit-learn==1.7.2
     #   -r requirements.txt
     #   imbalanced-learn
     #   shap
-scipy==1.15.3
+scipy==1.16.1
     # via
     #   -r requirements.txt
     #   imbalanced-learn

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,7 +62,7 @@ cloudpickle==3.1.1
     #   gymnasium
     #   shap
     #   stable-baselines3
-contourpy==1.3.2
+contourpy==1.3.3
     # via matplotlib
 cryptography==46.0.1
     # via
@@ -171,7 +171,7 @@ multidict==6.6.4
     # via
     #   aiohttp
     #   yarl
-networkx==3.4.2
+networkx==3.5
     # via torch
 numba==0.62.1
     # via
@@ -209,7 +209,7 @@ packaging==25.0
     #   statsmodels
     #   torchmetrics
     #   transformers
-pandas==2.3.2
+pandas==2.3.3
     # via
     #   -r requirements-core.in
     #   shap
@@ -232,7 +232,7 @@ psutil==7.1.0
     # via -r requirements-core.in
 pyarrow==21.0.0
     # via -r requirements-core.in
-pybit==5.11.0
+pybit==5.12.0
     # via -r requirements-core.in
 pycares==4.10.0
     # via aiodns
@@ -300,7 +300,7 @@ scikit-learn==1.7.2
     #   -r requirements-core.in
     #   imbalanced-learn
     #   shap
-scipy==1.15.3
+scipy==1.16.1
     # via
     #   -r requirements-core.in
     #   imbalanced-learn

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -116,7 +116,7 @@ def _run_pip_install(requirement: str) -> None:
 
 _required_packages: list[tuple[str, str]] = [
     ("numpy", "numpy==2.2.6"),
-    ("pandas", "pandas==2.3.2"),
+    ("pandas", "pandas==2.3.3"),
     ("pydantic", "pydantic==2.11.9"),
     ("flask", "flask>=3.0.3,<4"),
     ("requests", "requests>=2.32.3"),


### PR DESCRIPTION
## Summary
- align pinned versions for core dependencies across requirements files so Dependabot PRs install a consistent stack
- update the runtime dependency gate in `sitecustomize.py` to expect the new pandas release

## Testing
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_b_68dbd0afd6248321ba7ab374b8ae112e