### PR TITLE
Fix GPT-OSS workflow scripts path handling

### DIFF
--- a/scripts/check_pr_status.py
+++ b/scripts/check_pr_status.py
@@ -17,9 +17,16 @@ import re
 import ssl
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.request import HTTPSHandler, Request, build_opener
+
+if __package__ in {None, ""}:
+    package_root = Path(__file__).resolve().parent.parent
+    package_root_str = str(package_root)
+    if package_root_str not in sys.path:
+        sys.path.insert(0, package_root_str)
 
 from scripts.github_paths import resolve_github_path
 

--- a/scripts/prepare_gptoss_diff.py
+++ b/scripts/prepare_gptoss_diff.py
@@ -31,6 +31,12 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
 from urllib.request import HTTPSHandler, Request, build_opener
 
+if __package__ in {None, ""}:
+    package_root = Path(__file__).resolve().parent.parent
+    package_root_str = str(package_root)
+    if package_root_str not in sys.path:
+        sys.path.insert(0, package_root_str)
+
 from scripts.github_paths import resolve_github_path
 
 

--- a/scripts/run_gptoss_review.py
+++ b/scripts/run_gptoss_review.py
@@ -29,6 +29,12 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
+if __package__ in {None, ""}:
+    package_root = Path(__file__).resolve().parent.parent
+    package_root_str = str(package_root)
+    if package_root_str not in sys.path:
+        sys.path.insert(0, package_root_str)
+
 from scripts.github_paths import resolve_github_path
 
 _PROMPT_PREFIX = "Review the following diff and provide feedback:\n"


### PR DESCRIPTION
## Summary
- ensure the GPT-OSS helper scripts add the repository root to `sys.path` when executed directly so `from scripts...` imports succeed
- add the missing `Path` import required by the new bootstrap logic in `check_pr_status.py`

## Testing
- pytest
- python3 scripts/run_gptoss_review.py --help
- python3 scripts/check_pr_status.py --help
- python3 scripts/prepare_gptoss_diff.py --help

------
https://chatgpt.com/codex/tasks/task_b_68dbd0c673148321b7635524bb8a01bd