### PR TITLE
Fix Trivy workflow summary for forked PRs

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -131,7 +131,7 @@ jobs:
               github.event.pull_request.head.repo.fork }}
         run: |
           echo "::warning::Пропускаем загрузку артефакта Trivy для форк-пулреквеста из-за ограниченных прав."
-          printf '* Загрузка артефакта пропущена: требуется доступ actions:write, недоступный для форк-пулреквестов.\n' >> "$GITHUB_STEP_SUMMARY"
+          echo '* Загрузка артефакта пропущена: требуется доступ actions:write, недоступный для форк-пулреквестов.' >> "$GITHUB_STEP_SUMMARY"
 
       - name: Fail if Trivy scan failed unexpectedly
         if: ${{ steps.trivy.conclusion == 'failure' && steps.parse_trivy.outputs.sarif_exists != 'true' }}


### PR DESCRIPTION
## Summary
- ensure the Trivy workflow appends the fork warning to the job summary without relying on a broken line continuation

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_b_68dbd047e21c832194a092a01ed37671