### PR TITLE
Fix Release Drafter workflow permissions

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -21,6 +21,7 @@ permissions:
   actions: read  # allow downloading pinned Release Drafter action revisions
   contents: write
   pull-requests: write
+  issues: write
 
 concurrency:
   group: release-drafter-${{ github.event_name == 'pull_request_target' && format('pr-{0}', github.event.pull_request.number) || github.ref }}


### PR DESCRIPTION
## Summary
- grant the Release Drafter workflow issues: write permissions so it can manage pull request labels

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dbd0d45e9c832187079344f83fbd23