### PR TITLE
Fix dependency graph workflow permissions for dependency submissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -10,7 +10,9 @@ on:
       - 'dependency_graph/auto_submission'
 
 permissions:
-  contents: read
+  # GitHub requires write access to repository contents for dependency snapshot
+  # submissions performed with the dependency submission API.
+  contents: write
   # GitHub rejects the legacy dependency graph permission scope for this workflow; grant
   # `security-events` instead to satisfy the dependency submission API while keeping
   # permissions minimal.

--- a/tests/test_dependency_graph_workflow.py
+++ b/tests/test_dependency_graph_workflow.py
@@ -45,7 +45,7 @@ def test_dependency_graph_permissions_are_valid() -> None:
     allowed_keys = {"contents", "security-events"}
     assert set(permissions) <= allowed_keys
 
-    assert permissions.get("contents") == "read"
+    assert permissions.get("contents") == "write"
     assert permissions.get("security-events") == "write"
 
 


### PR DESCRIPTION
## Summary
- grant the dependency graph workflow `contents: write` so GitHub can accept dependency snapshots
- adjust the workflow test expectation to reflect the updated permission level

## Testing
- pytest tests/test_dependency_graph_workflow.py

------
https://chatgpt.com/codex/tasks/task_b_68dbd0bb9ea48321be2d758ea7742f67