### PR TITLE
Use stdlib HTTP client for dependency snapshot submission

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -210,14 +210,6 @@ jobs:
                       updated = "".join(filtered)
                       path.write_text(updated, encoding="utf-8")
           PY
-      - name: Install dependency snapshot dependencies
-        if: >-
-          steps.detect.outputs.changed == 'true' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'repository_dispatch'
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install requests
       - name: Submit dependency snapshot
         if: >-
           steps.detect.outputs.changed == 'true' ||


### PR DESCRIPTION
## Summary
- rewrite `scripts/submit_dependency_snapshot.py` to use the standard library HTTP client instead of `requests`, keeping retry/backoff and error reporting
- remove the `pip install requests` step from `dependency-graph.yml` because the workflow no longer needs third-party packages

## Testing
- python scripts/submit_dependency_snapshot.py


------
https://chatgpt.com/codex/tasks/task_b_68dc186490988321862e1012d68bebc4