### PR TITLE
Guard PR status check against missing helper

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -170,6 +170,17 @@ jobs:
         run: |
           set -euo pipefail
 
+          if [ ! -f scripts/check_pr_status.py ]; then
+            echo "::notice::Скрипт scripts/check_pr_status.py не найден, пропускаю проверку PR"
+            if [ -n "${GITHUB_OUTPUT:-}" ]; then
+              {
+                echo "skip=true"
+                echo "head_sha="
+              } >>"$GITHUB_OUTPUT"
+            fi
+            exit 0
+          fi
+
           if ! python3 scripts/check_pr_status.py \
             --repo "${REPOSITORY}" \
             --pr-number "${PR_NUMBER:-}" \


### PR DESCRIPTION
## Summary
- skip the GPT-OSS review status check when the helper script is unavailable
- mark the review job as skipped by exporting default outputs if the helper is missing

## Testing
- no tests (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_b_68dc18570554832184dc5c26d9ffb64d