### PR TITLE
Fix lint regressions blocking Dependabot

### DIFF
--- a/gpt_client.py
+++ b/gpt_client.py
@@ -5,18 +5,24 @@ For security reasons, the URL must either use HTTPS or resolve to a local
 or private address (HTTP is allowed only for such addresses).
 """
 
-import logging
-import os
-import json
-import socket
-from enum import Enum
-from urllib.parse import urlparse, urljoin
-from ipaddress import ip_address
 import asyncio
-import threading
 import importlib
 import importlib.util
-from typing import Any, Coroutine, Mapping, TYPE_CHECKING
+import json
+import logging
+import os
+import socket
+import threading
+from enum import Enum
+from ipaddress import ip_address
+from typing import TYPE_CHECKING, Any, Coroutine, Mapping
+from urllib.parse import urljoin, urlparse
+
+import httpx
+
+from bot.config import OFFLINE_MODE
+from bot.pydantic_compat import BaseModel, Field, ValidationError
+from bot.utils import retry
 
 if TYPE_CHECKING:  # pragma: no cover - import for typing only
     from openai import OpenAI as OpenAIType  # noqa: F401
@@ -29,16 +35,6 @@ if _openai_spec is not None:
     OpenAI: OpenAIType | None = getattr(_openai_module, "OpenAI", None)
 else:
     OpenAI = None
-
-# NOTE: httpx is imported for exception types only.
-import httpx
-
-from bot.pydantic_compat import BaseModel, Field, ValidationError
-
-from bot.utils import retry
-# Absolute import ensures the project's own configuration module is used
-# instead of any unrelated ``config`` module on the import path.
-from bot.config import OFFLINE_MODE
 if OFFLINE_MODE:
     from services.offline import OfflineGPT
 

--- a/model_builder/core.py
+++ b/model_builder/core.py
@@ -3,12 +3,10 @@
 from __future__ import annotations
 
 import asyncio
-import importlib
 import hashlib
 import math
 import os
 import random
-import re
 import sys
 import tempfile
 import time
@@ -34,7 +32,7 @@ from security import (
 )
 from services.logging_utils import sanitize_log_value
 
-from .storage import JOBLIB_AVAILABLE, joblib, save_artifacts, _is_within_directory
+from .storage import JOBLIB_AVAILABLE, joblib, _is_within_directory
 
 _utils = require_utils(
     "check_dataframe_empty",

--- a/scripts/submit_dependency_snapshot.py
+++ b/scripts/submit_dependency_snapshot.py
@@ -14,6 +14,7 @@ from collections import OrderedDict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, Mapping, TypedDict
+from urllib.parse import quote, urlparse
 
 
 # Ensure the repository root is on ``sys.path`` so that sibling modules can be
@@ -26,8 +27,6 @@ REPOSITORY_ROOT = SCRIPT_DIRECTORY.parent
 if str(REPOSITORY_ROOT) not in sys.path:
     sys.path.insert(0, str(REPOSITORY_ROOT))
 
-from urllib.parse import quote, urlparse
-
 if __package__ in {None, ""}:
     # Allow absolute ``scripts`` imports when the module is executed as a
     # script (``python scripts/submit_dependency_snapshot.py``).  Without this
@@ -35,7 +34,7 @@ if __package__ in {None, ""}:
     # ``import scripts`` fail.
     sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from scripts.github_paths import resolve_github_path
+from scripts.github_paths import resolve_github_path  # noqa: E402
 
 _REQUESTS_IMPORT_ERROR: ImportError | None = None
 

--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -12,7 +12,6 @@ import os
 import stat
 import tempfile
 import threading
-import time
 from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Mapping, cast


### PR DESCRIPTION
## Summary
- reorder `gpt_client` imports so httpx and project modules load before runtime checks
- drop unused imports flagged by Ruff in model builder and trade manager services
- silence the intentional path adjustment in `submit_dependency_snapshot` while keeping standard library imports at the top

## Testing
- pytest -m "not integration" -q
- ruff check

------
https://chatgpt.com/codex/tasks/task_b_68dc186c88b083218ff82973cbbba8d3