### PR TITLE
Fix lint issues blocking Dependabot workflow

### DIFF
--- a/gpt_client.py
+++ b/gpt_client.py
@@ -5,18 +5,27 @@ For security reasons, the URL must either use HTTPS or resolve to a local
 or private address (HTTP is allowed only for such addresses).
 """
 
-import logging
-import os
-import json
-import socket
-from enum import Enum
-from urllib.parse import urlparse, urljoin
-from ipaddress import ip_address
 import asyncio
-import threading
 import importlib
 import importlib.util
-from typing import Any, Coroutine, Mapping, TYPE_CHECKING
+import json
+import logging
+import os
+import socket
+import threading
+from enum import Enum
+from ipaddress import ip_address
+from typing import TYPE_CHECKING, Any, Coroutine, Mapping
+from urllib.parse import urljoin, urlparse
+
+import httpx
+
+from bot.config import OFFLINE_MODE
+from bot.pydantic_compat import BaseModel, Field, ValidationError
+from bot.utils import retry
+
+if OFFLINE_MODE:
+    from services.offline import OfflineGPT
 
 if TYPE_CHECKING:  # pragma: no cover - import for typing only
     from openai import OpenAI as OpenAIType  # noqa: F401
@@ -29,18 +38,6 @@ if _openai_spec is not None:
     OpenAI: OpenAIType | None = getattr(_openai_module, "OpenAI", None)
 else:
     OpenAI = None
-
-# NOTE: httpx is imported for exception types only.
-import httpx
-
-from bot.pydantic_compat import BaseModel, Field, ValidationError
-
-from bot.utils import retry
-# Absolute import ensures the project's own configuration module is used
-# instead of any unrelated ``config`` module on the import path.
-from bot.config import OFFLINE_MODE
-if OFFLINE_MODE:
-    from services.offline import OfflineGPT
 
 logger = logging.getLogger("TradingBot")
 

--- a/model_builder/core.py
+++ b/model_builder/core.py
@@ -3,12 +3,10 @@
 from __future__ import annotations
 
 import asyncio
-import importlib
 import hashlib
 import math
 import os
 import random
-import re
 import sys
 import tempfile
 import time
@@ -34,7 +32,7 @@ from security import (
 )
 from services.logging_utils import sanitize_log_value
 
-from .storage import JOBLIB_AVAILABLE, joblib, save_artifacts, _is_within_directory
+from .storage import JOBLIB_AVAILABLE, joblib, _is_within_directory
 
 _utils = require_utils(
     "check_dataframe_empty",

--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -12,7 +12,6 @@ import os
 import stat
 import tempfile
 import threading
-import time
 from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Mapping, cast


### PR DESCRIPTION
## Summary
- reorder GPT client imports so they stay at the module top level and satisfy ruff
- lazily import the dependency snapshot helper without violating lint rules
- drop unused imports flagged by the Dependabot workflow

## Testing
- pytest -m "not integration" -q
- ruff check

------
https://chatgpt.com/codex/tasks/task_b_68dc18776eac832192634c4ff4d439ed