### PR TITLE
Fix dependency snapshot workflow event type

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -7,7 +7,10 @@ on:
   workflow_dispatch:
   repository_dispatch:
     types:
-      - 'dependency_graph/auto_submission'
+      # Custom type used by auto-submission hooks. GitHub restricts repository
+      # dispatch event names to alphanumeric characters plus '-' and '_', so we
+      # cannot include a '/' separator here.
+      - dependency-graph-auto-submission
 
 permissions:
   # GitHub requires write access to repository contents for dependency snapshot

--- a/tests/test_dependency_graph_workflow.py
+++ b/tests/test_dependency_graph_workflow.py
@@ -94,5 +94,5 @@ def test_dependency_graph_supports_repository_dispatch_auto_submission() -> None
     workflow = Path(".github/workflows/dependency-graph.yml").read_text(encoding="utf-8")
 
     assert "repository_dispatch" in workflow
-    assert "dependency_graph/auto_submission" in workflow
+    assert "dependency-graph-auto-submission" in workflow
     assert "github.event_name == 'repository_dispatch'" in workflow


### PR DESCRIPTION
## Summary
- replace the repository_dispatch trigger type with a GitHub-compliant variant and document the restriction
- update the dependency graph workflow test expectations to match the new event type

## Testing
- pytest tests/test_dependency_graph_workflow.py

------
https://chatgpt.com/codex/tasks/task_b_68dc1890d59883218f226fa41ffb0f2f