### PR TITLE
Fix Dockerfile.cpu PPA setup

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -13,7 +13,6 @@ set -eux
 apt-get update
 apt-get upgrade -y
 apt-get install -y --no-install-recommends \
-    software-properties-common \
     gnupg \
     ca-certificates \
     linux-libc-dev \
@@ -21,7 +20,17 @@ apt-get install -y --no-install-recommends \
     build-essential patch \
     curl \
     zlib1g-dev
-add-apt-repository -y ppa:deadsnakes/ppa
+# Регистрируем PPA deadsnakes вручную, без утилиты add-apt-repository,
+# чтобы не зависеть от системного python3 в базовом образе.
+keyring_path=/usr/share/keyrings/deadsnakes-ppa.gpg
+codename="$(. /etc/os-release && printf '%s' "$VERSION_CODENAME")"
+tmp_key="$(mktemp)"
+curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xBA6932366A755776" -o "$tmp_key"
+gpg --batch --yes --dearmor -o "$keyring_path" "$tmp_key"
+rm -f "$tmp_key"
+chmod 644 "$keyring_path"
+printf 'deb [signed-by=%s] http://ppa.launchpad.net/deadsnakes/ppa/ubuntu %s main\n' \
+  "$keyring_path" "$codename" > /etc/apt/sources.list.d/deadsnakes-ppa.list
 apt-get update
 apt-get install -y --no-install-recommends \
     python3.11 \
@@ -33,7 +42,7 @@ python3.11 -m pip install --no-cache-dir --break-system-packages \
     'pip>=24.0' \
     'setuptools>=78.1.1,<81' \
     wheel
-apt-get purge -y --auto-remove software-properties-common gnupg || true
+apt-get purge -y --auto-remove gnupg || true
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 EOSHELL
@@ -130,7 +139,6 @@ set -eux
 apt-get update
 apt-get upgrade -y
 apt-get install -y --no-install-recommends \
-    software-properties-common \
     gnupg \
     ca-certificates \
     libssl3t64 \
@@ -139,13 +147,23 @@ apt-get install -y --no-install-recommends \
     curl \
     # Исключаем tar, чтобы избежать CVE-2025-45582
     coreutils libgcrypt20 login passwd
-add-apt-repository -y ppa:deadsnakes/ppa
+# Регистрируем PPA deadsnakes вручную, без утилиты add-apt-repository,
+# чтобы не зависеть от системного python3 в базовом образе.
+keyring_path=/usr/share/keyrings/deadsnakes-ppa.gpg
+codename="$(. /etc/os-release && printf '%s' "$VERSION_CODENAME")"
+tmp_key="$(mktemp)"
+curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xBA6932366A755776" -o "$tmp_key"
+gpg --batch --yes --dearmor -o "$keyring_path" "$tmp_key"
+rm -f "$tmp_key"
+chmod 644 "$keyring_path"
+printf 'deb [signed-by=%s] http://ppa.launchpad.net/deadsnakes/ppa/ubuntu %s main\n' \
+  "$keyring_path" "$codename" > /etc/apt/sources.list.d/deadsnakes-ppa.list
 apt-get update
 apt-get install -y --no-install-recommends \
     python3.11 \
     python3.11-minimal \
     python3.11-distutils
-apt-get purge -y --auto-remove software-properties-common gnupg || true
+apt-get purge -y --auto-remove gnupg || true
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 if command -v python3.11 >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- register the deadsnakes PPA manually in `Dockerfile.cpu` so Python 3.11 can be installed without relying on `add-apt-repository`
- stop installing `software-properties-common` now that the repository is added via GPG key material

## Testing
- not run (Docker image build requires GitHub-hosted runner)


------
https://chatgpt.com/codex/tasks/task_b_68dc18c5523c8321bca2c5e3a1c77ca3