### PR TITLE
Fix Release Drafter workflow configuration

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update release draft
-        uses: release-drafter/release-drafter@v6.1.0
+        uses: release-drafter/release-drafter@v5.24.0
         with:
           config-name: release-drafter.yml
         env:
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update pull request metadata
-        uses: release-drafter/release-drafter@v6.1.0
+        uses: release-drafter/release-drafter@v5.24.0
         with:
           config-name: release-drafter.yml
           disable-releases: true


### PR DESCRIPTION
## Summary
- pin the Release Drafter workflow to the latest supported v5 action tag to avoid failures when the workflow runs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68dc1b7d689c8321a817e1eeb8634536