### PR TITLE
Disable time-based cleanup when forget window is zero

### DIFF
--- a/data_handler/core.py
+++ b/data_handler/core.py
@@ -134,7 +134,10 @@ class DataHandler:
     async def cleanup_old_data(self) -> None:
         while True:
             await asyncio.sleep(getattr(self.cfg, "data_cleanup_interval", 1))
-            cutoff = pd.Timestamp.now(tz="UTC") - pd.Timedelta(seconds=getattr(self.cfg, "forget_window", 0))
+            forget_window = getattr(self.cfg, "forget_window", 0)
+            if forget_window <= 0:
+                continue
+            cutoff = pd.Timestamp.now(tz="UTC") - pd.Timedelta(seconds=forget_window)
             cutoff_dt = cutoff.to_pydatetime()
             if pl is not None and isinstance(self._ohlcv, pl.DataFrame) and self._ohlcv.height > 0:
                 self._ohlcv = _normalise_polars_timestamp(self._ohlcv)


### PR DESCRIPTION
## Summary
- skip cleanup filtering when the configuration forget window is disabled
- add regression test to ensure OHLCV data is preserved when the forget window is zero

## Testing
- pytest tests/test_data_handler.py -k cleanup

------
https://chatgpt.com/codex/tasks/task_b_68dc3d1092808321be01c7d7e1148737