### PR TITLE
Fix dependency graph workflow dependencies

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -31,6 +31,10 @@ jobs:
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: '3.11'
+      - name: Install dependency snapshot dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install requests
       - name: Detect dependency manifest changes
         id: detect
         env:


### PR DESCRIPTION
## Summary
- ensure the dependency graph workflow installs pip and requests before running the submission script

## Testing
- pytest tests/test_dependency_graph_workflow.py

------
https://chatgpt.com/codex/tasks/task_b_68dc3decf96c8321828f5a329c5f8fb7