### PR TITLE
Ensure dependency graph workflow installs requests

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -161,6 +161,14 @@ jobs:
           else:
               print("No dependency manifest changes detected.", flush=True)
           PY
+      - name: Install dependency snapshot dependencies
+        if: >-
+          steps.detect.outputs.changed == 'true' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'repository_dispatch'
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install requests
       - name: Prepare requirements
         if: >-
           steps.detect.outputs.changed == 'true' ||


### PR DESCRIPTION
## Summary
- ensure the dependency graph workflow installs pip and the requests package before submitting a snapshot

## Testing
- pytest tests/test_dependency_graph_workflow.py -q

------
https://chatgpt.com/codex/tasks/task_b_68dc3e196d8c832199cb3dda5636b445