### PR TITLE
Fix dependency snapshot workflow and model builder imports

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -161,6 +161,14 @@ jobs:
           else:
               print("No dependency manifest changes detected.", flush=True)
           PY
+      - name: Install dependency snapshot dependencies
+        if: >-
+          steps.detect.outputs.changed == 'true' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'repository_dispatch'
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install requests
       - name: Prepare requirements
         if: >-
           steps.detect.outputs.changed == 'true' ||

--- a/model_builder/core.py
+++ b/model_builder/core.py
@@ -29,8 +29,10 @@ from security import (
     set_model_dir,
     verify_model_state_signature,
     write_model_state_signature,
+    _is_within_directory,
 )
 from services.logging_utils import sanitize_log_value
+from .storage import JOBLIB_AVAILABLE, joblib
 
 
 _utils = require_utils(


### PR DESCRIPTION
## Summary
- ensure the dependency-submission workflow installs requests before running the snapshot script
- make the snapshot submission script gracefully handle missing requests and use the requests client for uploads
- import the security helpers and joblib availability flags in ModelBuilder to avoid NameErrors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dc3cbf99dc832189071261d55a6b36