### PR TITLE
Fix dependency snapshot submission and strengthen model builder guards

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -213,6 +213,14 @@ jobs:
                       updated = "".join(filtered)
                       path.write_text(updated, encoding="utf-8")
           PY
+      - name: Install dependency snapshot dependencies
+        if: >-
+          steps.detect.outputs.changed == 'true' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'repository_dispatch'
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install requests --no-cache-dir
       - name: Submit dependency snapshot
         if: >-
           steps.detect.outputs.changed == 'true' ||

--- a/model_builder/core.py
+++ b/model_builder/core.py
@@ -22,6 +22,7 @@ from bot.config import BotConfig
 from bot.ray_compat import IS_RAY_STUB, ray
 from bot.utils_loader import require_utils
 from models.architectures import KERAS_FRAMEWORKS, create_model
+from .storage import JOBLIB_AVAILABLE, joblib
 from security import (
     ArtifactDeserializationError,
     harden_mlflow,
@@ -29,6 +30,7 @@ from security import (
     set_model_dir,
     verify_model_state_signature,
     write_model_state_signature,
+    _is_within_directory,
 )
 from services.logging_utils import sanitize_log_value
 


### PR DESCRIPTION
## Summary
- ensure the dependency snapshot workflow installs requests before invoking the submission script
- harden the submission script to use requests, gracefully handle missing dependencies, and keep retry logic
- import the joblib stubs and path guards inside ModelBuilder so cache operations stay secure

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dc3cac15348321b129f9429229071e