### PR TITLE
Fix dependency snapshot workflow and ModelBuilder imports

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -31,6 +31,14 @@ jobs:
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: '3.11'
+      - name: Install dependency snapshot dependencies
+        if: >-
+          steps.detect.outputs.changed == 'true' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'repository_dispatch'
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install requests
       - name: Detect dependency manifest changes
         id: detect
         env:

--- a/model_builder/core.py
+++ b/model_builder/core.py
@@ -31,6 +31,7 @@ from security import (
     write_model_state_signature,
 )
 from services.logging_utils import sanitize_log_value
+from model_builder.storage import JOBLIB_AVAILABLE, _is_within_directory, joblib
 
 
 _utils = require_utils(


### PR DESCRIPTION
## Summary
- install the dependency snapshot requirements before submitting the dependency graph workflow
- make the dependency snapshot script fall back cleanly when requests is unavailable and route HTTP calls through requests.Session
- reuse the storage helpers in ModelBuilder to keep joblib-based persistence and SHAP caching inside the cache directory

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dc3d4cf36483219b24495a96b41c5d