### PR TITLE
Fix dependency snapshot automation for Dependabot

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -213,6 +213,14 @@ jobs:
                       updated = "".join(filtered)
                       path.write_text(updated, encoding="utf-8")
           PY
+      - name: Install dependency snapshot dependencies
+        if: >-
+          steps.detect.outputs.changed == 'true' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'repository_dispatch'
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install requests
       - name: Submit dependency snapshot
         if: >-
           steps.detect.outputs.changed == 'true' ||

--- a/model_builder/core.py
+++ b/model_builder/core.py
@@ -31,6 +31,7 @@ from security import (
     write_model_state_signature,
 )
 from services.logging_utils import sanitize_log_value
+from .storage import JOBLIB_AVAILABLE, _is_within_directory, joblib
 
 
 _utils = require_utils(


### PR DESCRIPTION
## Summary
- ensure the dependency snapshot workflow installs required Python dependencies before running
- import the storage helpers needed by `ModelBuilder` during state persistence and SHAP caching
- update the dependency snapshot submission script to use `requests`, gracefully handle its absence, and retain HTTPS validation

## Testing
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_b_68dc3e0f066883218793d32a48be84ec