### PR TITLE
Fix dependency snapshot script requests handling and ModelBuilder imports

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -31,6 +31,10 @@ jobs:
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: '3.11'
+      - name: Install dependency snapshot dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install requests
       - name: Detect dependency manifest changes
         id: detect
         env:

--- a/model_builder/core.py
+++ b/model_builder/core.py
@@ -22,8 +22,10 @@ from bot.config import BotConfig
 from bot.ray_compat import IS_RAY_STUB, ray
 from bot.utils_loader import require_utils
 from models.architectures import KERAS_FRAMEWORKS, create_model
+from model_builder.storage import JOBLIB_AVAILABLE, joblib
 from security import (
     ArtifactDeserializationError,
+    _is_within_directory,
     harden_mlflow,
     safe_joblib_load,
     set_model_dir,


### PR DESCRIPTION
## Summary
- add a pip install step for dependency snapshot workflows to guarantee requests is available
- make the dependency snapshot script gracefully handle missing requests and rely on the requests library for submissions
- import the joblib availability flag in ModelBuilder so state persistence and SHAP caching work in tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dc3e43e0fc83219f5d0d4a3ae9d06b