### PR TITLE
Fix summary redirection in Trivy workflow

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -148,7 +148,8 @@ jobs:
               steps.pr_context.outputs.is_fork_pr == 'true' }}
         run: |
           echo "::warning::Пропускаем загрузку артефакта Trivy для форк-пулреквеста из-за ограниченных прав."
-          echo '* Загрузка артефакта пропущена: требуется доступ actions:write, недоступный для форк-пулреквестов.' >> "$GITHUB_STEP_SUMMARY"
+          summary_line='* Загрузка артефакта пропущена: требуется доступ actions:write, недоступный для форк-пулреквестов.'
+          printf '%s\n' "$summary_line" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Fail if Trivy scan failed unexpectedly
         if: ${{ steps.trivy.conclusion == 'failure' && steps.parse_trivy.outputs.sarif_exists != 'true' }}


### PR DESCRIPTION
## Summary
- ensure the Trivy forked PR skip step writes its summary line without splitting the `$GITHUB_STEP_SUMMARY` variable

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_b_68dc3e766eb88321a3b06b76039b67c4