### PR TITLE
Harden mktemp usage in Dockerfile.cpu

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -24,7 +24,7 @@ apt-get install -y --no-install-recommends \
 # чтобы не зависеть от системного python3 в базовом образе.
 keyring_path=/usr/share/keyrings/deadsnakes-ppa.gpg
 codename="$(. /etc/os-release && printf '%s' "$VERSION_CODENAME")"
-tmp_key="$(mktemp)"
+tmp_key="$(mktemp -p /tmp deadsnakes-keyring.XXXXXX)"
 curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xBA6932366A755776" -o "$tmp_key"
 gpg --batch --yes --dearmor -o "$keyring_path" "$tmp_key"
 rm -f "$tmp_key"
@@ -151,7 +151,7 @@ apt-get install -y --no-install-recommends \
 # чтобы не зависеть от системного python3 в базовом образе.
 keyring_path=/usr/share/keyrings/deadsnakes-ppa.gpg
 codename="$(. /etc/os-release && printf '%s' "$VERSION_CODENAME")"
-tmp_key="$(mktemp)"
+tmp_key="$(mktemp -p /tmp deadsnakes-keyring.XXXXXX)"
 curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xBA6932366A755776" -o "$tmp_key"
 gpg --batch --yes --dearmor -o "$keyring_path" "$tmp_key"
 rm -f "$tmp_key"


### PR DESCRIPTION
## Summary
- replace ad-hoc mktemp invocations in Dockerfile.cpu with template-based variants to avoid insecure temporary files

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dc3e033c588321953d8db3a7dc8d5e