### PR TITLE
Fix missing validation imports for model builder pipeline

### DIFF
--- a/model_builder/core.py
+++ b/model_builder/core.py
@@ -33,6 +33,13 @@ from security import (
 )
 from services.logging_utils import sanitize_log_value
 from .storage import JOBLIB_AVAILABLE, joblib
+from .validation import (
+    FeatureValidationError,
+    MAX_FEATURES_PER_SAMPLE,
+    MAX_SAMPLES,
+    coerce_feature_matrix,
+    coerce_label_vector,
+)
 
 
 _utils = require_utils(

--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -19,8 +19,6 @@ from typing import TYPE_CHECKING, Any, Dict
 
 import numpy as np
 from flask import Flask, jsonify, request
-from numpy.typing import NDArray
-
 from bot.dotenv_utils import load_dotenv
 from bot.utils_loader import require_utils
 from model_builder.validation import (


### PR DESCRIPTION
## Summary
- import the validation helpers used by `prepare_features` in `model_builder/core.py`
- drop the unused `NDArray` type import from the model builder service module

## Testing
- ruff check
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68de5c6de1008321825fcf3f89308593