### PR TITLE
Fix missing validation imports in model builder

### DIFF
--- a/model_builder/core.py
+++ b/model_builder/core.py
@@ -22,6 +22,13 @@ from bot.config import BotConfig
 from bot.ray_compat import IS_RAY_STUB, ray
 from bot.utils_loader import require_utils
 from models.architectures import KERAS_FRAMEWORKS, create_model
+from model_builder.validation import (
+    FeatureValidationError,
+    MAX_FEATURES_PER_SAMPLE,
+    MAX_SAMPLES,
+    coerce_feature_matrix,
+    coerce_label_vector,
+)
 from security import (
     ArtifactDeserializationError,
     harden_mlflow,


### PR DESCRIPTION
## Summary
- import the validation helpers used by `prepare_features` to satisfy lint checks

## Testing
- python -m flake8 .
- pytest tests/test_model_builder_import.py

------
https://chatgpt.com/codex/tasks/task_b_68de5c7dcfac832184be986c330cdee2