### PR TITLE
Pin Release Drafter action to secure commit

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update release draft
-        uses: release-drafter/release-drafter@v5.24.0
+        uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         with:
           config-name: release-drafter.yml
         env:
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update pull request metadata
-        uses: release-drafter/release-drafter@v5.24.0
+        uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         with:
           config-name: release-drafter.yml
           disable-releases: true


### PR DESCRIPTION
## Summary
- pin the Release Drafter GitHub Action to the commit that corresponds to v6.1.0 to avoid tag drift

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68de6c2f27e483219366c015841b15d5