### PR TITLE
Fix Release Drafter workflow concurrency evaluation

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -26,8 +26,7 @@ permissions:
 concurrency:
   group: >-
     release-drafter-${{
-      github.event_name == 'pull_request_target' &&
-      format('pr-{0}', github.event.pull_request.number) ||
+      github.event.number ||
       github.ref
     }}
   cancel-in-progress: false


### PR DESCRIPTION
## Summary
- simplify the concurrency group expression in the Release Drafter workflow
- avoid referencing pull request fields when they are unavailable for push events

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68deb7d65668832180cd8411da36716a