### PR TITLE
Expand dependency snapshot event path allowlist

### DIFF
--- a/scripts/github_paths.py
+++ b/scripts/github_paths.py
@@ -41,6 +41,13 @@ def allowed_github_directories() -> list[Path]:
             if grandparent != parent:
                 allowed.append(grandparent)
 
+    runner_temp = os.getenv("RUNNER_TEMP")
+    if runner_temp:
+        try:
+            allowed.append(Path(runner_temp).resolve(strict=True))
+        except OSError:
+            pass
+
     try:
         allowed.append(Path.cwd().resolve(strict=True))
     except OSError:

--- a/tests/test_github_paths.py
+++ b/tests/test_github_paths.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+
+from scripts.github_paths import allowed_github_directories, resolve_github_path
+
+
+def test_resolve_github_path_accepts_runner_temp(tmp_path: Path, monkeypatch) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("GITHUB_WORKSPACE", str(workspace))
+
+    runner_temp = tmp_path / "runner_temp"
+    runner_temp.mkdir()
+    monkeypatch.setenv("RUNNER_TEMP", str(runner_temp))
+
+    event_path = runner_temp / "_github_workflow" / "event.json"
+    event_path.parent.mkdir(parents=True)
+    event_path.write_text("{}", encoding="utf-8")
+
+    resolved = resolve_github_path(str(event_path))
+    assert resolved == event_path.resolve()
+
+    directories = allowed_github_directories()
+    assert runner_temp.resolve() in directories
+
+
+def test_resolve_github_path_rejects_untrusted_locations(tmp_path: Path, monkeypatch) -> None:
+    workspace = tmp_path / "nested" / "workspace"
+    workspace.mkdir(parents=True)
+    monkeypatch.setenv("GITHUB_WORKSPACE", str(workspace))
+
+    monkeypatch.delenv("RUNNER_TEMP", raising=False)
+    tempfile.tempdir = str((tmp_path / "runner_temp").resolve())
+
+    outside_root = tmp_path.parent / "outside"
+    outside_root.mkdir(exist_ok=True)
+    malicious = outside_root / "event.json"
+    malicious.write_text("{}", encoding="utf-8")
+
+    assert resolve_github_path(str(malicious)) is None


### PR DESCRIPTION
## Summary
- include the `RUNNER_TEMP` directory in the dependency snapshot path allowlist so repository_dispatch payloads stored under the runner temp directory are trusted
- add regression tests covering trusted runner temp paths and rejecting files outside the configured workspace roots

## Testing
- pytest tests/test_github_paths.py

------
https://chatgpt.com/codex/tasks/task_b_68deb5e860508321b483242c295808e1