### PR TITLE
Stabilize timing-sensitive Dependabot tests

### DIFF
--- a/tests/test_trade_manager_loops.py
+++ b/tests/test_trade_manager_loops.py
@@ -217,13 +217,13 @@ async def test_run_cancels_pending_tasks_on_failure(monkeypatch):
 
     run_task = asyncio.create_task(tm.run())
 
-    await asyncio.wait_for(failure_started.wait(), timeout=1)
+    await asyncio.wait_for(failure_started.wait(), timeout=5)
 
     with pytest.raises(trade_manager.TradeManagerTaskError):
         await run_task
 
     for event in cancel_events:
-        await asyncio.wait_for(event.wait(), timeout=1)
+        await asyncio.wait_for(event.wait(), timeout=5)
 
 
 @pytest.mark.asyncio
@@ -274,7 +274,7 @@ async def test_run_restarts_non_critical_task(monkeypatch, caplog):
 
     stop_event.set()
     await tm.stop()
-    await asyncio.wait_for(run_task, timeout=1)
+    await asyncio.wait_for(run_task, timeout=5)
 
 
 @pytest.mark.asyncio

--- a/tests/test_trade_manager_service_api.py
+++ b/tests/test_trade_manager_service_api.py
@@ -266,13 +266,15 @@ def test_exchange_calls_are_serialized(monkeypatch):
     first_entered = threading.Event()
     release_first = threading.Event()
 
+    event_timeout = 5.0
+
     def create_order(*_args, **_kwargs):
         assert not in_call.is_set(), 'create_order re-entered concurrently'
         in_call.set()
         try:
             if not first_entered.is_set():
                 first_entered.set()
-                assert release_first.wait(timeout=1), 'release not signalled'
+                assert release_first.wait(timeout=event_timeout), 'release not signalled'
             time.sleep(0.01)
             call_sequence.append(len(call_sequence) + 1)
             return {'id': call_sequence[-1]}
@@ -297,7 +299,7 @@ def test_exchange_calls_are_serialized(monkeypatch):
     second = threading.Thread(target=worker)
 
     first.start()
-    assert first_entered.wait(timeout=1)
+    assert first_entered.wait(timeout=event_timeout)
     second.start()
     time.sleep(0.05)
     release_first.set()


### PR DESCRIPTION
## Summary
- raise event waits in the server and trade manager tests to avoid race conditions on slower runners

## Testing
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_b_68deb732f03c83218f676fa709dc067b