### PR TITLE
Prevent credentials in GPT OSS API URLs

### DIFF
--- a/gpt_client.py
+++ b/gpt_client.py
@@ -327,6 +327,10 @@ def _validate_api_url(api_url: str, allowed_hosts: set[str]) -> tuple[str, set[s
         )
     if not parsed.hostname:
         raise GPTClientError("GPT_OSS_API URL must include a hostname")
+    if parsed.username or parsed.password:
+        raise GPTClientError(
+            "GPT_OSS_API URL must not contain embedded credentials"
+        )
 
     scheme = parsed.scheme.lower()
     if scheme not in {"http", "https"}:

--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -497,6 +497,14 @@ def test_validate_api_url_multiple_dns_results_public_blocked(monkeypatch):
         _validate_api_url("http://foo.local", _load_allowed_hosts())
 
 
+def test_validate_api_url_rejects_userinfo():
+    with pytest.raises(GPTClientError) as excinfo:
+        _validate_api_url(
+            "https://user:pass@example.com", _load_allowed_hosts()
+        )
+    assert "must not contain embedded credentials" in str(excinfo.value)
+
+
 def test_validate_api_url_insecure_allowed_with_env(monkeypatch, caplog):
     def fake_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
         assert host == "foo.local"


### PR DESCRIPTION
## Summary
- reject GPT_OSS_API URLs that embed userinfo credentials before contacting the service
- add a regression test covering the new validation rule for credentialed URLs

## Testing
- pytest tests/test_gpt_client.py
- semgrep --config p/ci --error --sarif --output semgrep.sarif

------
https://chatgpt.com/codex/tasks/task_b_68deb7ea86508321a4c5b68f39d918a5