### PR TITLE
Sanitize null strings in dependency graph workflow

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -69,13 +69,23 @@ jobs:
           from pathlib import Path
           from typing import Sequence
 
+          _NULL_STRINGS = {"null", "none", "undefined"}
+
+          def _normalise_value(raw: str | None) -> str:
+              if not raw:
+                  return ""
+              candidate = raw.strip()
+              if candidate.lower() in _NULL_STRINGS:
+                  return ""
+              return candidate
+
           patterns: Sequence[str] = (
               "requirements*.txt",
               "requirements*.in",
               "requirements*.out",
           )
-          before = os.environ.get("BEFORE") or ""
-          after = os.environ.get("AFTER") or ""
+          before = _normalise_value(os.environ.get("BEFORE"))
+          after = _normalise_value(os.environ.get("AFTER"))
 
           diff_failed = False
           changed: list[str]

--- a/tests/test_dependency_graph_workflow.py
+++ b/tests/test_dependency_graph_workflow.py
@@ -57,6 +57,14 @@ def test_dependency_graph_detect_step_handles_nested_manifests() -> None:
     assert "fnmatch(filename, pattern)" in workflow
 
 
+def test_dependency_graph_detect_step_normalises_null_strings() -> None:
+    workflow = Path(".github/workflows/dependency-graph.yml").read_text(encoding="utf-8")
+
+    assert '_NULL_STRINGS = {"null", "none", "undefined"}' in workflow
+    assert "def _normalise_value" in workflow
+    assert "candidate.lower() in _NULL_STRINGS" in workflow
+
+
 def test_dependency_graph_detect_step_uses_dispatch_commit_fallbacks() -> None:
     workflow = Path(".github/workflows/dependency-graph.yml").read_text(encoding="utf-8")
 

--- a/tests/test_dependency_snapshot.py
+++ b/tests/test_dependency_snapshot.py
@@ -413,6 +413,21 @@ def test_submit_dependency_snapshot_prefers_payload_token(
     assert payload["ref"] == "refs/heads/auto"
 
 
+def test_extract_payload_value_skips_null_like_strings() -> None:
+    payload: dict[str, object] = {"sha": "null", "after": " cafebabe ", "ref": "None"}
+
+    result = snapshot._extract_payload_value(payload, "sha", "after", "ref")
+
+    assert result == "cafebabe"
+
+
+def test_env_treats_null_strings_as_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITHUB_TOKEN", " null ")
+
+    with pytest.raises(snapshot.MissingEnvironmentVariableError):
+        snapshot._env("GITHUB_TOKEN")
+
+
 def test_submit_dependency_snapshot_uses_root_payload_values(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- normalize null-like strings in the dependency graph workflow before diffing manifests
- sanitize environment and payload values in the dependency snapshot script to skip placeholder strings
- extend the regression test suite to cover null-string handling in both the workflow and submission script

## Testing
- pytest tests/test_dependency_graph_workflow.py tests/test_dependency_snapshot.py -q

------
https://chatgpt.com/codex/tasks/task_b_68deb73fda048321adc1cef960cd4ff3