### PR TITLE
Fix Dockerfile script copies for Trivy workflow stability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ COPY docker/patches/linux-pam-CVE-2024-10041.patch /tmp/security/linux-pam-CVE-2
 COPY docker/scripts/update_pam_changelog.py /tmp/security/update_pam_changelog.py
 COPY docker/scripts/setup_zlib_and_pam.sh /tmp/security/setup_zlib_and_pam.sh
 COPY docker/scripts/update_commons_lang3.py /tmp/security/update_commons_lang3.py
+COPY docker/scripts/build_patched_pam.sh /tmp/security/build_patched_pam.sh
+COPY docker/scripts/harden_gnutar.sh /tmp/security/harden_gnutar.sh
 
 WORKDIR /tmp/build
 


### PR DESCRIPTION
## Summary
- copy the build_patched_pam.sh helper into the CUDA builder stage
- copy the harden_gnutar.sh wrapper into the CUDA builder stage so tar hardening runs during builds

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_b_68deb82e89b483219ab0c9beed351c6b