### PR TITLE
Handle PR status checker failures gracefully

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -186,6 +186,13 @@ jobs:
             --pr-number "${PR_NUMBER:-}" \
             --token "${GITHUB_TOKEN}"; then
             echo "::warning::Проверка статуса PR завершилась с ошибкой – пропускаю обзор"
+            if [ -n "${GITHUB_OUTPUT:-}" ]; then
+              {
+                echo "skip=true"
+                echo "head_sha="
+              } >>"$GITHUB_OUTPUT"
+            fi
+            exit 0
           fi
 
       - name: Checkout PR head


### PR DESCRIPTION
## Summary
- ensure the GPT-OSS review workflow writes skip outputs and exits cleanly when the PR status helper fails
- add regression tests to lock in the workflow guards around the PR status checker

## Testing
- pytest tests/test_gptoss_workflow_python3.py tests/test_check_pr_status.py -q

------
https://chatgpt.com/codex/tasks/task_b_68deb74eeda08321acc4951665404837