### PR TITLE
Fix offline mode stubs configuration handling

### DIFF
--- a/config.py
+++ b/config.py
@@ -361,7 +361,7 @@ class BotConfig:
         return isinstance(value, origin)
 
     def _validate_types(self) -> None:
-        type_hints = get_type_hints(BotConfig)
+        type_hints = get_type_hints(BotConfig, globalns=globals(), localns=locals())
         for fdef in fields(self):
             val = getattr(self, fdef.name)
             expected = type_hints.get(fdef.name, fdef.type)

--- a/services/offline.py
+++ b/services/offline.py
@@ -16,6 +16,9 @@ logger = logging.getLogger("TradingBot")
 
 _PlaceholderValue = str | Callable[[], str]
 
+# Mirror the configuration flag so tests can override it via monkeypatch.
+OFFLINE_MODE: bool = bool(bot_config.OFFLINE_MODE)
+
 
 def generate_placeholder_credential(name: str, *, entropy_bytes: int = 32) -> str:
     """Return a high-entropy placeholder credential for offline usage.
@@ -68,7 +71,7 @@ def ensure_offline_env(
         when nothing was changed or :data:`OFFLINE_MODE` is disabled.
     """
 
-    if not bot_config.OFFLINE_MODE:
+    if not OFFLINE_MODE:
         return []
 
     applied: list[str] = []
@@ -94,7 +97,7 @@ def ensure_offline_env(
     return applied
 
 
-if bot_config.OFFLINE_MODE:
+if OFFLINE_MODE:
     ensure_offline_env()
 
 


### PR DESCRIPTION
## Summary
- expose the OFFLINE_MODE flag from the offline services module so tests can monkeypatch it
- ensure type validation resolves annotations with the module globals to avoid forward reference errors during offline imports

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68debffc5adc83219e867e52805522f2