### PR TITLE
Fix offline environment checks for Dependabot workflow

### DIFF
--- a/services/offline.py
+++ b/services/offline.py
@@ -16,6 +16,11 @@ logger = logging.getLogger("TradingBot")
 
 _PlaceholderValue = str | Callable[[], str]
 
+# Export a module-level OFFLINE_MODE flag so tests can monkeypatch the value
+# without having to reload configuration modules.  The default mirrors the
+# runtime configuration but callers are free to toggle it temporarily.
+OFFLINE_MODE: bool = bool(bot_config.OFFLINE_MODE)
+
 
 def generate_placeholder_credential(name: str, *, entropy_bytes: int = 32) -> str:
     """Return a high-entropy placeholder credential for offline usage.
@@ -68,7 +73,7 @@ def ensure_offline_env(
         when nothing was changed or :data:`OFFLINE_MODE` is disabled.
     """
 
-    if not bot_config.OFFLINE_MODE:
+    if not OFFLINE_MODE:
         return []
 
     applied: list[str] = []
@@ -94,7 +99,7 @@ def ensure_offline_env(
     return applied
 
 
-if bot_config.OFFLINE_MODE:
+if OFFLINE_MODE:
     ensure_offline_env()
 
 


### PR DESCRIPTION
## Summary
- export a patchable OFFLINE_MODE flag in the offline service helpers so Dependabot PRs respect the test stubs
- modernize configuration type hints to use builtin generics and support PEP 604 unions during validation

## Testing
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_b_68dec02081e88321b036fd4ebca54e43