### PR TITLE
Fix release drafter workflow conditions

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -24,11 +24,7 @@ permissions:
   issues: write
 
 concurrency:
-  group: >-
-    release-drafter-${{
-      github.event.number ||
-      github.ref
-    }}
+  group: release-drafter-${{ github.head_ref || github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -44,14 +40,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   autolabel_pull_request:
-    if: >-
-      github.event_name == 'pull_request_target' &&
-      github.event.pull_request != null &&
-      github.event.pull_request.head.repo != null &&
-      github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - name: Update pull request metadata
+        if: >-
+          github.event.pull_request != null &&
+          github.event.pull_request.head.repo != null &&
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         with:
           config-name: release-drafter.yml


### PR DESCRIPTION
## Summary
- simplify the concurrency group so it always resolves for pushes and pull requests
- gate the pull request metadata job by event type and keep repo ownership checks at the step level

## Testing
- not run (workflow configuration change)


------
https://chatgpt.com/codex/tasks/task_b_68dec03758b8832196d8f9592138186b