### PR TITLE
Remove runtime assert from trading loop error handling

### DIFF
--- a/run_bot.py
+++ b/run_bot.py
@@ -392,7 +392,9 @@ async def run_trading_cycle(trade_manager, runtime: float | None) -> None:
 
             if new_exc is None:
                 new_exc = matched_cls(enriched_args[0]) if matched_cls else RuntimeError(enriched_args[0])
-            assert new_exc is not None
+
+            if new_exc is None:  # pragma: no cover - defensive fallback
+                raise RuntimeError(enriched_args[0])
             try:
                 new_exc.args = enriched_args
             except Exception as assignment_error:  # pragma: no cover - defensive


### PR DESCRIPTION
## Summary
- replace the runtime assert in `run_bot.py` with an explicit fallback to satisfy Semgrep's `python.lang.best-practice.no-assert` rule

## Testing
- /root/.pyenv/versions/3.11.12/bin/semgrep --config p/ci --error --sarif --output semgrep.sarif

------
https://chatgpt.com/codex/tasks/task_b_68dec044a964832194ee468c34f791bb