### PR TITLE
Fix offline mode stubs and type validation

### DIFF
--- a/config.py
+++ b/config.py
@@ -361,7 +361,15 @@ class BotConfig:
         return isinstance(value, origin)
 
     def _validate_types(self) -> None:
-        type_hints = get_type_hints(BotConfig)
+        try:
+            type_hints = get_type_hints(BotConfig)
+        except NameError:
+            fallback_globals = dict(globals())
+            fallback_globals.setdefault("List", list)
+            fallback_globals.setdefault("Dict", dict)
+            fallback_globals.setdefault("Optional", Optional)
+            fallback_globals.setdefault("Union", Union)
+            type_hints = get_type_hints(BotConfig, globalns=fallback_globals)
         for fdef in fields(self):
             val = getattr(self, fdef.name)
             expected = type_hints.get(fdef.name, fdef.type)

--- a/services/offline.py
+++ b/services/offline.py
@@ -16,6 +16,11 @@ logger = logging.getLogger("TradingBot")
 
 _PlaceholderValue = str | Callable[[], str]
 
+# Mirror the configuration flag so tests can monkeypatch the offline mode state
+# without having to reload the ``config`` module. The value is intentionally
+# coerced to ``bool`` to avoid surprising truthiness of custom objects.
+OFFLINE_MODE: bool = bool(bot_config.OFFLINE_MODE)
+
 
 def generate_placeholder_credential(name: str, *, entropy_bytes: int = 32) -> str:
     """Return a high-entropy placeholder credential for offline usage.
@@ -68,7 +73,7 @@ def ensure_offline_env(
         when nothing was changed or :data:`OFFLINE_MODE` is disabled.
     """
 
-    if not bot_config.OFFLINE_MODE:
+    if not OFFLINE_MODE:
         return []
 
     applied: list[str] = []
@@ -94,7 +99,7 @@ def ensure_offline_env(
     return applied
 
 
-if bot_config.OFFLINE_MODE:
+if OFFLINE_MODE:
     ensure_offline_env()
 
 


### PR DESCRIPTION
## Summary
- expose the offline flag in `services.offline` so placeholder credentials can be injected when tests toggle the module state
- harden `BotConfig._validate_types` against `NameError` when evaluating postponed annotations during offline imports

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dec05080008321baa3221aab9abe24