### PR TITLE
Fix Trivy misconfiguration warnings in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /tmp/build
 
 RUN set -eux; \
     apt-get update; \
-    apt-get dist-upgrade -y; \
+    apt-get upgrade -y; \
     apt-get install -y --no-install-recommends \
         tzdata \
         linux-libc-dev \
@@ -117,7 +117,7 @@ COPY --from=builder /tmp/pam-fixed /tmp/pam-fixed
 COPY docker/scripts/harden_gnutar.sh /tmp/security/harden_gnutar.sh
 
 # Установка минимальных пакетов выполнения
-RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     python3 \
     libpython3.12-stdlib \
     coreutils \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -7,11 +7,11 @@ FROM ubuntu:24.04@sha256:985be7c735afdf6f18aaa122c23f87d989c30bba4e9aa24c8278912
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Обновление linux-libc-dev устраняет CVE-2025-21976, а libgcrypt20 — CVE-2024-2236.
-# Дополнительно выполняем dist-upgrade, чтобы подтянуть свежие патчи безопасности из Ubuntu.
+# Дополнительно выполняем upgrade, чтобы подтянуть свежие патчи безопасности из Ubuntu.
 # После создания виртуального окружения обновляем pip и setuptools до версий,
 # закрывающих CVE-2024-6345 и CVE-2025-47273, иначе Trivy обнаруживает
 # уязвимые копии setuptools внутри образа.
-RUN apt-get update && apt-get dist-upgrade -y && apt-get install --no-install-recommends -y \
+RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y \
     python3 python3-venv build-essential linux-libc-dev libgcrypt20 git patch \
     ca-certificates \
     && apt-get install -y --no-install-recommends gnupg dirmngr \
@@ -45,7 +45,7 @@ FROM ubuntu:24.04@sha256:985be7c735afdf6f18aaa122c23f87d989c30bba4e9aa24c8278912
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Устанавливаем только необходимые пакеты выполнения и сразу обновляем базовую систему
-RUN apt-get update && apt-get dist-upgrade -y && apt-get install --no-install-recommends -y \
+RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y \
     libssl3t64 \
     python3.12-minimal \
     openssl \

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -11,7 +11,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN <<'EOSHELL'
 set -eux
 apt-get update
-apt-get dist-upgrade -y
+apt-get upgrade -y
 apt-get install -y --no-install-recommends \
     build-essential \
     ca-certificates \
@@ -111,7 +111,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN <<'EOSHELL'
 set -eux
 apt-get update
-apt-get dist-upgrade -y
+apt-get upgrade -y
 apt-get install -y --no-install-recommends \
     libgomp1 \
     libssl3


### PR DESCRIPTION
## Summary
- replace the use of `apt-get dist-upgrade` with `apt-get upgrade` in all Dockerfiles to satisfy Trivy's misconfiguration checks
- update the CI Dockerfile documentation to reflect the new upgrade approach

## Testing
- /tmp/trivy-bin/trivy config --severity HIGH,CRITICAL --exit-code 1 .


------
https://chatgpt.com/codex/tasks/task_b_68dec05bd42083218db715aedbe2658f