### PR TITLE
Harden commons-lang3 download in Dockerfile.cpu

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -46,7 +46,19 @@ import textwrap
 exec(textwrap.dedent("""
     import hashlib
     import pathlib
-    import urllib.request
+    from tempfile import NamedTemporaryFile
+    from urllib.parse import urlsplit
+
+    import requests
+
+    COMMONS_LANG3_URL = (
+        "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.18.0/"
+        "commons-lang3-3.18.0.jar"
+    )
+    COMMONS_LANG3_SHA256 = (
+        "4eeeae8d20c078abb64b015ec158add383ac581571cddc45c68f0c9ae0230720"
+    )
+    COMMONS_LANG3_ALLOWED_HOST = "repo1.maven.org"
 
     try:
         import ray  # type: ignore
@@ -57,30 +69,71 @@ exec(textwrap.dedent("""
         jars_dir.mkdir(parents=True, exist_ok=True)
         for jar in jars_dir.glob("commons-lang3-*.jar"):
             jar.unlink()
-        commons_lang3_url = (
-            "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.18.0/"
-            "commons-lang3-3.18.0.jar"
-        )
-        commons_lang3_sha256 = (
-            "4eeeae8d20c078abb64b015ec158add383ac581571cddc45c68f0c9ae0230720"
-        )
         destination = jars_dir / "commons-lang3-3.18.0.jar"
         hasher = hashlib.sha256()
-        with urllib.request.urlopen(commons_lang3_url) as response, destination.open("wb") as fh:
-            while True:
-                chunk = response.read(8192)
-                if not chunk:
-                    break
-                fh.write(chunk)
-                hasher.update(chunk)
+
+        parsed_url = urlsplit(COMMONS_LANG3_URL)
+        if parsed_url.scheme != "https":
+            raise RuntimeError(
+                "Ожидалась схема https при скачивании commons-lang3, "
+                f"получено: {parsed_url.scheme}"
+            )
+        if parsed_url.netloc != COMMONS_LANG3_ALLOWED_HOST:
+            raise RuntimeError(
+                "Получен неожиданный хост при скачивании commons-lang3: "
+                f"{parsed_url.netloc}"
+            )
+
+        temp_path = None
+        try:
+            with requests.Session() as session:
+                adapter = requests.adapters.HTTPAdapter()
+                session.mount("https://", adapter)
+                session.trust_env = False
+                with session.get(
+                    COMMONS_LANG3_URL,
+                    stream=True,
+                    timeout=30,
+                    allow_redirects=False,
+                ) as response:
+                    if 300 <= response.status_code < 400:
+                        location = response.headers.get("Location", "")
+                        raise RuntimeError(
+                            "commons-lang3 download unexpectedly redirected"
+                            + (f" to {location}" if location else "")
+                        )
+                    response.raise_for_status()
+                    with NamedTemporaryFile(
+                        "wb", delete=False, dir=jars_dir
+                    ) as temp_file:
+                        temp_path = pathlib.Path(temp_file.name)
+                        for chunk in response.iter_content(chunk_size=8192):
+                            if not chunk:
+                                continue
+                            temp_file.write(chunk)
+                            hasher.update(chunk)
+        except Exception:
+            if temp_path is not None:
+                temp_path.unlink(missing_ok=True)
+            raise
+
+        if temp_path is None:
+            raise RuntimeError("Failed to create temporary commons-lang3 download")
 
         digest = hasher.hexdigest()
-        if digest != commons_lang3_sha256:
+        if digest != COMMONS_LANG3_SHA256:
             destination.unlink(missing_ok=True)
+            temp_path.unlink(missing_ok=True)
             raise RuntimeError(
                 "SHA256 mismatch while downloading commons-lang3: expected "
-                f"{commons_lang3_sha256}, got {digest}"
+                f"{COMMONS_LANG3_SHA256}, got {digest}"
             )
+
+        try:
+            temp_path.replace(destination)
+        except Exception:
+            temp_path.unlink(missing_ok=True)
+            raise
 """))
 PY
 


### PR DESCRIPTION
## Summary
- harden the inline commons-lang3 downloader in the CPU Dockerfile by validating the target host and scheme
- replace urllib.urlopen usage with a requests session that disables redirects, enforces HTTPS, and writes through a temporary file before moving into place
- ensure temporary artifacts are cleaned up on errors to avoid leaving partially downloaded jars

## Testing
- bandit -r . -ll -ii -x ./tests,./scripts,./gptoss_check -f sarif -o bandit.sarif

------
https://chatgpt.com/codex/tasks/task_b_68dedca3a95c83219860b621b94530d7