### PR TITLE
Fix release drafter metadata job for forked PRs

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -46,8 +46,7 @@ jobs:
       - name: Update pull request metadata
         if: >-
           github.event.pull_request != null &&
-          github.event.pull_request.head.repo != null &&
-          github.event.pull_request.head.repo.full_name == github.repository
+          github.event.pull_request.head.repo != null
         uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         with:
           config-name: release-drafter.yml


### PR DESCRIPTION
## Summary
- remove the repository equality guard so Release Drafter updates metadata for pull requests coming from forks
- keep a null-check on the head repository reference to avoid running when GitHub omits that data

## Testing
- python - <<'PY'
import yaml
from pathlib import Path
for path in (Path('.github/workflows/release-drafter.yml'), Path('.github/release-drafter.yml')):
    with path.open() as f:
        yaml.safe_load(f)
PY

------
https://chatgpt.com/codex/tasks/task_b_68dedcfe69808321b6ecadf58b70186f