### PR TITLE
Improve Semgrep workflow resilience

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -43,15 +43,52 @@ jobs:
         env:
           PIP_DISABLE_PIP_VERSION_CHECK: "1"
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install "semgrep>=1.52.0"
+          set -euo pipefail
+
+          retry() {
+            local attempts=$1
+            shift
+            for attempt in $(seq 1 "${attempts}"); do
+              if "$@"; then
+                return 0
+              fi
+              if [ "${attempt}" -eq "${attempts}" ]; then
+                echo "Command failed after ${attempts} attempts: $*" >&2
+                return 1
+              fi
+              sleep $((attempt * 5))
+            done
+          }
+
+          retry 3 python -m pip install --upgrade pip
+          retry 3 python -m pip install "semgrep>=1.52.0"
+
+          user_bin="$(python -m site --user-base)/bin"
+          if [ -d "${user_bin}" ]; then
+            echo "${user_bin}" >> "${GITHUB_PATH}"
+          fi
       - name: Run Semgrep
         id: run_semgrep
         env:
           SEMGREP_SEND_METRICS: "off"
         continue-on-error: true
         run: |
-          semgrep --config p/ci --error --sarif --output semgrep.sarif
+          set -euo pipefail
+          rm -f semgrep.sarif
+
+          for attempt in 1 2 3; do
+            if semgrep --config p/ci --error --sarif --output semgrep.sarif; then
+              break
+            fi
+
+            if [ "${attempt}" -eq 3 ]; then
+              echo "Semgrep scan failed after ${attempt} attempts" >&2
+              exit 1
+            fi
+
+            echo "Semgrep scan failed (attempt ${attempt}); retrying after backoff" >&2
+            sleep $((attempt * 10))
+          done
       - name: Ensure SARIF report exists
         run: python scripts/ensure_semgrep_sarif.py
       - name: Install jq


### PR DESCRIPTION
## Summary
- add retry logic around Semgrep CLI installation to mitigate transient network issues
- ensure the user base binary directory is added to `PATH` so the Semgrep executable is discoverable
- rerun the Semgrep scan up to three times before giving up to handle flakey runs

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_b_68dedd0b66948321a9d977d1d19b9a2d