### PR TITLE
Refresh CUDA and Ubuntu bases for Trivy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Этап сборки
-FROM nvidia/cuda:13.0.0-cudnn-devel-ubuntu24.04 AS builder
+FROM nvidia/cuda:13.0.1-cudnn-devel-ubuntu24.04 AS builder
 ARG ZLIB_VERSION=1.3.1
 ARG ZLIB_SHA256=9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23
 ENV OMP_NUM_THREADS=1
@@ -100,7 +100,7 @@ RUN find /app/venv -type d -name '__pycache__' -exec rm -rf {} + && \
     find /app/venv -name "*.so" -exec strip --strip-unneeded {} +
 
 # Этап выполнения (минимальный образ)
-FROM nvidia/cuda:13.0.0-cudnn-runtime-ubuntu24.04
+FROM nvidia/cuda:13.0.1-cudnn-runtime-ubuntu24.04
 ARG PYTHON_VERSION=3.12.3-1ubuntu0.7
 ARG PYTHON_META=3.12.3-0ubuntu2
 ENV OMP_NUM_THREADS=1

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -2,7 +2,7 @@
 
 # -------- Builder stage --------
 # Используем публичный LTS-образ Ubuntu для сборки зависимостей
-FROM ubuntu:24.04@sha256:985be7c735afdf6f18aaa122c23f87d989c30bba4e9aa24c8278912aac339a8d AS builder
+FROM ubuntu:24.04@sha256:ce8f79aecc435fc0b22d4dd58c72836e330beddf204491eef3f91af51bc48ed7 AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -40,7 +40,7 @@ COPY services services
 COPY tests tests
 
 # -------- Runtime stage --------
-FROM ubuntu:24.04@sha256:985be7c735afdf6f18aaa122c23f87d989c30bba4e9aa24c8278912aac339a8d AS runtime
+FROM ubuntu:24.04@sha256:ce8f79aecc435fc0b22d4dd58c72836e330beddf204491eef3f91af51bc48ed7 AS runtime
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
## Summary
- bump the CUDA devel/runtime stages to the 13.0.1 images so Trivy no longer reports the patched CVEs in the 13.0.0 series
- update the Ubuntu 24.04 pinned digest in the CI image to the latest published build with current security fixes

## Testing
- trivy fs --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed --format table .

------
https://chatgpt.com/codex/tasks/task_b_68dedd21b0308321907fd4b68bd4c785