### PR TITLE
Harden docker publish workflow secret gating

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,11 +22,18 @@ jobs:
     env:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-      PUBLISH_IMAGES: ${{ github.repository == 'averinaleks/bot' }}
+      PUBLISH_IMAGES: >-
+        ${{ github.repository == 'averinaleks/bot'
+           && github.event_name != 'pull_request'
+           && github.event_name != 'pull_request_target' }}
       PUBLISH_DOCKERHUB: >-
         ${{ github.repository == 'averinaleks/bot'
+           && github.event_name != 'pull_request'
+           && github.event_name != 'pull_request_target'
            && secrets.DOCKERHUB_USERNAME != ''
-           && secrets.DOCKERHUB_TOKEN != '' }}
+           && secrets.DOCKERHUB_USERNAME != null
+           && secrets.DOCKERHUB_TOKEN != ''
+           && secrets.DOCKERHUB_TOKEN != null }}
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- avoid pushing Docker images for pull request events
- guard the Docker Hub login behind explicit null/empty checks for secrets

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_b_68dee6c676b08321baae24d3d7a64f65