### PR TITLE
Fix configuration defaults loader file handling

### DIFF
--- a/config.py
+++ b/config.py
@@ -18,6 +18,7 @@ import threading
 from dataclasses import MISSING, asdict, dataclass, field, fields
 from pathlib import Path
 from types import UnionType
+from typing import Any, Callable, TextIO, Union, cast, get_args, get_origin, get_type_hints
 
 logger = logging.getLogger(__name__)
 
@@ -223,11 +224,9 @@ def open_config_file(path: Path) -> TextIO:
         handle.close()
         raise
     else:
-        os.close(fd)
+        handle.close()
 
     return builtins.open(path, "r", encoding="utf-8")
-
-    return handle
 
 
 class ConfigLoadError(Exception):


### PR DESCRIPTION
## Summary
- prevent the config defaults loader from returning a file handle with a closed descriptor
- add the missing typing imports needed for runtime type validation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dee6dba8f48321b1caf1f18c71566a