### PR TITLE
Align dependency snapshot workflow with dispatch payload

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -28,6 +28,18 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           fetch-depth: 0
+          ref: >-
+            ${{
+              github.event.client_payload.sha ||
+              github.event.client_payload.commit_sha ||
+              github.event.client_payload.commit_oid ||
+              github.event.client_payload.head_sha ||
+              github.event.client_payload.after ||
+              github.event.client_payload.ref ||
+              github.event.client_payload.ref_name ||
+              github.event.client_payload.branch ||
+              github.ref
+            }}
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: '3.11'

--- a/tests/test_dependency_graph_workflow.py
+++ b/tests/test_dependency_graph_workflow.py
@@ -107,3 +107,12 @@ def test_dependency_graph_supports_repository_dispatch_auto_submission() -> None
     assert "repository_dispatch" in workflow
     assert "dependency-graph-auto-submission" in workflow
     assert "github.event_name == 'repository_dispatch'" in workflow
+
+
+def test_dependency_graph_checkout_resolves_dispatch_ref() -> None:
+    workflow = Path(".github/workflows/dependency-graph.yml").read_text(encoding="utf-8")
+
+    assert "github.event.client_payload.head_sha" in workflow
+    assert "github.event.client_payload.commit_sha" in workflow
+    assert "github.event.client_payload.ref_name" in workflow
+    assert "github.event.client_payload.branch" in workflow


### PR DESCRIPTION
## Summary
- update the dependency snapshot workflow to check out the commit or ref provided by repository_dispatch payloads
- extend the dependency graph workflow test suite to cover the new checkout expression

## Testing
- pytest tests/test_dependency_graph_workflow.py

------
https://chatgpt.com/codex/tasks/task_b_68dfc1b2af9883219ba2129f9cee1040