### PR TITLE
Fix docker publish failure by refreshing CI Ubuntu digest

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -2,7 +2,7 @@
 
 # -------- Builder stage --------
 # Используем публичный LTS-образ Ubuntu для сборки зависимостей
-FROM ubuntu:24.04@sha256:ce8f79aecc435fc0b22d4dd58c72836e330beddf204491eef3f91af51bc48ed7 AS builder
+FROM --platform=linux/amd64 ubuntu:24.04@sha256:78281ac7684a7caf02348780a1b5de85844548a3cc0505df924de98380a0eeea AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -40,7 +40,7 @@ COPY services services
 COPY tests tests
 
 # -------- Runtime stage --------
-FROM ubuntu:24.04@sha256:ce8f79aecc435fc0b22d4dd58c72836e330beddf204491eef3f91af51bc48ed7 AS runtime
+FROM --platform=linux/amd64 ubuntu:24.04@sha256:78281ac7684a7caf02348780a1b5de85844548a3cc0505df924de98380a0eeea AS runtime
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
## Summary
- refresh the pinned Ubuntu 24.04 digest used in Dockerfile.ci so buildx can pull the base image again
- restrict both stages to linux/amd64 to ensure the digest matches the expected platform

## Testing
- not run (Dockerfile-only update)


------
https://chatgpt.com/codex/tasks/task_b_68dfd5f21c6c8321b6925cd60411936b