### PR TITLE
Fix CI linting and typing issues

### DIFF
--- a/bot/trade_manager/core.py
+++ b/bot/trade_manager/core.py
@@ -15,7 +15,17 @@ import logging
 import re
 import time
 from dataclasses import dataclass
-from typing import Any, Awaitable, Callable, Dict, Optional, Tuple, TYPE_CHECKING, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    Optional,
+    Tuple,
+    TypeAlias,
+    cast,
+)
 import shutil
 try:  # pragma: no cover - optional dependency
     import aiohttp  # type: ignore
@@ -71,7 +81,7 @@ except ImportError:  # pragma: no cover - заглушка
         pass
 from bot import config as bot_config  # noqa: E402
 
-BotConfig = bot_config.BotConfig
+BotConfig: TypeAlias = bot_config.BotConfig
 from services.logging_utils import sanitize_log_value  # noqa: E402
 from telegram_logger import resolve_unsent_path  # noqa: E402
 import contextlib  # noqa: E402

--- a/services/offline.py
+++ b/services/offline.py
@@ -22,9 +22,6 @@ OFFLINE_MODE: bool = bool(bot_config.OFFLINE_MODE)
 _PlaceholderValue = str | Callable[[], str]
 
 # Mirror the configuration flag so tests can override it via monkeypatch.
-OFFLINE_MODE: bool = bool(bot_config.OFFLINE_MODE)
-
-
 def generate_placeholder_credential(name: str, *, entropy_bytes: int = 32) -> str:
     """Return a high-entropy placeholder credential for offline usage.
 

--- a/tests/test_model_builder_client_security.py
+++ b/tests/test_model_builder_client_security.py
@@ -1,7 +1,5 @@
 import socket
 
-import pytest
-
 import model_builder_client
 
 


### PR DESCRIPTION
## Summary
- remove an unused pytest import from the model builder security tests
- eliminate the duplicate OFFLINE_MODE declaration in the offline services helpers
- mark BotConfig as a proper typing alias so mypy recognises the configuration object

## Testing
- python -m ruff check bot tests
- python -m mypy bot
- python -m bandit -r bot -x tests -ll
- python -m flake8 .
- pytest -m "not integration"
- pytest -m integration

------
https://chatgpt.com/codex/tasks/task_b_68dfd5fd83408321be5003086fefa158