### PR TITLE
Fix docker-publish BuildKit cache media type failures

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -164,8 +164,11 @@ jobs:
           file: ${{ matrix.file }}
           push: ${{ env.PUBLISH_IMAGES == 'true' }}
           tags: ${{ steps.tags.outputs.list }}
-          cache-from: type=gha,scope=${{ matrix.image }}
-          cache-to: type=gha,scope=${{ matrix.image }},mode=max
+          # Используем отдельный scope с OCI media types, чтобы BuildKit
+          # не пытался читать устаревший кэш с generic "application/octet-stream"
+          # и не падал с "unexpected media type ... not found".
+          cache-from: type=gha,scope=${{ matrix.image }}-oci
+          cache-to: type=gha,scope=${{ matrix.image }}-oci,mode=max,oci-mediatypes=true
 
       - name: Cleanup before Trivy scan
         if: ${{ env.PUBLISH_DOCKERHUB == 'true' }}


### PR DESCRIPTION
## Summary
- switch the docker build cache scope to a fresh suffix and enable OCI media types
- document the change to avoid BuildKit failures when reading legacy caches

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_b_68dfdde8fe7c83219b2ca5cba58b08ab