### PR TITLE
Bump setuptools floor to 80.9.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,12 +45,12 @@ RUN set -eux; \
     /bin/bash /tmp/security/harden_gnutar.sh; \
     python3 -m pip install --no-compile --no-cache-dir --break-system-packages \
         'pip>=24.0' \
-        'setuptools>=78.1.1,<81' \
+        'setuptools>=80.9.0,<81' \
         wheel; \
     if command -v python3.11 >/dev/null 2>&1; then \
         python3.11 -m ensurepip --upgrade; \
         python3.11 -m pip install --no-compile --no-cache-dir --break-system-packages \
-            'setuptools>=78.1.1,<81'; \
+            'setuptools>=80.9.0,<81'; \
     fi; \
     curl --netrc-file /dev/null -L https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz -o zlib.tar.gz; \
     echo "${ZLIB_SHA256}  zlib.tar.gz" | sha256sum -c -
@@ -89,8 +89,8 @@ ENV VIRTUAL_ENV=/app/venv
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Устанавливаем зависимости (pip >=24.0 устраняет CVE-2023-32681, setuptools>=78.1.1 закрывает свежие уязвимости)
-RUN pip install --no-compile --no-cache-dir 'pip>=24.0' 'setuptools>=78.1.1,<81' wheel && \
+# Устанавливаем зависимости (pip >=24.0 устраняет CVE-2023-32681, setuptools>=80.9.0 закрывает свежие уязвимости)
+RUN pip install --no-compile --no-cache-dir 'pip>=24.0' 'setuptools>=80.9.0,<81' wheel && \
     pip install --no-compile --no-cache-dir -r requirements-core.txt -r requirements-gpu.txt && \
     $VIRTUAL_ENV/bin/python /tmp/security/update_commons_lang3.py
 
@@ -128,12 +128,12 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     openssl \
     ca-certificates \
     && python3 -m ensurepip --upgrade \
-    && python3 -m pip install --no-cache-dir --break-system-packages 'setuptools>=78.1.1,<81' \
+    && python3 -m pip install --no-cache-dir --break-system-packages 'setuptools>=80.9.0,<81' \
     && dpkg -i /tmp/pam-fixed/*.deb \
     && /bin/bash /tmp/security/harden_gnutar.sh \
     && if command -v python3.11 >/dev/null 2>&1; then \
         python3.11 -m ensurepip --upgrade; \
-        python3.11 -m pip install --no-cache-dir --break-system-packages 'setuptools>=78.1.1,<81'; \
+        python3.11 -m pip install --no-cache-dir --break-system-packages 'setuptools>=80.9.0,<81'; \
     fi \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/pam-fixed \
     && ldconfig \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recomme
     && /venv/bin/python -m ensurepip --upgrade \
     && /venv/bin/pip install --no-cache-dir \
         'pip>=24.0' \
-        'setuptools>=78.1.1,<81' \
+        'setuptools>=80.9.0,<81' \
         wheel \
     && /venv/bin/pip cache purge \
     && rm -rf /root/.cache/pip \

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -43,7 +43,7 @@ if (major, minor) != (3, 11):
     )
 PY
 
-# pip>=24.0 устраняет CVE-2023-32681, setuptools>=78.1.1 закрывает известные
+# pip>=24.0 устраняет CVE-2023-32681, setuptools>=80.9.0 закрывает известные
 # уязвимости и совместимы с зависимостями проекта.
 RUN python -m venv "$VIRTUAL_ENV"
 
@@ -51,7 +51,7 @@ RUN "$VIRTUAL_ENV"/bin/python -m ensurepip --upgrade
 
 RUN "$VIRTUAL_ENV"/bin/pip install --no-cache-dir \
         'pip>=24.0' \
-        'setuptools>=78.1.1,<81' \
+        'setuptools>=80.9.0,<81' \
         wheel
 
 RUN "$VIRTUAL_ENV"/bin/pip install --no-cache-dir \

--- a/Dockerfile.gptoss
+++ b/Dockerfile.gptoss
@@ -1,4 +1,4 @@
-# Python 3.12 slim already ships with patched setuptools (>=78.1.1),
+# Python 3.12 slim already ships with patched setuptools (>=80.9.0),
 # eliminating CVE-2024-6345 / CVE-2025-47273 flagged by Trivy in the
 # previous Python 3.11 base image.
 FROM python:3.12-slim
@@ -9,7 +9,7 @@ ENV VLLM_DEVICE=cpu VLLM_LOGGING_LEVEL=DEBUG
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \
     && python -m ensurepip --upgrade \
-    && python -m pip install --no-cache-dir 'pip>=24.0' 'setuptools>=78.1.1,<81' wheel \
+    && python -m pip install --no-cache-dir 'pip>=24.0' 'setuptools>=80.9.0,<81' wheel \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd --system bot \
     && useradd --system --gid bot --home-dir /home/bot --shell /bin/bash bot \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=78.1.1", "wheel"]
+requires = ["setuptools>=80.9.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -27,7 +27,7 @@ ccxt==4.5.7
 # pinned numpy; keep everything aligned with the Docker images.
 scikit-learn==1.7.2; python_version<'3.12'
 joblib==1.5.2
-setuptools>=78.1.1
+setuptools>=80.9.0
 types-requests
 mypy==1.18.2
 hypothesis>=6.90.0

--- a/requirements-core.in
+++ b/requirements-core.in
@@ -36,5 +36,5 @@ bcrypt>=4.2.0
 jsonschema==4.25.1
 pytest-asyncio>=1.1
 backports-asyncio-runner==1.2.0; python_version < "3.11"
-setuptools>=78.1.1,<81
+setuptools>=80.9.0,<81
 

--- a/requirements-gpu.in
+++ b/requirements-gpu.in
@@ -3,4 +3,4 @@ torch==2.8.0
 tensorflow==2.20.0
 keras>=3.11.3,<3.12
 jsonschema==4.25.1
-setuptools>=78.1.1,<81
+setuptools>=80.9.0,<81

--- a/scripts/setup-tests.sh
+++ b/scripts/setup-tests.sh
@@ -2,5 +2,5 @@
 set -e
 # Install packages required for running the unit tests.
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-python -m pip install --upgrade 'pip>=24.0' 'setuptools>=78.1.1,<81' wheel
+python -m pip install --upgrade 'pip>=24.0' 'setuptools>=80.9.0,<81' wheel
 python -m pip install -r "$REPO_ROOT/requirements.txt"


### PR DESCRIPTION
## Summary
- raise the minimum supported setuptools version to 80.9.0 across build scripts, dependency manifests, and Dockerfiles
- refresh associated comments so CI environments default to the patched release

## Testing
- python scripts/run_pip_audit.py --strict --output pip-audit.json

------
https://chatgpt.com/codex/tasks/task_b_68dfddf19ba483219d3598387cda4ee5