### PR TITLE
Skip GPT-OSS review on pull_request_target events

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -72,6 +72,13 @@ jobs:
                 run_review=true
               fi
               ;;
+            pull_request_target)
+              pr_number="${PR_NUMBER:-}"
+              skip_reason="Workflow triggered for pull_request_target – обзор не выполняется"
+              if [ -z "$pr_number" ]; then
+                skip_reason="PR не найден"
+              fi
+              ;;
             issue_comment)
               pr_number="${ISSUE_NUMBER:-}"
               comment_author="${COMMENT_AUTHOR:-}"
@@ -127,6 +134,7 @@ jobs:
     needs: evaluate
     if: >-
       ${{ needs.evaluate.outputs.run_review == 'true'
+          && github.event_name != 'pull_request_target'
           && (github.event_name != 'pull_request'
               || github.event.pull_request.head.repo.full_name == github.repository)
           && (github.event_name != 'issue_comment'


### PR DESCRIPTION
## Summary
- treat pull_request_target triggers as unsupported in the evaluate job so the workflow records a skip reason instead of attempting a review
- guard the review job so it never runs on pull_request_target events

## Testing
- pytest tests/test_check_pr_status.py tests/test_run_gptoss_review.py

------
https://chatgpt.com/codex/tasks/task_b_68dfde059bc48321aa2383ef2a5bc51e