### PR TITLE
Fix Buildx cache media type failures in docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -166,9 +166,10 @@ jobs:
           tags: ${{ steps.tags.outputs.list }}
           # Используем отдельный scope с OCI media types, чтобы BuildKit
           # не пытался читать устаревший кэш с generic "application/octet-stream"
-          # и не падал с "unexpected media type ... not found".
-          cache-from: type=gha,scope=${{ matrix.image }}-oci
-          cache-to: type=gha,scope=${{ matrix.image }}-oci,mode=max,oci-mediatypes=true
+          # и не падал с "unexpected media type ... not found". Новый суффикс
+          # ``-oci-v2`` гарантирует создание отдельного пула слоёв.
+          cache-from: type=gha,scope=${{ matrix.image }}-oci-v2,ignore-error=true
+          cache-to: type=gha,scope=${{ matrix.image }}-oci-v2,mode=max,oci-mediatypes=true
 
       - name: Cleanup before Trivy scan
         if: ${{ env.PUBLISH_DOCKERHUB == 'true' }}


### PR DESCRIPTION
## Summary
- add a new cache scope suffix and ignore errors when reusing the GitHub Actions cache so Buildx stops pulling layers with the legacy application/octet-stream media type

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_b_68e244318d0c8321b9dec43d80593873