### PR TITLE
Ensure TradeManager positions endpoint still requires token

### DIFF
--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -128,7 +128,7 @@ def _bind_exchange() -> None:
 def _require_api_token() -> ResponseReturnValue | None:
     """Simple token-based authentication middleware."""
 
-    if request.method in {'GET', 'HEAD', 'OPTIONS'}:
+    if request.method != 'POST' and request.path != '/positions':
         return None
 
     expected = _resolve_expected_token()


### PR DESCRIPTION
## Summary
- restore the API-token check for GET /positions while continuing to rely on runtime token refresh

## Testing
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_b_68e244816b2c832182e8d2c57bb340d3