### PR TITLE
Handle head_ref in dependency graph workflow

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -37,6 +37,7 @@ jobs:
               github.event.client_payload.after ||
               github.event.client_payload.ref ||
               github.event.client_payload.ref_name ||
+              github.event.client_payload.head_ref ||
               github.event.client_payload.branch ||
               github.ref
             }}

--- a/tests/test_dependency_graph_workflow.py
+++ b/tests/test_dependency_graph_workflow.py
@@ -115,4 +115,5 @@ def test_dependency_graph_checkout_resolves_dispatch_ref() -> None:
     assert "github.event.client_payload.head_sha" in workflow
     assert "github.event.client_payload.commit_sha" in workflow
     assert "github.event.client_payload.ref_name" in workflow
+    assert "github.event.client_payload.head_ref" in workflow
     assert "github.event.client_payload.branch" in workflow


### PR DESCRIPTION
## Summary
- include repository_dispatch head_ref fallback when checking out commits for the dependency graph snapshot
- extend the dependency graph workflow test suite to cover the new checkout fallback

## Testing
- pytest tests/test_dependency_graph_workflow.py

------
https://chatgpt.com/codex/tasks/task_b_68e2448f73948321b514680c43dc5b23