### PR TITLE
Harden model signature storage permissions

### DIFF
--- a/tests/test_model_builder_signatures.py
+++ b/tests/test_model_builder_signatures.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import importlib.util
+import os
+import stat
 import sys
 from pathlib import Path
 
@@ -67,6 +69,10 @@ def test_load_model_validates_signatures(
     assert module._model is None, "Model must not load without a signature"
 
     security.write_model_state_signature(model_path)
+    if os.name != "nt":
+        assert sig_path.exists()
+        sig_mode = stat.S_IMODE(sig_path.stat().st_mode)
+        assert sig_mode == 0o600
     module._model = None
     module._load_model()
     assert isinstance(module._model, DummyModel)


### PR DESCRIPTION
## Summary
- ensure model state signatures are written via an atomic helper that enforces restrictive permissions
- extend the model builder signature test to verify secure permissions on non-Windows platforms

## Testing
- pytest tests/test_model_builder_signatures.py::test_load_model_validates_signatures -q

------
https://chatgpt.com/codex/tasks/task_b_68e2445ce6f883218cd2d9bd33ddffa4