### PR TITLE
Stabilize Release Drafter workflow execution

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -24,7 +24,15 @@ permissions:
   issues: write
 
 concurrency:
-  group: release-drafter-${{ github.head_ref || github.ref }}
+  group: >-
+    ${{
+      (
+        github.event_name == 'pull_request_target'
+        && github.event.pull_request != null
+        && github.event.pull_request.number != null
+        && format('release-drafter-pr-{0}', github.event.pull_request.number)
+      ) || format('release-drafter-ref-{0}', github.ref)
+    }}
   cancel-in-progress: false
 
 jobs:
@@ -40,13 +48,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   autolabel_pull_request:
-    if: github.event_name == 'pull_request_target'
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request != null &&
+      github.event.pull_request.head.repo != null &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Update pull request metadata
-        if: >-
-          github.event.pull_request != null &&
-          github.event.pull_request.head.repo != null
         uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         with:
           config-name: release-drafter.yml


### PR DESCRIPTION
## Summary
- refine the concurrency group so pull-request runs get their own slot while other runs fall back to the ref name
- skip the auto-label job for pull requests coming from forks to avoid permission-related failures

## Testing
- ./actionlint .github/workflows/release-drafter.yml

------
https://chatgpt.com/codex/tasks/task_b_68e24548138883218cba05be212a22b3