### PR TITLE
Handle pip managed environment in dependency graph workflow

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -46,8 +46,10 @@ jobs:
           python-version: '3.11'
       - name: Install dependency snapshot dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install requests
+          python -m pip install --upgrade pip \
+            || python -m pip install --upgrade pip --break-system-packages
+          python -m pip install requests \
+            || python -m pip install requests --break-system-packages
       - name: Detect dependency manifest changes
         id: detect
         env:
@@ -198,8 +200,10 @@ jobs:
           github.event_name == 'workflow_dispatch' ||
           github.event_name == 'repository_dispatch'
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install requests
+          python -m pip install --upgrade pip \
+            || python -m pip install --upgrade pip --break-system-packages
+          python -m pip install requests \
+            || python -m pip install requests --break-system-packages
       - name: Prepare requirements
         if: >-
           steps.detect.outputs.changed == 'true' ||


### PR DESCRIPTION
## Summary
- add a fallback that retries pip installations with --break-system-packages so dependency snapshot runs succeed on externally managed environments

## Testing
- pytest tests/test_dependency_graph_workflow.py -q

------
https://chatgpt.com/codex/tasks/task_b_68e2575495288321a8450207d95b6f01