### PR TITLE
Fix release drafter concurrency guard

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -28,9 +28,9 @@ concurrency:
     ${{
       (
         github.event_name == 'pull_request_target'
-        && github.event.pull_request != null
-        && github.event.pull_request.number != null
-        && format('release-drafter-pr-{0}', github.event.pull_request.number)
+        && github.event.number != null
+        && github.event.number != ''
+        && format('release-drafter-pr-{0}', github.event.number)
       ) || format('release-drafter-ref-{0}', github.ref)
     }}
   cancel-in-progress: false


### PR DESCRIPTION
## Summary
- guard Release Drafter concurrency group calculation by using the top-level pull request number field

## Testing
- actionlint .github/workflows/release-drafter.yml

------
https://chatgpt.com/codex/tasks/task_b_68e2577133c08321b8ef747058050a1f