### PR TITLE
Sanitize logging to address CodeQL alerts

### DIFF
--- a/telegram_logger.py
+++ b/telegram_logger.py
@@ -221,7 +221,7 @@ class TelegramLogger(logging.Handler):
                     except httpx.HTTPError as e:
                         logger.warning(
                             "HTTP ошибка Telegram: %s. Попытка %s/5",
-                            e,
+                            sanitize_log_value(str(e)),
                             attempt + 1,
                         )
                         if attempt < 4:
@@ -230,14 +230,17 @@ class TelegramLogger(logging.Handler):
                         else:
                             raise
                     except (BadRequest, Forbidden) as e:
-                        logger.error("Ошибка Telegram: %s", e)
+                        logger.error(
+                            "Ошибка Telegram: %s",
+                            sanitize_log_value(str(e)),
+                        )
                         raise
                     except asyncio.CancelledError:
                         raise
                     except Exception as e:
                         logger.exception(
                             "Ошибка отправки сообщения Telegram: %s",
-                            e,
+                            sanitize_log_value(str(e)),
                         )
                         raise
     def _save_unsent(self, chat_id: int | str, text: str) -> None:

--- a/utils.py
+++ b/utils.py
@@ -59,8 +59,8 @@ def _wrap_tempfile_mkdtemp() -> None:
             except OSError as exc:
                 logger.error(
                     "Не удалось подготовить каталог временных файлов %s: %s",
-                    target_dir,
-                    exc,
+                    sanitize_log_value(str(target_dir)),
+                    sanitize_log_value(str(exc)),
                 )
                 raise RuntimeError(
                     "Не удалось подготовить каталог временных файлов"
@@ -302,7 +302,10 @@ except ImportError:
 try:  # pragma: no cover - prefer package import to avoid shadowing
     from bot.telegram_logger import TelegramLogger  # type: ignore  # noqa: F401
 except Exception as exc:  # pragma: no cover - fallback when package import fails
-    logger.warning("Failed to import TelegramLogger via package: %s", exc)
+    logger.warning(
+        "Failed to import TelegramLogger via package: %s",
+        sanitize_log_value(str(exc)),
+    )
     try:
         from telegram_logger import TelegramLogger  # type: ignore  # noqa: F401
     except Exception:
@@ -322,7 +325,10 @@ except Exception as exc:  # pragma: no cover - fallback when package import fail
 try:
     from telegram.error import RetryAfter, BadRequest, Forbidden
 except ImportError as exc:  # pragma: no cover - allow missing telegram package
-    logging.getLogger("TradingBot").error("Telegram package not available: %s", exc)
+    logging.getLogger("TradingBot").error(
+        "Telegram package not available: %s",
+        sanitize_log_value(str(exc)),
+    )
 
     class _TelegramError(Exception):
         pass


### PR DESCRIPTION
## Summary
- sanitize configuration warnings that log environment-controlled paths and errors
- harden Telegram logger and trading workflow logs against log injection
- ensure utility fallbacks scrub exception details before logging

## Testing
- pytest tests/test_security.py

------
https://chatgpt.com/codex/tasks/task_b_68e2573633408321822ced20537843ee