### PR TITLE
Update CI Docker cache scope to avoid outdated cache blobs

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -167,9 +167,9 @@ jobs:
           # Используем отдельный scope с OCI media types, чтобы BuildKit
           # не пытался читать устаревший кэш с generic "application/octet-stream"
           # и не падал с "unexpected media type ... not found". Новый суффикс
-          # ``-oci-v2`` гарантирует создание отдельного пула слоёв.
-          cache-from: type=gha,scope=${{ matrix.image }}-oci-v2,ignore-error=true
-          cache-to: type=gha,scope=${{ matrix.image }}-oci-v2,mode=max,oci-mediatypes=true
+          # ``-oci-v3`` гарантирует создание отдельного пула слоёв.
+          cache-from: type=gha,scope=${{ matrix.image }}-oci-v3,ignore-error=true
+          cache-to: type=gha,scope=${{ matrix.image }}-oci-v3,mode=max,oci-mediatypes=true
 
       - name: Cleanup before Trivy scan
         if: ${{ env.PUBLISH_DOCKERHUB == 'true' }}


### PR DESCRIPTION
## Summary
- move the buildx cache scope used in docker-publish to a fresh `-oci-v3` suffix
- update the accompanying comment so future runs know why the new scope exists

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e257235f3483218431d4f8d424a04d