### PR TITLE
Sanitize Telegram logger errors flagged by Semgrep

### DIFF
--- a/telegram_logger.py
+++ b/telegram_logger.py
@@ -221,7 +221,7 @@ class TelegramLogger(logging.Handler):
                     except httpx.HTTPError as e:
                         logger.warning(
                             "HTTP ошибка Telegram: %s. Попытка %s/5",
-                            e,
+                            sanitize_log_value(str(e)),
                             attempt + 1,
                         )
                         if attempt < 4:
@@ -230,14 +230,17 @@ class TelegramLogger(logging.Handler):
                         else:
                             raise
                     except (BadRequest, Forbidden) as e:
-                        logger.error("Ошибка Telegram: %s", e)
+                        logger.error(
+                            "Ошибка Telegram: %s",
+                            sanitize_log_value(str(e)),
+                        )
                         raise
                     except asyncio.CancelledError:
                         raise
                     except Exception as e:
                         logger.exception(
                             "Ошибка отправки сообщения Telegram: %s",
-                            e,
+                            sanitize_log_value(str(e)),
                         )
                         raise
     def _save_unsent(self, chat_id: int | str, text: str) -> None:


### PR DESCRIPTION
## Summary
- sanitize Telegram logger error and warning messages before logging exception details
- keep the asynchronous worker resilient to Semgrep log-injection checks

## Testing
- semgrep --config p/ci --error
- pytest tests/test_telegram_logger.py tests/test_telegram_logger_shutdown_all.py

------
https://chatgpt.com/codex/tasks/task_b_68e2577c6024832180ffaa9d18136f85