### PR TITLE
Fix predict fallback signal handling without trained model

### DIFF
--- a/services/model_builder_service.py
+++ b/services/model_builder_service.py
@@ -660,8 +660,7 @@ def predict() -> ResponseReturnValue:
         model = _model_builder.predictive_models.get(symbol)
         if model is None:
             price = float(features[0, 0]) if features.size else 0.0
-            signal = "buy" if price > 0 else None
-            prob = 1.0 if signal else 0.0
+            prob = 1.0 if price > 0 else 0.0
         else:
             try:
                 scaler = _model_builder.scalers.get(symbol)
@@ -716,13 +715,11 @@ def predict() -> ResponseReturnValue:
         features = scaler.transform(features)
     if model is None:
         price = float(features[0, 0]) if features.size else 0.0
-        signal = "buy" if price > 0 else None
-        prob = 1.0 if signal else 0.0
+        prob = 1.0 if price > 0 else 0.0
     else:
         prob = float(model.predict_proba(features)[0, 1])
     threshold = 0.5
-    if model is not None:
-        signal = "buy" if prob >= threshold else "sell"
+    signal = "buy" if prob >= threshold else "sell"
     return jsonify({"signal": signal, "prob": prob, "threshold": threshold})
 
 

--- a/tests/integration/test_model_builder_predict.py
+++ b/tests/integration/test_model_builder_predict.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+pytest.importorskip("flask")
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture()
+def model_builder_service(monkeypatch, tmp_path):
+    monkeypatch.setenv("TEST_MODE", "1")
+    monkeypatch.setenv("MODEL_DIR", str(tmp_path))
+    monkeypatch.setenv("NN_FRAMEWORK", "sklearn")
+
+    module_name = "services.model_builder_service"
+    original_module = sys.modules.pop(module_name, None)
+    try:
+        module = importlib.import_module(module_name)
+        module = importlib.reload(module)
+        with module.app.test_client() as client:
+            yield module, client
+    finally:
+        sys.modules.pop(module_name, None)
+        if original_module is not None:
+            sys.modules[module_name] = original_module
+
+
+def test_predict_returns_string_signal_without_model(model_builder_service):
+    _, client = model_builder_service
+
+    response = client.post("/predict", json={"price": -1.0})
+    assert response.status_code == 200
+
+    payload = response.get_json()
+    assert isinstance(payload["signal"], str)
+    assert payload["signal"] in {"buy", "sell"}


### PR DESCRIPTION
## Summary
- ensure the /predict fallback path always produces a string signal when no model is loaded
- reuse the standard threshold logic and add an integration test covering the regression

## Testing
- pytest tests/integration/test_model_builder_predict.py

------
https://chatgpt.com/codex/tasks/task_b_68e26deedae08321a4c24a8d70f86bfa