### PR TITLE
Implement robust data handler settings loader

### DIFF
--- a/data_handler/__init__.py
+++ b/data_handler/__init__.py
@@ -1,4 +1,10 @@
+from __future__ import annotations
+
 from collections.abc import Iterable
+from dataclasses import dataclass
+import json
+import os
+from typing import Any
 
 import numpy as np
 
@@ -8,6 +14,71 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # pragma: no cover - Flask not installed
     api_app = None  # type: ignore[assignment]
 from .storage import DEFAULT_PRICE
+
+
+@dataclass(frozen=True, slots=True)
+class DataHandlerSettings:
+    """Settings returned by :func:`get_settings`."""
+
+    symbols: list[str]
+    config: Any | None = None
+
+
+def _load_bot_config() -> Any | None:
+    """Best-effort loading of :class:`bot.config.BotConfig`."""
+
+    try:  # Deferred import keeps data_handler usable without full config
+        from bot import config as bot_config  # noqa: WPS433 - local import is intentional
+    except Exception:  # pragma: no cover - configuration import errors
+        return None
+
+    try:
+        return bot_config.load_config()
+    except Exception:  # pragma: no cover - fall back to direct instantiation
+        try:
+            return bot_config.BotConfig()
+        except Exception:  # pragma: no cover - give up and use defaults
+            return None
+
+
+def _parse_symbols(raw: str | None, fallback: list[str]) -> list[str]:
+    """Parse *raw* into a list of trading symbols."""
+
+    if raw is None:
+        return list(fallback)
+
+    raw = raw.strip()
+    if not raw:
+        return list(fallback)
+
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        candidates = [item.strip() for item in raw.split(",")]
+    else:
+        if isinstance(parsed, str):
+            candidates = [parsed.strip()]
+        elif isinstance(parsed, list):
+            candidates = [str(item).strip() for item in parsed]
+        else:
+            candidates = []
+
+    symbols = [candidate for candidate in candidates if candidate]
+    return symbols or list(fallback)
+
+
+def get_settings() -> DataHandlerSettings:
+    """Load data handler settings from environment/configuration."""
+
+    config = _load_bot_config()
+    default_symbols = ["BTCUSDT"]
+    if config is not None:
+        configured = getattr(config, "symbols", None)
+        if isinstance(configured, list) and configured:
+            default_symbols = [str(symbol).strip() for symbol in configured if str(symbol).strip()]
+
+    symbols = _parse_symbols(os.getenv("SYMBOLS"), default_symbols)
+    return DataHandlerSettings(symbols=list(symbols), config=config)
 
 
 async def get_http_client():
@@ -59,4 +130,6 @@ __all__ = [
     "DataHandler",
     "api_app",
     "DEFAULT_PRICE",
+    "DataHandlerSettings",
+    "get_settings",
 ]


### PR DESCRIPTION
## Summary
- add a DataHandlerSettings container and expose a new get_settings helper
- parse SYMBOLS from the environment with a safe fallback and resilient config loading
- export the new helpers alongside existing data handler utilities

## Testing
- pytest tests/test_main_missing_env.py::test_main_missing_required_env -q

------
https://chatgpt.com/codex/tasks/task_b_68e276083f488321bb0abade53998429