### PR TITLE
Handle HTTP errors in manage_positions loop

### DIFF
--- a/bot/trade_manager/core.py
+++ b/bot/trade_manager/core.py
@@ -1600,7 +1600,7 @@ class TradeManager:
                 await asyncio.sleep(self.check_interval)
             except asyncio.CancelledError:
                 raise
-            except (ValueError, RuntimeError, KeyError) as e:
+            except (ValueError, RuntimeError, KeyError, httpx.HTTPError) as e:
                 logger.exception(
                     "Error managing positions (%s): %s",
                     type(e).__name__,

--- a/tests/test_trade_manager_loops.py
+++ b/tests/test_trade_manager_loops.py
@@ -6,6 +6,7 @@ import types
 import pandas as pd
 import pytest
 import tempfile
+import httpx
 from bot.config import BotConfig
 
 # Stub heavy dependencies before importing the trade manager
@@ -168,7 +169,7 @@ async def test_manage_positions_recovery(monkeypatch):
     async def fake_check(symbol, price):
         call['n'] += 1
         if call['n'] == 1:
-            raise RuntimeError('boom')
+            raise httpx.HTTPError('boom')
     monkeypatch.setattr(tm, 'check_trailing_stop', fake_check)
     monkeypatch.setattr(tm, 'check_stop_loss_take_profit', lambda *a, **k: None)
     monkeypatch.setattr(tm, 'check_exit_signal', lambda *a, **k: None)


### PR DESCRIPTION
## Summary
- update the manage_positions loop to catch httpx.HTTPError alongside existing recoverable exceptions
- extend the manage_positions recovery test to raise an httpx.HTTPError and verify the loop continues

## Testing
- pytest tests/test_trade_manager_loops.py
- ruff check .

------
https://chatgpt.com/codex/tasks/task_b_68e279621f1c8321babc05bce93464c8