### PR TITLE
Handle httpx errors in ranked signal loop

### DIFF
--- a/bot/trade_manager/core.py
+++ b/bot/trade_manager/core.py
@@ -1986,7 +1986,7 @@ class TradeManager:
                 await asyncio.sleep(self.check_interval)
             except asyncio.CancelledError:
                 raise
-            except (ValueError, RuntimeError) as e:
+            except (ValueError, RuntimeError, httpx.HTTPError) as e:
                 logger.exception(
                     "Error processing ranked signals (%s): %s",
                     type(e).__name__,


### PR DESCRIPTION
## Summary
- include httpx.HTTPError in ranked signal loop error handling so network failures are retried
- add async test to ensure ranked_signal_loop retries after HTTP failures in open_position

## Testing
- pytest tests/test_trade_manager_loops.py::test_ranked_signal_loop_http_error_retry -q

------
https://chatgpt.com/codex/tasks/task_b_68e2916c4c1c8321bb459a22e88be88c