### PR TITLE
Fix ConfigLoadError behavior on invalid defaults

### DIFF
--- a/config.py
+++ b/config.py
@@ -263,7 +263,10 @@ def load_defaults() -> dict[str, Any]:
                 else:
                     logger.error("Failed to load %s: %s", path, exc)
                     raise ConfigLoadError from exc
-            except (OSError, json.JSONDecodeError) as exc:
+            except json.JSONDecodeError as exc:
+                logger.error("Failed to load %s: %s", path, exc)
+                raise ConfigLoadError from exc
+            except OSError as exc:
                 if OFFLINE_MODE or os.getenv("TEST_MODE") == "1":
                     logger.warning(
                         "Failed to load %s: %s; using empty defaults in offline/test mode",


### PR DESCRIPTION
## Summary
- ensure invalid default configuration files raise ConfigLoadError instead of silently returning empty defaults

## Testing
- pytest tests/test_load_defaults_error.py

------
https://chatgpt.com/codex/tasks/task_b_68e2938bee1c8321afd8899940c60281