### PR TITLE
Fix ConfigLoadError handling for custom config paths

### DIFF
--- a/config.py
+++ b/config.py
@@ -253,7 +253,11 @@ def load_defaults() -> dict[str, Any]:
                 with opener(path) as handle:
                     DEFAULTS = json.load(handle)
             except FileNotFoundError as exc:
-                if OFFLINE_MODE or os.getenv("TEST_MODE") == "1":
+                allow_empty_defaults = (
+                    (OFFLINE_MODE or os.getenv("TEST_MODE") == "1")
+                    and path == _DEFAULT_CONFIG_PATH
+                )
+                if allow_empty_defaults:
                     logger.warning(
                         "Failed to load %s: %s; using empty defaults in offline/test mode",
                         path,
@@ -264,7 +268,11 @@ def load_defaults() -> dict[str, Any]:
                     logger.error("Failed to load %s: %s", path, exc)
                     raise ConfigLoadError from exc
             except (OSError, json.JSONDecodeError) as exc:
-                if OFFLINE_MODE or os.getenv("TEST_MODE") == "1":
+                allow_empty_defaults = (
+                    (OFFLINE_MODE or os.getenv("TEST_MODE") == "1")
+                    and path == _DEFAULT_CONFIG_PATH
+                )
+                if allow_empty_defaults:
                     logger.warning(
                         "Failed to load %s: %s; using empty defaults in offline/test mode",
                         path,


### PR DESCRIPTION
## Summary
- ensure load_defaults only swallows errors for the bundled default config file when running in offline or test mode
- raise ConfigLoadError for invalid custom config paths even in test environments

## Testing
- pytest tests/test_load_defaults_error.py

------
https://chatgpt.com/codex/tasks/task_b_68e29396f16c8321b356c28603c4b65a