### PR TITLE
Handle workflow_run commits in dependency snapshot workflow

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -39,6 +39,11 @@ jobs:
               github.event.client_payload.ref_name ||
               github.event.client_payload.head_ref ||
               github.event.client_payload.branch ||
+              github.event.workflow_run.head_sha ||
+              github.event.workflow_run.head_commit.id ||
+              github.event.workflow_run.head_commit.sha ||
+              github.event.workflow_run.head_ref ||
+              github.event.workflow_run.head_branch ||
               github.ref
             }}
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
@@ -61,6 +66,9 @@ jobs:
               github.event.client_payload.before_sha ||
               github.event.client_payload.previous_sha ||
               github.event.client_payload.previous_oid ||
+              github.event.workflow_run.before ||
+              github.event.workflow_run.previous_sha ||
+              github.event.workflow_run.head_commit.before ||
               ''
             }}
           AFTER: >-
@@ -72,6 +80,9 @@ jobs:
               github.event.client_payload.commit_sha ||
               github.event.client_payload.after_sha ||
               github.event.client_payload.sha ||
+              github.event.workflow_run.head_sha ||
+              github.event.workflow_run.head_commit.id ||
+              github.event.workflow_run.head_commit.sha ||
               ''
             }}
         run: |

--- a/tests/test_dependency_graph_workflow.py
+++ b/tests/test_dependency_graph_workflow.py
@@ -80,6 +80,12 @@ def test_dependency_graph_detect_step_uses_dispatch_commit_fallbacks() -> None:
     assert "github.event.client_payload.commit_oid" in workflow
     assert "github.event.client_payload.commit_sha" in workflow
     assert "github.event.client_payload.sha" in workflow
+    assert "github.event.workflow_run.head_sha" in workflow
+    assert "github.event.workflow_run.head_commit.id" in workflow
+    assert "github.event.workflow_run.head_commit.sha" in workflow
+    assert "github.event.workflow_run.before" in workflow
+    assert "github.event.workflow_run.previous_sha" in workflow
+    assert "github.event.workflow_run.head_commit.before" in workflow
 
 
 def test_dependency_graph_installs_requests_before_submission() -> None:
@@ -117,3 +123,8 @@ def test_dependency_graph_checkout_resolves_dispatch_ref() -> None:
     assert "github.event.client_payload.ref_name" in workflow
     assert "github.event.client_payload.head_ref" in workflow
     assert "github.event.client_payload.branch" in workflow
+    assert "github.event.workflow_run.head_sha" in workflow
+    assert "github.event.workflow_run.head_commit.id" in workflow
+    assert "github.event.workflow_run.head_commit.sha" in workflow
+    assert "github.event.workflow_run.head_ref" in workflow
+    assert "github.event.workflow_run.head_branch" in workflow


### PR DESCRIPTION
## Summary
- add workflow_run commit fallbacks when checking out code for dependency snapshots
- feed workflow_run commit hashes into the manifest change detector
- extend workflow tests to cover the new workflow_run fallback expressions

## Testing
- pytest tests/test_dependency_graph_workflow.py

------
https://chatgpt.com/codex/tasks/task_b_68e297900e088321ba5e512f96f8a721