### PR TITLE
Handle GPU manifests in Dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -51,6 +51,37 @@ jobs:
         uses: dependabot/fetch-metadata@46cfd663b8c18cab02928a3fa963cf0e73994bb1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Detect GPU-only manifests
+        id: manifest
+        if: ${{ steps.metadata.outputs['package-ecosystem'] == 'pip' }}
+        env:
+          MANIFEST_NAME: ${{ steps.metadata.outputs['manifest-name'] }}
+        run: |
+          set -euo pipefail
+
+          write_summary() {
+            if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+              mkdir -p "$(dirname "$GITHUB_STEP_SUMMARY")"
+              printf '%s\n' "$1" >>"$GITHUB_STEP_SUMMARY"
+            else
+              printf '%s\n' "$1"
+            fi
+          }
+
+          if [[ -z "${MANIFEST_NAME}" ]]; then
+            echo "requires_gpu=false" >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          shopt -s nocasematch
+          if [[ "${MANIFEST_NAME}" == requirements-gpu.* ]]; then
+            echo "requires_gpu=true" >>"$GITHUB_OUTPUT"
+            write_summary "Skipping GPU-specific manifest '${MANIFEST_NAME}' to avoid installing unavailable CUDA dependencies."
+          else
+            echo "requires_gpu=false" >>"$GITHUB_OUTPUT"
+          fi
+          shopt -u nocasematch
+
       - name: Auto approve
         if: ${{ steps.metadata.outputs['update-type'] != 'version-update:semver-major' }}
         # v4.0.0
@@ -59,7 +90,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-number: ${{ (github.event.pull_request && github.event.pull_request.number) || '' }}
       - name: Checkout code
-        if: ${{ steps.metadata.outputs['package-ecosystem'] == 'pip' }}
+        if: ${{ steps.metadata.outputs['package-ecosystem'] == 'pip' && steps.manifest.outputs.requires_gpu != 'true' }}
         # v5.0.0
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
@@ -72,7 +103,7 @@ jobs:
       # heavier setup used in the main CI workflow which was causing
       # Dependabot update checks to fail.
       - name: Setup Python
-        if: ${{ steps.metadata.outputs['package-ecosystem'] == 'pip' }}
+        if: ${{ steps.metadata.outputs['package-ecosystem'] == 'pip' && steps.manifest.outputs.requires_gpu != 'true' }}
         # v6.0.0
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
         with:
@@ -81,7 +112,8 @@ jobs:
       - name: Install dependencies
         if: >-
           steps.metadata.outputs['package-ecosystem'] == 'pip' &&
-          github.event.pull_request.head.repo.full_name == github.repository
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          steps.manifest.outputs.requires_gpu != 'true'
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e .
@@ -91,7 +123,8 @@ jobs:
         if: >-
           steps.metadata.outputs['package-ecosystem'] == 'pip' &&
           github.event.pull_request.head.repo.full_name == github.repository &&
-          steps.metadata.outputs['manifest-path'] != ''
+          steps.metadata.outputs['manifest-path'] != '' &&
+          steps.manifest.outputs.requires_gpu != 'true'
         env:
           MANIFEST_PATH: ${{ steps.metadata.outputs['manifest-path'] }}
           MANIFEST_NAME: ${{ steps.metadata.outputs['manifest-name'] }}
@@ -123,7 +156,8 @@ jobs:
       - name: Install Dependabot updates
         if: >-
           steps.metadata.outputs['package-ecosystem'] == 'pip' &&
-          github.event.pull_request.head.repo.full_name == github.repository
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          steps.manifest.outputs.requires_gpu != 'true'
         env:
           DEPENDENCIES_JSON: ${{ steps.metadata.outputs['updated-dependencies-json'] }}
         run: |
@@ -204,8 +238,25 @@ jobs:
       - name: Run unit tests
         if: >-
           steps.metadata.outputs['package-ecosystem'] == 'pip' &&
-          github.event.pull_request.head.repo.full_name == github.repository
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          steps.manifest.outputs.requires_gpu != 'true'
         run: pytest -m "not integration" -q
+
+      - name: Report skipped GPU validation
+        if: >-
+          steps.metadata.outputs['package-ecosystem'] == 'pip' &&
+          steps.manifest.outputs.requires_gpu == 'true'
+        run: |
+          write_summary() {
+            if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+              mkdir -p "$(dirname "$GITHUB_STEP_SUMMARY")"
+              printf '%s\n' "$1" >>"$GITHUB_STEP_SUMMARY"
+            else
+              printf '%s\n' "$1"
+            fi
+          }
+
+          write_summary "GPU-specific dependency updates require manual verification. Tests were skipped to avoid missing CUDA runtimes."
 
       - name: Check auto-merge availability
         id: auto_merge


### PR DESCRIPTION
## Summary
- detect Dependabot updates targeting GPU-only manifests and skip steps that require CUDA packages
- add step summaries explaining why GPU updates bypass automated validation

## Testing
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_b_68e2979f515c8321885fc5dc2a84dd50