### PR TITLE
Pin checkout action revisions in CI workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
         language: [ 'python' ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       PYTHONHASHSEED: "0"
       PIP_DISABLE_PIP_VERSION_CHECK: "1"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - name: Set up Python
         uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
## Summary
- pin actions/checkout to a specific commit in the CodeQL analysis workflow
- pin actions/checkout to the same vetted commit in the test workflow to avoid unpinned actions warnings

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_b_68e297aa069c8321aac11aa6eb0c737a