### PR TITLE
Fix release drafter concurrency expression

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -24,15 +24,7 @@ permissions:
   issues: write
 
 concurrency:
-  group: >-
-    ${{
-      (
-        github.event_name == 'pull_request_target'
-        && github.event.number != null
-        && github.event.number != ''
-        && format('release-drafter-pr-{0}', github.event.number)
-      ) || format('release-drafter-ref-{0}', github.ref)
-    }}
+  group: release-drafter-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary
- simplify the concurrency group expression to avoid boolean results
- ensure release drafter workflows consistently scope runs by PR number or ref

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e297b4d0d4832193bd4e2a07542209