### PR TITLE
Handle pull_request_target events in GPT-OSS workflow

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -164,7 +164,9 @@ jobs:
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Checkout workflow helpers
-        if: ${{ steps.validate_event.outputs.skip != 'true' }}
+        if: >-
+          ${{ steps.validate_event.outputs.skip != 'true'
+              && github.event_name != 'pull_request_target' }}
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           fetch-depth: 1
@@ -179,6 +181,17 @@ jobs:
           REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
+
+          if [ "${GITHUB_EVENT_NAME:-}" = "pull_request_target" ]; then
+            echo "::notice::Workflow triggered for pull_request_target – пропускаю проверку PR"
+            if [ -n "${GITHUB_OUTPUT:-}" ]; then
+              {
+                echo "skip=true"
+                echo "head_sha="
+              } >>"$GITHUB_OUTPUT"
+            fi
+            exit 0
+          fi
 
           helpers_dir="${HELPERS_DIR:-gptoss_helpers}"
 

--- a/tests/test_gptoss_workflow_python3.py
+++ b/tests/test_gptoss_workflow_python3.py
@@ -38,3 +38,13 @@ def test_pr_status_step_sets_outputs_on_failure() -> None:
     assert 'echo "skip=true"' in failure_block
     assert 'echo "head_sha="' in failure_block
     assert failure_block.count('exit 0') >= 1
+
+
+def test_pr_status_step_skips_pull_request_target() -> None:
+    workflow_text = WORKFLOW_PATH.read_text(encoding='utf-8')
+
+    guard_snippet = 'GITHUB_EVENT_NAME:-}" = "pull_request_target"'
+    notice_message = 'Workflow triggered for pull_request_target – пропускаю проверку PR'
+
+    assert guard_snippet in workflow_text
+    assert notice_message in workflow_text


### PR DESCRIPTION
## Summary
- skip the helper checkout and PR status validation when gptoss_review is triggered via pull_request_target
- write the skip outputs explicitly and cover the guard with a workflow test

## Testing
- pytest tests/test_gptoss_workflow_python3.py

------
https://chatgpt.com/codex/tasks/task_b_68e2c7552388832189e97937a5a54f86