### PR TITLE
Expand Trivy scan coverage

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -48,7 +48,7 @@ jobs:
         # v4.3.0
         with:
           path: ${{ steps.trivy_cache.outputs.dir }}
-          key: ${{ runner.os }}-trivy-db-${{ hashFiles('requirements*.txt', 'Dockerfile*') }}
+          key: ${{ runner.os }}-trivy-db-${{ hashFiles('requirements*.txt', 'requirements*.in', 'Dockerfile*') }}
           restore-keys: |
             ${{ runner.os }}-trivy-db-
 
@@ -65,6 +65,8 @@ jobs:
               --scanners vuln \
               --severity HIGH,CRITICAL \
               --ignore-unfixed \
+              --file-patterns 'pip:requirements*.txt' \
+              --file-patterns 'pip:requirements*.in' \
               --format sarif \
               --output trivy-results.sarif \
               --cache-dir "${TRIVY_CACHE_DIR}" \


### PR DESCRIPTION
## Summary
- include requirements *.in files in the Trivy cache key
- scan every requirements*.txt and requirements*.in file when invoking Trivy so additional dependency manifests are covered

## Testing
- trivy fs --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed --file-patterns 'pip:requirements*.txt' --file-patterns 'pip:requirements*.in' --format sarif --output trivy-test.sarif .


------
https://chatgpt.com/codex/tasks/task_b_68e2c77f33608321b022b837170e52f2