### PR TITLE
Implement lightweight offline TradeManager stub

### DIFF
--- a/bot/trade_manager/__init__.py
+++ b/bot/trade_manager/__init__.py
@@ -18,9 +18,9 @@ else:
     TelegramLoggerType = Any
 
 if bot_config.OFFLINE_MODE:
-    from services.offline import OfflineBybit, OfflineTelegram
+    from services.offline import OfflineTradeManager, OfflineTelegram
 
-    TradeManager = cast(type[TradeManagerType], OfflineBybit)
+    TradeManager = cast(type[TradeManagerType], OfflineTradeManager)
     TelegramLogger = cast(type[TelegramLoggerType], OfflineTelegram)
 
     __all__ = ["TradeManager", "TelegramLogger"]


### PR DESCRIPTION
## Summary
- add a lightweight OfflineTradeManager implementation that runs a short asynchronous loop
- expose the new OfflineTradeManager through the bot.trade_manager facade when OFFLINE_MODE is enabled

## Testing
- python run_bot.py --offline

------
https://chatgpt.com/codex/tasks/task_b_68e2d9b503a08321bfc696913ce42fe5