### PR TITLE
Prevent GPT-OSS review job from running when skipped

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -119,7 +119,7 @@ jobs:
 
   skip:
     needs: evaluate
-    if: ${{ needs.evaluate.outputs.run_review != 'true' }}
+    if: ${{ needs.evaluate.outputs.skip_reason != '' }}
     runs-on: ubuntu-latest
     steps:
       - name: Skip unsupported event
@@ -133,7 +133,7 @@ jobs:
   review:
     needs: evaluate
     if: >-
-      ${{ needs.evaluate.outputs.run_review == 'true'
+      ${{ needs.evaluate.outputs.skip_reason == ''
           && github.event_name != 'pull_request_target'
           && (github.event_name != 'pull_request'
               || github.event.pull_request.head.repo.full_name == github.repository)


### PR DESCRIPTION
## Summary
- gate the skip job on the presence of a skip reason from the evaluation step
- only run the review job when no skip reason was produced, avoiding unwanted executions on pull_request_target events

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_b_68e2d95435648321b5627109a7b6d56b