### PR TITLE
Handle workflow_run payloads in dependency snapshot

### DIFF
--- a/tests/test_dependency_snapshot.py
+++ b/tests/test_dependency_snapshot.py
@@ -349,6 +349,71 @@ def test_submit_dependency_snapshot_supports_commit_oid_and_ref_name(
     assert submitted["ref"] == "refs/heads/feature"
 
 
+def test_submit_dependency_snapshot_uses_client_workflow_run_payload(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload_path = tmp_path / "event.json"
+    payload_path.write_text(
+        json.dumps(
+            {
+                "client_payload": {
+                    "workflow_run": {
+                        "head_sha": "feedface",
+                        "head_branch": "auto-main",
+                        "head_repository": {"full_name": "averinaleks/bot"},
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("GITHUB_WORKSPACE", str(tmp_path))
+    monkeypatch.setenv("GITHUB_TOKEN", "dummy-token")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(payload_path))
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "repository_dispatch")
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+    monkeypatch.delenv("GITHUB_SHA", raising=False)
+    monkeypatch.delenv("GITHUB_REF", raising=False)
+    monkeypatch.setenv("GITHUB_RUN_ID", "789")
+    monkeypatch.setenv("GITHUB_WORKFLOW", "dependency-graph")
+    monkeypatch.setenv("GITHUB_JOB", "submit")
+
+    manifest: snapshot.Manifest = {
+        "name": "requirements.txt",
+        "file": {"source_location": "requirements.txt"},
+        "resolved": {
+            "httpx": {
+                "package_url": HTTPX_PURL,
+                "relationship": "direct",
+                "scope": "runtime",
+                "dependencies": [],
+            }
+        },
+    }
+    monkeypatch.setattr(snapshot, "_build_manifests", lambda _: {"requirements.txt": manifest})
+
+    submitted: dict[str, object] = {}
+
+    def capture_submission(url: str, body: bytes, headers: dict[str, str]) -> None:
+        del url, headers
+        submitted.update(json.loads(body))
+
+    monkeypatch.setattr(snapshot, "_submit_with_headers", capture_submission)
+
+    snapshot.submit_dependency_snapshot()
+
+    captured = capsys.readouterr()
+    assert "Missing required environment variable" not in captured.err
+    assert "Using event payload" in captured.out
+
+    assert submitted["sha"] == "feedface"
+    assert submitted["ref"] == "refs/heads/auto-main"
+    assert submitted["job"]["html_url"].endswith("/actions/runs/789")
+
+
 def test_submit_dependency_snapshot_prefers_payload_token(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- make the dependency snapshot script consume workflow_run data nested under client payloads so repository_dispatch auto-submission runs can recover repository, sha, and ref metadata
- extend the test suite with coverage for repository_dispatch events that only expose workflow_run details inside the client payload

## Testing
- pytest tests/test_dependency_snapshot.py

------
https://chatgpt.com/codex/tasks/task_b_68e2d8fa83188321ac6f7f228d0b9015