### PR TITLE
Fix mypy errors in RL agent and dependency snapshot script

### DIFF
--- a/model_builder/core.py
+++ b/model_builder/core.py
@@ -12,7 +12,7 @@ import tempfile
 import time
 from collections import deque
 from pathlib import Path
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import pandas as pd
@@ -306,6 +306,11 @@ except ImportError as e:  # pragma: no cover - optional dependency
     PPO = DQN = DummyVecEnv = None  # type: ignore
     SB3_AVAILABLE = False
     logger.warning("Не удалось импортировать stable_baselines3: %s", e)
+
+if TYPE_CHECKING:
+    from stable_baselines3.common.base_class import BaseAlgorithm as SB3BaseAlgorithm
+else:  # pragma: no cover - typing helper when SB3 is optional
+    SB3BaseAlgorithm = Any
 
 
 _torch_modules = None
@@ -2034,10 +2039,11 @@ class RLAgent:
                 )
                 return
             env = DummyVecEnv([lambda: TradingEnv(features_df, self.config)])
+            model: SB3BaseAlgorithm
             if algo == "DQN":
-                model = DQN("MlpPolicy", env, verbose=0)
+                model = cast(SB3BaseAlgorithm, DQN("MlpPolicy", env, verbose=0))
             else:
-                model = PPO("MlpPolicy", env, verbose=0)
+                model = cast(SB3BaseAlgorithm, PPO("MlpPolicy", env, verbose=0))
             model.learn(total_timesteps=timesteps)
             self.models[symbol] = model
         logger.info("RL-модель обучена для %s", symbol)

--- a/scripts/submit_dependency_snapshot.py
+++ b/scripts/submit_dependency_snapshot.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, Mapping, MutableMapping, TypedDict
 from urllib.parse import quote, urlparse
 
+_REQUESTS_IMPORT_ERROR: ImportError | None
 try:  # pragma: no cover - import guard exercised in tests
     import requests  # type: ignore
 except ImportError as import_error:  # pragma: no cover - requests may be absent in CI


### PR DESCRIPTION
## Summary
- annotate the dependency snapshot script import guard so the optional requests dependency exposes a consistent error placeholder
- add a stable-baselines3 base algorithm type alias and casts so RL training assigns models without mypy conflicts

## Testing
- mypy .
- pytest tests/test_run_dependabot_script.py tests/test_model_builder_cache.py -q

------
https://chatgpt.com/codex/tasks/task_b_68e2d934cc708321b4c64ecfe0af31a2