### PR TITLE
Align ccxt pin across compiled requirements

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -35,7 +35,7 @@ bcrypt==5.0.0
     # via -r requirements-core.in
 blinker==1.9.0
     # via flask
-ccxt==4.5.6
+ccxt==4.5.7
     # via -r requirements-core.in
 certifi==2025.8.3
     # via

--- a/requirements.out
+++ b/requirements.out
@@ -47,7 +47,7 @@ blinker==1.9.0
     # via
     #   -r requirements.txt
     #   flask
-ccxt==4.5.6
+ccxt==4.5.7
     # via -r requirements.txt
 certifi==2025.8.3
     # via


### PR DESCRIPTION
## Summary
- update `requirements-core.txt` and `requirements.out` to pin ccxt 4.5.7, matching the other manifests

## Testing
- `pytest -m "not integration" -q`


------
https://chatgpt.com/codex/tasks/task_b_68e2d93e43448321809da9a6fdc25080