### PR TITLE
Handle new pip CVE aliases in pip-audit wrapper

### DIFF
--- a/scripts/run_pip_audit.py
+++ b/scripts/run_pip_audit.py
@@ -51,8 +51,15 @@ def _should_ignore_vulnerability(
 ) -> bool:
     if spec.name.lower() != "pip":
         return False
+
     identifiers = {vulnerability.id.lower(), *(alias.lower() for alias in vulnerability.aliases)}
-    return "ghsa-4xh5-x5gv-qwph" in identifiers or "cve-2025-8869" in identifiers
+    ignored_ids = {
+        "ghsa-4xh5-x5gv-qwph",
+        "cve-2025-8869",
+        "pysec-2025-8869",
+        "bit-pip-2025-8869",
+    }
+    return bool(identifiers & ignored_ids)
 
 
 def _run_audit(strict: bool) -> Tuple[Dict[ResolvedDependency, List[VulnerabilityResult]], List[SkippedDependency]]:


### PR DESCRIPTION
## Summary
- extend the pip-audit helper to ignore the newest published aliases for the known pip CVE so CI stays green when metadata changes

## Testing
- pytest -q --maxfail=1 --disable-warnings

------
https://chatgpt.com/codex/tasks/task_b_68e2d971de788321b3d61f6f2548254c