### PR TITLE
Improve Trivy workflow robustness and refresh GPU dependencies

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -60,19 +60,31 @@ jobs:
         run: |
           set -o pipefail
           mkdir -p "${TRIVY_CACHE_DIR}"
+          max_attempts=3
+          attempt=1
           exit_code=0
-          if ! trivy fs \
-              --scanners vuln \
-              --severity HIGH,CRITICAL \
-              --ignore-unfixed \
-              --file-patterns 'pip:requirements*.txt' \
-              --file-patterns 'pip:requirements*.in' \
-              --format sarif \
-              --output trivy-results.sarif \
-              --cache-dir "${TRIVY_CACHE_DIR}" \
-              .; then
+          while [ "$attempt" -le "$max_attempts" ]; do
+            echo "Running Trivy scan (attempt ${attempt}/${max_attempts})"
+            if trivy fs \
+                --scanners vuln \
+                --severity HIGH,CRITICAL \
+                --ignore-unfixed \
+                --file-patterns 'pip:requirements*.txt' \
+                --file-patterns 'pip:requirements*.in' \
+                --format sarif \
+                --output trivy-results.sarif \
+                --cache-dir "${TRIVY_CACHE_DIR}" \
+                .; then
+              exit_code=0
+              break
+            fi
             exit_code=$?
-          fi
+            if [ "$attempt" -lt "$max_attempts" ]; then
+              echo "Trivy failed with exit code ${exit_code}. Retrying in 10 seconds..."
+              sleep 10
+            fi
+            attempt=$((attempt + 1))
+          done
           echo "exit_code=${exit_code}" >> "${GITHUB_OUTPUT}"
           if [ "${exit_code}" -ne 0 ]; then
             exit "${exit_code}"

--- a/requirements-gpu.in
+++ b/requirements-gpu.in
@@ -4,3 +4,5 @@ tensorflow==2.20.0
 keras>=3.11.3,<3.12
 jsonschema==4.25.1
 setuptools>=80.9.0,<81
+grpcio>=1.75.1
+protobuf>=6.32.1

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -33,7 +33,7 @@ gast==0.6.0
     # via tensorflow
 google-pasta==0.2.0
     # via tensorflow
-grpcio==1.74.0
+grpcio==1.75.1
     # via
     #   tensorboard
     #   tensorflow
@@ -131,7 +131,7 @@ packaging==25.0
     #   tensorflow
 pillow==11.3.0
     # via tensorboard
-protobuf==6.32.0
+protobuf==6.32.1
     # via
     #   tensorboard
     #   tensorflow


### PR DESCRIPTION
## Summary
- add retry logic to the Trivy filesystem scan step so transient failures are retried before aborting the job
- bump grpcio and protobuf pins in the GPU requirements to the latest patched releases to resolve the high-severity findings reported by Trivy

## Testing
- /tmp/trivy fs --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed --file-patterns 'pip:requirements*.txt' --file-patterns 'pip:requirements*.in' --format sarif --output trivy-results.sarif --cache-dir /tmp/trivy-cache .

------
https://chatgpt.com/codex/tasks/task_b_68e2d97bad9883218457d35aeab04e0e