### PR TITLE
Fix ruff lint errors in model_builder and snapshot script

### DIFF
--- a/model_builder/__init__.py
+++ b/model_builder/__init__.py
@@ -38,6 +38,17 @@ from .core import (
     validate_host,
 )
 
+from .storage import (
+    JOBLIB_AVAILABLE,
+    MODEL_DIR,
+    MODEL_FILE,
+    joblib,
+    save_artifacts,
+    _is_within_directory,
+    _resolve_model_artifact,
+    _safe_model_file_path,
+)
+
 _API_AVAILABLE = True
 _API_IMPORT_ERROR: ImportError | None = None
 _API_IMPORT_TRACEBACK = ""
@@ -90,16 +101,6 @@ except ImportError as exc:
     _api.ping = _api_stub("ping")
     _api.predict_route = _api_stub("predict_route")
     _api.train_route = _api_stub("train_route")
-from .storage import (
-    JOBLIB_AVAILABLE,
-    MODEL_DIR,
-    MODEL_FILE,
-    joblib,
-    save_artifacts,
-    _is_within_directory,
-    _resolve_model_artifact,
-    _safe_model_file_path,
-)
 
 api_app = _api.api_app
 configure_logging = _api.configure_logging

--- a/scripts/submit_dependency_snapshot.py
+++ b/scripts/submit_dependency_snapshot.py
@@ -6,7 +6,6 @@ import fnmatch
 import json
 import os
 import re
-import shutil
 import sys
 import time
 from collections import OrderedDict


### PR DESCRIPTION
## Summary
- move the `model_builder.storage` import to the top-level import section so ruff no longer reports E402
- drop the unused `shutil` import from `scripts/submit_dependency_snapshot.py`

## Testing
- pytest -m "not integration" -q
- ruff check

------
https://chatgpt.com/codex/tasks/task_b_68e364a5b7408321911a2293ff34103b