### PR TITLE
Fix lint errors for dependabot workflow

### DIFF
--- a/model_builder/__init__.py
+++ b/model_builder/__init__.py
@@ -37,6 +37,16 @@ from .core import (
     spaces,
     validate_host,
 )
+from .storage import (
+    JOBLIB_AVAILABLE,
+    MODEL_DIR,
+    MODEL_FILE,
+    joblib,
+    save_artifacts,
+    _is_within_directory,
+    _resolve_model_artifact,
+    _safe_model_file_path,
+)
 
 _API_AVAILABLE = True
 _API_IMPORT_ERROR: ImportError | None = None
@@ -90,16 +100,6 @@ except ImportError as exc:
     _api.ping = _api_stub("ping")
     _api.predict_route = _api_stub("predict_route")
     _api.train_route = _api_stub("train_route")
-from .storage import (
-    JOBLIB_AVAILABLE,
-    MODEL_DIR,
-    MODEL_FILE,
-    joblib,
-    save_artifacts,
-    _is_within_directory,
-    _resolve_model_artifact,
-    _safe_model_file_path,
-)
 
 api_app = _api.api_app
 configure_logging = _api.configure_logging

--- a/scripts/submit_dependency_snapshot.py
+++ b/scripts/submit_dependency_snapshot.py
@@ -6,7 +6,6 @@ import fnmatch
 import json
 import os
 import re
-import shutil
 import sys
 import time
 from collections import OrderedDict


### PR DESCRIPTION
## Summary
- move the storage import block in `model_builder.__init__` to the module top level to satisfy linting
- drop an unused `shutil` import from the dependency snapshot script

## Testing
- `ruff check`
- `pytest -m "not integration" -q`


------
https://chatgpt.com/codex/tasks/task_b_68e364af8db48321a171016a2d6b0aac