### PR TITLE
Ensure GPT-OSS review job only runs when required

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -132,15 +132,7 @@ jobs:
 
   review:
     needs: evaluate
-    if: >-
-      ${{ needs.evaluate.outputs.skip_reason == ''
-          && github.event_name != 'pull_request_target'
-          && (github.event_name != 'pull_request'
-              || github.event.pull_request.head.repo.full_name == github.repository)
-          && (github.event_name != 'issue_comment'
-              || github.event.comment.author_association == 'OWNER'
-              || github.event.comment.author_association == 'MEMBER'
-              || github.event.comment.author_association == 'COLLABORATOR') }}
+    if: ${{ needs.evaluate.outputs.run_review == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:


### PR DESCRIPTION
## Summary
- gate the GPT-OSS review job purely on the evaluate step's run_review output so that pull_request_target runs skip cleanly

## Testing
- pytest tests/test_gptoss_workflow_python3.py

------
https://chatgpt.com/codex/tasks/task_b_68e364bf012c8321be0244c2e812c423