### PR TITLE
Fix docker-publish CPU image missing C++ runtime libs

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -204,14 +204,17 @@ ARG DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 
 # Обновляем индекс пакетов и добавляем только необходимые зависимости
-# выполнения. libgomp1 требуется бинарям NumPy/Scikit-learn, а libssl3 — для
-# криптографических библиотек. ``apt-get upgrade`` не используется во
+# выполнения. ``libstdc++6`` и ``libgcc-s1`` требуются бинарям PyTorch/
+# TorchMetrics, ``libgomp1`` — NumPy/Scikit-learn, а ``libssl3`` —
+# криптографическим библиотекам. ``apt-get upgrade`` не используется во
 # исполнение требования Semgrep ``dockerfile.security.apt-get-upgrade``.
 RUN <<'EOSHELL'
 set -eux
 apt-get update
 apt-get install -y --no-install-recommends \
+    libgcc-s1 \
     libgomp1 \
+    libstdc++6 \
     libssl3
 rm -rf /var/lib/apt/lists/*
 EOSHELL


### PR DESCRIPTION
## Summary
- install libgcc-s1 and libstdc++6 in the CPU runtime stage to satisfy PyTorch/TorchMetrics
- document why each shared library is installed to aid future maintenance

## Testing
- `pytest tests/test_force_cpu.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68e364943b18832196fc42dfe47a4e1f