### PR TITLE
chore: resync dependency snapshots for auto submission

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,17 +26,11 @@ anyio==4.10.0
     #   httpx
     #   openai
     #   starlette
-async-timeout==5.0.1
-    # via aiohttp
 attrs==25.3.0
     # via
     #   aiohttp
     #   jsonschema
     #   referencing
-backports-asyncio-runner==1.2.0 ; python_version < "3.11"
-    # via
-    #   -r requirements-core.in
-    #   pytest-asyncio
 bcrypt==5.0.0
     # via -r requirements-core.in
 blinker==1.9.0
@@ -72,10 +66,6 @@ cycler==0.12.1
     # via matplotlib
 distro==1.9.0
     # via openai
-exceptiongroup==1.3.0
-    # via
-    #   anyio
-    #   pytest
 farama-notifications==0.0.4
     # via gymnasium
 fastapi==0.118.0
@@ -335,8 +325,6 @@ threadpoolctl==3.6.0
     #   scikit-learn
 tokenizers==0.22.0
     # via transformers
-tomli==2.2.1
-    # via pytest
 torch==2.8.0+cpu
     # via
     #   pytorch-lightning
@@ -355,17 +343,13 @@ transformers==4.56.2
     # via -r requirements-core.in
 typing-extensions==4.14.1
     # via
-    #   a2wsgi
     #   aiosignal
     #   anyio
     #   ccxt
-    #   cryptography
-    #   exceptiongroup
     #   fastapi
     #   gymnasium
     #   huggingface-hub
     #   lightning-utilities
-    #   multidict
     #   openai
     #   pydantic
     #   pydantic-core


### PR DESCRIPTION
## Summary
- regenerate requirements.txt from requirements-core.in with pip-compile so the automatic dependency submission validator sees an up-to-date snapshot

## Testing
- pytest
- pytest tests/test_data_handler_service_concurrency.py -k isolated


------
https://chatgpt.com/codex/tasks/task_b_68e3647399c88321a5025ef23ef8ed80