### PR TITLE
Fix Release Drafter concurrency expression

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -24,7 +24,13 @@ permissions:
   issues: write
 
 concurrency:
-  group: release-drafter-${{ github.event.pull_request.number || github.ref }}
+  group: >-
+    release-drafter-${{
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.number ||
+      github.ref ||
+      github.run_id
+    }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary
- guard the Release Drafter concurrency group against null pull request payloads
- fall back to the workflow ref or run identifier when no pull request context exists

------
https://chatgpt.com/codex/tasks/task_b_68e3f78ba96c8321a0de2dd1df5b61d5