### PR TITLE
Harden utils loader path resolution

### DIFF
--- a/bot/utils_loader.py
+++ b/bot/utils_loader.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import stat
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -12,6 +13,65 @@ _UTILS_CACHE: ModuleType | None = None
 _ALLOWED_MODULE_NAMES = ("utils", "bot.utils")
 
 
+def _project_root() -> Path:
+    """Return the repository root used for resolving ``utils.py``."""
+
+    return Path(__file__).resolve().parent.parent
+
+
+def _resolve_utils_path(base: Path | None = None) -> Path:
+    """Return a secure absolute path to ``utils.py`` within *base*.
+
+    The helper verifies that the target exists, is a regular file, and resides
+    inside the expected repository directory.  Symlinks are explicitly rejected
+    to avoid time-of-check/time-of-use attacks where an attacker could swap in a
+    different module between checks.  ``ImportError`` is raised whenever the
+    invariants cannot be satisfied so callers can surface a clear failure
+    message to operators.
+    """
+
+    root = base if base is not None else _project_root()
+    try:
+        resolved_root = root.resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise ImportError(
+            f"Project root {root} is unavailable"
+        ) from exc
+    except OSError as exc:
+        raise ImportError(f"Unable to resolve project root {root}: {exc}") from exc
+
+    candidate = root / "utils.py"
+    try:
+        if candidate.is_symlink():
+            raise ImportError("Refusing to load utils.py through a symlink")
+    except OSError as exc:
+        raise ImportError(f"Unable to inspect utils.py at {candidate}: {exc}") from exc
+
+    try:
+        resolved_candidate = candidate.resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise ImportError(f"utils.py not found at {candidate}") from exc
+    except OSError as exc:
+        raise ImportError(f"Unable to resolve utils.py at {candidate}: {exc}") from exc
+
+    try:
+        stat_info = resolved_candidate.stat()
+    except OSError as exc:
+        raise ImportError(f"Unable to stat utils.py at {resolved_candidate}: {exc}") from exc
+
+    if not stat.S_ISREG(stat_info.st_mode):
+        raise ImportError("utils.py must be a regular file")
+
+    try:
+        resolved_candidate.relative_to(resolved_root)
+    except ValueError as exc:
+        raise ImportError(
+            f"Resolved utils.py {resolved_candidate} escapes project root {resolved_root}"
+        ) from exc
+
+    return resolved_candidate
+
+
 def _load_from_source() -> ModuleType:
     """Load the real ``utils`` module directly from its source file."""
 
@@ -19,8 +79,7 @@ def _load_from_source() -> ModuleType:
     if _UTILS_CACHE is not None:
         return _UTILS_CACHE
 
-    project_root = Path(__file__).resolve().parent.parent
-    utils_path = project_root / "utils.py"
+    utils_path = _resolve_utils_path()
     spec = importlib.util.spec_from_file_location("_bot_real_utils", utils_path)
     if spec is None:
         raise ImportError(f"Unable to load utils module from {utils_path!s}")

--- a/tests/test_utils_loader_security.py
+++ b/tests/test_utils_loader_security.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from bot import utils_loader
+
+
+@pytest.fixture(autouse=True)
+def _reset_utils_loader_cache():
+    original_cache = utils_loader._UTILS_CACHE
+    utils_loader._UTILS_CACHE = None
+    try:
+        yield
+    finally:
+        utils_loader._UTILS_CACHE = original_cache
+
+
+def test_resolve_utils_path_rejects_symlink(tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    outside = tmp_path / "outside.py"
+    outside.write_text("VALUE = 1", encoding="utf-8")
+    target = project_root / "utils.py"
+    target.symlink_to(outside)
+
+    with pytest.raises(ImportError, match="symlink"):
+        utils_loader._resolve_utils_path(project_root)
+
+
+def test_resolve_utils_path_requires_regular_file(tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    utils_dir = project_root / "utils.py"
+    utils_dir.mkdir(parents=True)
+
+    with pytest.raises(ImportError, match="regular file"):
+        utils_loader._resolve_utils_path(project_root)
+
+
+def test_load_from_source_uses_secure_path(tmp_path: Path, monkeypatch) -> None:
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    utils_path = project_root / "utils.py"
+    utils_path.write_text("VALUE = 1\n", encoding="utf-8")
+
+    monkeypatch.setattr(utils_loader, "_project_root", lambda: project_root)
+    monkeypatch.setattr(utils_loader, "_UTILS_CACHE", None)
+
+    original_stub = sys.modules.pop("_bot_real_utils", None)
+    try:
+        resolved = utils_loader._resolve_utils_path()
+        assert resolved == utils_path.resolve()
+
+        module = utils_loader._load_from_source()
+        assert getattr(module, "VALUE") == 1
+    finally:
+        if original_stub is not None:
+            sys.modules["_bot_real_utils"] = original_stub
+        else:
+            sys.modules.pop("_bot_real_utils", None)


### PR DESCRIPTION
## Summary
- guard the utils loader against symlinked or out-of-tree utils.py targets
- add regression tests covering the secure path resolution logic

## Testing
- pytest tests/test_utils_loader_security.py
- bandit -r . -ll -ii -x ./tests,./scripts,./gptoss_check -f sarif -o bandit.sarif

------
https://chatgpt.com/codex/tasks/task_b_68e3f721f0f0832198e39728861862ca