### PR TITLE
Align cryptography pins for dependabot workflow

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -58,7 +58,7 @@ cloudpickle==3.1.1
     #   stable-baselines3
 contourpy==1.3.3
     # via matplotlib
-cryptography==46.0.1
+cryptography==46.0.2
     # via
     #   -r requirements-core.in
     #   ccxt

--- a/requirements.out
+++ b/requirements.out
@@ -79,7 +79,7 @@ contourpy==1.3.3
     # via
     #   -r requirements.txt
     #   matplotlib
-cryptography==46.0.1
+cryptography==46.0.2
     # via
     #   -r requirements.txt
     #   ccxt


### PR DESCRIPTION
## Summary
- update the cryptography pin in requirements-core.txt to 46.0.2 so dependabot upgrades apply cleanly
- regenerate the compiled requirements.out entry to match the new cryptography version

## Testing
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_b_68e3f75df1248321a08c62d7c92de4f6