### PR TITLE
Fix dependency graph workflow event type parsing

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -10,7 +10,7 @@ on:
       # Custom type used by auto-submission hooks. GitHub restricts repository
       # dispatch event names to alphanumeric characters plus '-' and '_', so we
       # cannot include a '/' separator here.
-      - dependency-graph-auto-submission
+      - "dependency-graph-auto-submission"
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- quote the repository_dispatch event type so GitHub parses the workflow correctly

## Testing
- pytest tests/test_dependency_graph_workflow.py -q

------
https://chatgpt.com/codex/tasks/task_b_68e3f713284c8321a9f5071d387b8216