### PR TITLE
Handle filesystem errors in dependency graph workflow

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -271,6 +271,12 @@ jobs:
                       flush=True,
                   )
                   continue
+              except OSError as exc:
+                  print(
+                      f"Skipping {path} due to filesystem error: {exc}",
+                      flush=True,
+                  )
+                  continue
               lines = original.splitlines(keepends=True)
               filtered: list[str] = []
               for line in lines:
@@ -283,7 +289,13 @@ jobs:
                   filtered.append(line)
               if filtered != lines:
                   updated = "".join(filtered)
-                  path.write_text(updated, encoding="utf-8")
+                  try:
+                      path.write_text(updated, encoding="utf-8")
+                  except OSError as exc:
+                      print(
+                          f"::warning::Unable to update {path}: {exc}",
+                          flush=True,
+                      )
           PY
       - name: Submit dependency snapshot
         if: >-

--- a/tests/test_dependency_graph_workflow.py
+++ b/tests/test_dependency_graph_workflow.py
@@ -107,6 +107,14 @@ def test_dependency_graph_filters_ccxtpro_lines_before_snapshot() -> None:
     assert 'if stripped_lower.startswith("#") and "ccxtpro" in stripped_lower' in workflow
 
 
+def test_dependency_graph_prepare_step_handles_filesystem_errors() -> None:
+    workflow = Path(".github/workflows/dependency-graph.yml").read_text(encoding="utf-8")
+
+    assert "except OSError as exc" in workflow
+    assert "due to filesystem error" in workflow
+    assert "::warning::Unable to update" in workflow
+
+
 def test_dependency_graph_supports_repository_dispatch_auto_submission() -> None:
     workflow = Path(".github/workflows/dependency-graph.yml").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- guard the dependency graph workflow against filesystem read/write failures when sanitising requirements files
- cover the new safeguards in the dependency graph workflow regression tests

## Testing
- pytest tests/test_dependency_graph_workflow.py -q

------
https://chatgpt.com/codex/tasks/task_b_68e3f774d1a88321b09f361b267632d8