### PR TITLE
Skip GPT-OSS review workflow on pull_request_target events

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -119,7 +119,7 @@ jobs:
 
   skip:
     needs: evaluate
-    if: ${{ needs.evaluate.outputs.skip_reason != '' }}
+    if: ${{ needs.evaluate.outputs.skip_reason != '' || github.event_name == 'pull_request_target' }}
     runs-on: ubuntu-latest
     steps:
       - name: Skip unsupported event
@@ -132,7 +132,7 @@ jobs:
 
   review:
     needs: evaluate
-    if: ${{ needs.evaluate.outputs.run_review == 'true' }}
+    if: ${{ needs.evaluate.outputs.run_review == 'true' && github.event_name != 'pull_request_target' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:

--- a/tests/test_gptoss_workflow_python3.py
+++ b/tests/test_gptoss_workflow_python3.py
@@ -48,3 +48,23 @@ def test_pr_status_step_skips_pull_request_target() -> None:
 
     assert guard_snippet in workflow_text
     assert notice_message in workflow_text
+
+
+def test_review_job_skips_target_events() -> None:
+    workflow_text = WORKFLOW_PATH.read_text(encoding='utf-8')
+
+    condition = (
+        "needs.evaluate.outputs.run_review == 'true' && github.event_name != 'pull_request_target'"
+    )
+
+    assert condition in workflow_text
+
+
+def test_skip_job_covers_target_events() -> None:
+    workflow_text = WORKFLOW_PATH.read_text(encoding='utf-8')
+
+    condition = (
+        "needs.evaluate.outputs.skip_reason != '' || github.event_name == 'pull_request_target'"
+    )
+
+    assert condition in workflow_text


### PR DESCRIPTION
## Summary
- block the GPT-OSS review job from executing on pull_request_target events and keep the skip message job active
- extend the workflow tests to assert the new guards for review and skip jobs

## Testing
- pytest tests/test_gptoss_workflow_python3.py

------
https://chatgpt.com/codex/tasks/task_b_68e3f77ff9e48321ba41d9c059d293e4