### PR TITLE
Handle aiohttp errors in position monitoring

### DIFF
--- a/bot/trade_manager/core.py
+++ b/bot/trade_manager/core.py
@@ -1600,7 +1600,13 @@ class TradeManager:
                 await asyncio.sleep(self.check_interval)
             except asyncio.CancelledError:
                 raise
-            except (ValueError, RuntimeError, KeyError, httpx.HTTPError) as e:
+            except (
+                ValueError,
+                RuntimeError,
+                KeyError,
+                httpx.HTTPError,
+                aiohttp.ClientError,
+            ) as e:
                 logger.exception(
                     "Error managing positions (%s): %s",
                     type(e).__name__,

--- a/position_manager.py
+++ b/position_manager.py
@@ -5,9 +5,15 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import inspect
+import types
 from typing import Optional
 
 import httpx
+
+try:  # pragma: no cover - optional dependency in minimal environments
+    import aiohttp  # type: ignore
+except Exception:  # pragma: no cover - fallback when aiohttp unavailable
+    aiohttp = types.SimpleNamespace(ClientError=Exception)  # type: ignore[assignment]
 
 from bot.utils import check_dataframe_empty_async as _check_df_async, logger
 
@@ -52,7 +58,13 @@ class PositionManager:
                 await asyncio.sleep(self.check_interval)
             except asyncio.CancelledError:
                 raise
-            except (ValueError, RuntimeError, KeyError, httpx.HTTPError) as exc:
+            except (
+                ValueError,
+                RuntimeError,
+                KeyError,
+                httpx.HTTPError,
+                aiohttp.ClientError,
+            ) as exc:
                 logger.exception("PositionManager failed (%s): %s", type(exc).__name__, exc)
                 await asyncio.sleep(self.check_interval)
 


### PR DESCRIPTION
## Summary
- extend the position and trade manager loops to catch aiohttp client errors alongside httpx failures
- parameterize the loop recovery tests to cover both httpx and aiohttp exception types

## Testing
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_b_68e3f7698380832196ba6fc41560d1a9