### PR TITLE
Use shared dotenv loader in config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "numpy>=2.2.6",
     "pydantic>=2.11.7",
     "cloudpickle>=3.1",
+    "python-dotenv>=1.0.1",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary
- add python-dotenv to the core project dependencies
- switch config.py to reuse bot.dotenv_utils.dotenv_values so optional dotenv handling is centralized

## Testing
- pytest tests/test_env_parsing.py

------
https://chatgpt.com/codex/tasks/task_b_68e402389a0c8321b6d701e79c420e45