### PR TITLE
Refactor trade manager state handling

### DIFF
--- a/tests/integration/test_offline_trade_manager_service.py
+++ b/tests/integration/test_offline_trade_manager_service.py
@@ -42,7 +42,8 @@ def offline_trade_manager(monkeypatch, tmp_path):
 
         cache_file = tmp_path / "positions.json"
         monkeypatch.setattr(module, "POSITIONS_FILE", cache_file)
-        module.POSITIONS.clear()
+        state = module._get_state()
+        state.clear_positions()
         if cache_file.exists():
             cache_file.unlink()
         module._load_positions()
@@ -50,17 +51,17 @@ def offline_trade_manager(monkeypatch, tmp_path):
         module.init_exchange()
 
         with module.app.test_client() as client:
-            yield module, client, NetworkError
+            yield module, client, NetworkError, state
     finally:
         module = sys.modules.pop(module_name, None)
         if original_module is not None:
             sys.modules[module_name] = original_module
         if module is not None:
-            module.exchange = None
+            module._get_state().set_exchange(None)
 
 
 def test_offline_open_close_cycle(offline_trade_manager):
-    module, client, _ = offline_trade_manager
+    module, client, _, state = offline_trade_manager
 
     open_payload = {
         "symbol": "BTCUSDT",
@@ -87,18 +88,19 @@ def test_offline_open_close_cycle(offline_trade_manager):
     assert close_data["status"] == "ok"
 
     # Positions should be cleared after the successful close request.
-    assert module.POSITIONS == []
+    assert not state.snapshot_positions()
 
 
 def test_offline_open_position_network_degradation(monkeypatch, offline_trade_manager):
-    module, client, network_error = offline_trade_manager
+    module, client, network_error, state = offline_trade_manager
 
-    original_create_order = module.exchange.create_order
+    exchange = state.get_exchange()
+    original_create_order = exchange.create_order
 
     def flaky_create_order(*args, **kwargs):
         raise network_error("temporary outage")
 
-    monkeypatch.setattr(module.exchange, "create_order", flaky_create_order)
+    monkeypatch.setattr(exchange, "create_order", flaky_create_order)
 
     response = client.post(
         "/open_position",
@@ -107,28 +109,30 @@ def test_offline_open_position_network_degradation(monkeypatch, offline_trade_ma
     assert response.status_code == 503
     payload = response.get_json()
     assert payload["error"] == "network error contacting exchange"
-    assert module.POSITIONS == []
+    assert not state.snapshot_positions()
 
     # Restore the original implementation so subsequent tests can reuse the fixture safely.
-    monkeypatch.setattr(module.exchange, "create_order", original_create_order)
+    monkeypatch.setattr(exchange, "create_order", original_create_order)
 
 
 def test_offline_close_position_network_degradation(monkeypatch, offline_trade_manager):
-    module, client, network_error = offline_trade_manager
+    module, client, network_error, state = offline_trade_manager
 
     open_response = client.post(
         "/open_position",
         json={"symbol": "SOLUSDT", "side": "buy", "amount": 2, "price": 40.0},
     )
     order_id = open_response.get_json()["order_id"]
-    assert module.POSITIONS and module.POSITIONS[0]["id"] == order_id
+    positions = state.snapshot_positions()
+    assert positions and positions[0]["id"] == order_id
 
-    original_create_order = module.exchange.create_order
+    exchange = state.get_exchange()
+    original_create_order = exchange.create_order
 
     def failing_close(symbol, order_type, side, amount, price=None, params=None):
         raise network_error("connection reset")
 
-    monkeypatch.setattr(module.exchange, "create_order", failing_close)
+    monkeypatch.setattr(exchange, "create_order", failing_close)
 
     close_response = client.post(
         "/close_position", json={"order_id": order_id, "side": "sell"}
@@ -138,20 +142,21 @@ def test_offline_close_position_network_degradation(monkeypatch, offline_trade_m
     assert payload["error"] == "network error contacting exchange"
 
     # Original position should remain intact so operators can retry.
-    assert module.POSITIONS and module.POSITIONS[0]["id"] == order_id
+    positions = state.snapshot_positions()
+    assert positions and positions[0]["id"] == order_id
 
-    monkeypatch.setattr(module.exchange, "create_order", original_create_order)
+    monkeypatch.setattr(exchange, "create_order", original_create_order)
 
 
 def test_offline_recovers_from_corrupted_cache(offline_trade_manager):
-    module, client, _ = offline_trade_manager
+    module, client, _, state = offline_trade_manager
 
     module.POSITIONS_FILE.parent.mkdir(parents=True, exist_ok=True)
     module.POSITIONS_FILE.write_text("{not-valid-json", encoding="utf-8")
 
     # Corrupted cache should be ignored when reloading state.
     module._load_positions()
-    assert module.POSITIONS == []
+    assert not state.snapshot_positions()
 
     response = client.post(
         "/open_position",

--- a/tests/test_trade_manager_service_api.py
+++ b/tests/test_trade_manager_service_api.py
@@ -13,10 +13,12 @@ def _reset_positions(tmp_path, monkeypatch):
     from services import trade_manager_service as tms
 
     cache_file = tmp_path / 'positions.json'
-    monkeypatch.setattr(tms, 'POSITIONS_FILE', cache_file)
-    monkeypatch.setattr(tms, 'POSITIONS', [])
+    monkeypatch.setattr(tms, 'POSITIONS_FILE', cache_file, raising=False)
     monkeypatch.setattr(tms, 'API_TOKEN', 'test-token')
     tms.exchange_provider.override(None)
+    state = tms._get_state()
+    state.clear_positions()
+    state.set_exchange(None)
     yield
     tms.exchange_provider.close()
 
@@ -148,7 +150,7 @@ def test_open_position_records_even_when_stop_loss_fails(monkeypatch):
 
     from services import trade_manager_service as tms_reload
 
-    assert len(tms_reload.POSITIONS) == 1
+    assert len(tms_reload._get_state().snapshot_positions()) == 1
 
 
 def test_open_position_warns_when_positions_cache_fails(monkeypatch, caplog):
@@ -159,6 +161,7 @@ def test_open_position_warns_when_positions_cache_fails(monkeypatch, caplog):
             return {'id': 'primary'}
 
     tms.exchange_provider.override(Exchange())
+    state = tms._get_state()
 
     def failing_replace(*_args, **_kwargs):
         raise OSError('disk full')
@@ -177,7 +180,7 @@ def test_open_position_warns_when_positions_cache_fails(monkeypatch, caplog):
     warning = payload['warnings']['positions_cache_failed']
     assert warning['message'] == 'не удалось обновить кэш позиций'
     assert 'details' in warning
-    assert len(tms.POSITIONS) == 1
+    assert len(state.snapshot_positions()) == 1
     assert any('не удалось обновить кэш позиций' in record.getMessage() for record in caplog.records)
 
 
@@ -221,7 +224,7 @@ def test_open_position_emergency_close_when_cancel_unavailable(monkeypatch):
 
     from services import trade_manager_service as tms_reload
 
-    assert len(tms_reload.POSITIONS) == 1
+    assert len(tms_reload._get_state().snapshot_positions()) == 1
 
 
 def test_close_position_warns_when_positions_cache_fails(monkeypatch, caplog):
@@ -232,9 +235,17 @@ def test_close_position_warns_when_positions_cache_fails(monkeypatch, caplog):
             return {'id': 'close'}
 
     tms.exchange_provider.override(Exchange())
-    tms.POSITIONS.append(
-        {'id': 'open-order', 'symbol': 'BTCUSDT', 'side': 'buy', 'amount': 1, 'action': 'open'}
-    )
+    state = tms._get_state()
+    with state.positions_guard() as positions:
+        positions.append(
+            {
+                'id': 'open-order',
+                'symbol': 'BTCUSDT',
+                'side': 'buy',
+                'amount': 1,
+                'action': 'open',
+            }
+        )
 
     def failing_dump(*_args, **_kwargs):
         raise OSError('disk full')
@@ -254,7 +265,7 @@ def test_close_position_warns_when_positions_cache_fails(monkeypatch, caplog):
     warning = payload['warnings']['positions_cache_failed']
     assert warning['message'] == 'не удалось обновить кэш позиций'
     assert 'details' in warning
-    assert not tms.POSITIONS
+    assert not state.snapshot_positions()
     assert any('не удалось обновить кэш позиций' in record.getMessage() for record in caplog.records)
 
 

--- a/tests/test_trade_manager_service_sync.py
+++ b/tests/test_trade_manager_service_sync.py
@@ -16,7 +16,8 @@ def _reload_service(monkeypatch, tmp_path, exchange):
     monkeypatch.setenv('TRADE_MANAGER_TOKEN', 'token')
     service = importlib.reload(importlib.import_module('services.trade_manager_service'))
     service.POSITIONS_FILE = tmp_path / 'positions.json'
-    service.POSITIONS[:] = []
+    state = service._get_state()
+    state.replace_positions([])
     service.exchange_provider.override(exchange)
     # Bandit note - a placeholder token is used solely for fixture initialisation.
     service.API_TOKEN = secrets.token_hex(8)
@@ -36,15 +37,18 @@ def test_sync_removes_closed_positions(monkeypatch, tmp_path):
 
     exchange = DummyExchange()
     service = _reload_service(monkeypatch, tmp_path, exchange)
-    service.POSITIONS[:] = [
-        {'id': '1', 'symbol': 'BTCUSDT', 'side': 'buy', 'amount': 1, 'action': 'open'},
-        {'id': '2', 'symbol': 'ETHUSDT', 'side': 'sell', 'amount': 2, 'action': 'open'},
-    ]
+    state = service._get_state()
+    state.replace_positions(
+        [
+            {'id': '1', 'symbol': 'BTCUSDT', 'side': 'buy', 'amount': 1, 'action': 'open'},
+            {'id': '2', 'symbol': 'ETHUSDT', 'side': 'sell', 'amount': 2, 'action': 'open'},
+        ]
+    )
     service._save_positions()
 
     service._sync_positions_with_exchange(exchange)
 
-    assert [pos['id'] for pos in service.POSITIONS] == ['2']
+    assert [pos['id'] for pos in state.snapshot_positions()] == ['2']
     with service.POSITIONS_FILE.open('r', encoding='utf-8') as fh:
         cached = json.load(fh)
     assert [pos['id'] for pos in cached] == ['2']
@@ -61,9 +65,12 @@ def test_positions_endpoint_triggers_sync(monkeypatch, tmp_path):
 
     exchange = DummyExchange()
     service = _reload_service(monkeypatch, tmp_path, exchange)
-    service.POSITIONS[:] = [
-        {'id': '1', 'symbol': 'BTCUSDT', 'side': 'buy', 'amount': 1, 'action': 'open'},
-    ]
+    state = service._get_state()
+    state.replace_positions(
+        [
+            {'id': '1', 'symbol': 'BTCUSDT', 'side': 'buy', 'amount': 1, 'action': 'open'},
+        ]
+    )
     response = service.app.test_client().get(
         '/positions',
         headers={'Authorization': 'Bearer token'},


### PR DESCRIPTION
## Summary
- introduce a TradeManagerState container to guard exchange access and position storage in the trade manager service
- update exchange binding, persistence helpers, and routes to use the shared state instance
- adapt trade manager service tests and offline integration fixtures to work with the new state API

## Testing
- pytest tests/test_trade_manager_service_sync.py tests/test_trade_manager_service_api.py tests/integration/test_offline_trade_manager_service.py

------
https://chatgpt.com/codex/tasks/task_b_68e401fd3ac08321b1d524b84b928825