### PR TITLE
Require API token for TradeManager positions endpoint

### DIFF
--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -124,11 +124,18 @@ def _bind_exchange() -> None:
         exchange = runtime.bind()
 
 
+_UNAUTHENTICATED_PATHS: frozenset[str] = frozenset({'/ping', '/ready'})
+_UNAUTHENTICATED_METHODS: frozenset[str] = frozenset({'GET', 'HEAD'})
+
+
 @app.before_request
 def _require_api_token() -> ResponseReturnValue | None:
     """Simple token-based authentication middleware."""
 
-    if request.method != 'POST' and request.path != '/positions':
+    if (
+        request.path in _UNAUTHENTICATED_PATHS
+        and request.method.upper() in _UNAUTHENTICATED_METHODS
+    ):
         return None
 
     expected = _resolve_expected_token()

--- a/tests/services/test_trade_manager_service.py
+++ b/tests/services/test_trade_manager_service.py
@@ -1,0 +1,32 @@
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def trade_manager_service(monkeypatch):
+    module = importlib.reload(importlib.import_module('services.trade_manager_service'))
+    monkeypatch.setattr(module, 'API_TOKEN', 'test-token')
+    monkeypatch.setenv('TRADE_MANAGER_TOKEN', 'test-token')
+    monkeypatch.delenv('OFFLINE_MODE', raising=False)
+    monkeypatch.delenv('TRADE_MANAGER_USE_STUB', raising=False)
+    monkeypatch.setattr(module, 'POSITIONS', [])
+    return module
+
+
+def test_positions_requires_token(trade_manager_service):
+    with trade_manager_service.app.test_client() as client:
+        response = client.get('/positions')
+
+    assert response.status_code == 401
+    assert response.get_json() == {'error': 'unauthorized'}
+
+
+def test_positions_allows_requests_with_valid_token(trade_manager_service):
+    with trade_manager_service.app.test_client() as client:
+        response = client.get(
+            '/positions', headers={'Authorization': 'Bearer test-token'}
+        )
+
+    assert response.status_code == 200
+    assert response.get_json() == {'positions': []}


### PR DESCRIPTION
## Summary
- enforce the TradeManager token middleware with an explicit whitelist for health-check routes only
- add service-level tests ensuring GET /positions responds with 401 without a token and 200 with a valid token

## Testing
- pytest tests/services/test_trade_manager_service.py

------
https://chatgpt.com/codex/tasks/task_b_68e40208a7288321a5ce6ec3fb545bf1