### PR TITLE
Refine Release Drafter concurrency configuration

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -23,20 +23,17 @@ permissions:
   pull-requests: write
   issues: write
 
-concurrency:
-  group: >-
-    release-drafter-${{
-      github.event_name == 'pull_request_target' &&
-      github.event.pull_request.number ||
-      github.ref ||
-      github.run_id
-    }}
-  cancel-in-progress: false
-
 jobs:
   update_release_draft:
     if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
+    concurrency:
+      group: >-
+        release-drafter-${{
+          github.ref ||
+          github.run_id
+        }}
+      cancel-in-progress: false
     steps:
       - name: Update release draft
         uses: release-drafter/release-drafter@v6.1.0 # Latest available release as of 2025-10-05
@@ -52,6 +49,12 @@ jobs:
       github.event.pull_request.head.repo != null &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    concurrency:
+      group: >-
+        release-drafter-pr-${{
+          github.event.pull_request.number
+        }}
+      cancel-in-progress: false
     steps:
       - name: Update pull request metadata
         uses: release-drafter/release-drafter@v6.1.0 # Latest available release as of 2025-10-05


### PR DESCRIPTION
## Summary
- move concurrency settings from the workflow level to the individual jobs
- scope push runs to branch-based concurrency and PR runs to pull request numbers

## Testing
- /root/.local/share/mise/installs/go/1.24.3/bin/actionlint .github/workflows/release-drafter.yml

------
https://chatgpt.com/codex/tasks/task_b_68e40bc522008321b4a50cfe58771d68