### PR TITLE
Configure pip-tools defaults and refresh locks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,3 +56,7 @@ line-length = 120
 [tool.ruff.lint]
 select = ["E", "F"]
 per-file-ignores = {"tests/*" = ["E402"]}
+
+[tool.pip-tools]
+pip-args = ["--extra-index-url", "https://download.pytorch.org/whl/cpu"]
+strip-extras = true

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -185,7 +185,7 @@ numpy==2.2.6
     #   ta
     #   torchmetrics
     #   transformers
-openai==1.109.1
+openai==2.1.0
     # via -r requirements-core.in
 packaging==25.0
     # via
@@ -339,7 +339,7 @@ tqdm==4.67.1
     #   pytorch-lightning
     #   shap
     #   transformers
-transformers==4.56.2
+transformers==4.57.0
     # via -r requirements-core.in
 typing-extensions==4.14.1
     # via
@@ -353,6 +353,7 @@ typing-extensions==4.14.1
     #   openai
     #   pydantic
     #   pydantic-core
+    #   pytest-asyncio
     #   pytorch-lightning
     #   referencing
     #   shap

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -35,6 +35,7 @@ google-pasta==0.2.0
     # via tensorflow
 grpcio==1.75.1
     # via
+    #   -r requirements-gpu.in
     #   tensorboard
     #   tensorflow
 h5py==3.14.0
@@ -133,6 +134,7 @@ pillow==11.3.0
     # via tensorboard
 protobuf==6.32.1
     # via
+    #   -r requirements-gpu.in
     #   tensorboard
     #   tensorflow
 pygments==2.19.2
@@ -170,6 +172,7 @@ triton==3.4.0
     # via torch
 typing-extensions==4.14.1
     # via
+    #   grpcio
     #   optree
     #   referencing
     #   tensorflow

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,17 +26,11 @@ anyio==4.10.0
     #   httpx
     #   openai
     #   starlette
-async-timeout==5.0.1
-    # via aiohttp
 attrs==25.3.0
     # via
     #   aiohttp
     #   jsonschema
     #   referencing
-backports-asyncio-runner==1.2.0 ; python_version < "3.11"
-    # via
-    #   -r requirements-core.in
-    #   pytest-asyncio
 bcrypt==5.0.0
     # via -r requirements-core.in
 blinker==1.9.0
@@ -72,10 +66,6 @@ cycler==0.12.1
     # via matplotlib
 distro==1.9.0
     # via openai
-exceptiongroup==1.3.0
-    # via
-    #   anyio
-    #   pytest
 farama-notifications==0.0.4
     # via gymnasium
 fastapi==0.118.0
@@ -337,8 +327,6 @@ threadpoolctl==3.6.0
     #   scikit-learn
 tokenizers==0.22.0
     # via transformers
-tomli==2.2.1
-    # via pytest
 torch==2.8.0+cpu
     # via
     #   pytorch-lightning
@@ -357,17 +345,13 @@ transformers==4.57.0
     # via -r requirements-core.in
 typing-extensions==4.14.1
     # via
-    #   a2wsgi
     #   aiosignal
     #   anyio
     #   ccxt
-    #   cryptography
-    #   exceptiongroup
     #   fastapi
     #   gymnasium
     #   huggingface-hub
     #   lightning-utilities
-    #   multidict
     #   openai
     #   pydantic
     #   pydantic-core


### PR DESCRIPTION
## Summary
- add tool.pip-tools defaults so pip-compile uses the PyTorch CPU index and strips extras by default
- recompile requirements.txt, requirements-core.txt, and requirements-gpu.txt with pip-compile to capture the latest pins

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e40cc1f4ec8321b8289f446b3f83f6