### PR TITLE
Fix Trivy workflow conditional logic

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -47,12 +47,16 @@ jobs:
           limit-severities-for-sarif: true
 
       - name: Summarize Trivy findings
+        id: summarize
         if: always()
+        shell: bash
         run: |
           if [ ! -f trivy-results.sarif ]; then
             printf '### Trivy scan summary\n\n* Отчёт Trivy не был создан.\n' >> "$GITHUB_STEP_SUMMARY"
+            echo "sarif=false" >>"$GITHUB_OUTPUT"
             exit 0
           fi
+          echo "sarif=true" >>"$GITHUB_OUTPUT"
           if command -v jq >/dev/null 2>&1; then
             count=$(jq -r '[.runs[]?.results[]?] | length' trivy-results.sarif)
           else
@@ -63,7 +67,7 @@ jobs:
           printf '### Trivy scan summary\n\n* Найдено high/critical уязвимостей: `%s`\n' "$count" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload Trivy SARIF to GitHub Security tab
-        if: ${{ github.event_name != 'pull_request' && always() && hashFiles('trivy-results.sarif') != '' }}
+        if: ${{ github.event_name != 'pull_request' && always() && steps.summarize.outputs.sarif == 'true' }}
         uses: github/codeql-action/upload-sarif@64d10c13136e1c5bce3e5fbde8d4906eeaafc885
         # v3.30.6
         with:
@@ -71,7 +75,7 @@ jobs:
           sarif_file: trivy-results.sarif
 
       - name: Upload Trivy report artifact
-        if: ${{ always() && hashFiles('trivy-results.sarif') != '' }}
+        if: ${{ always() && steps.summarize.outputs.sarif == 'true' }}
         uses: actions/upload-artifact@604f733a2e36051e8c3ab8bb4ff7f266622f8dba
         # v4.4.0
         with:


### PR DESCRIPTION
## Summary
- emit an explicit output from the Trivy summary step that notes whether a SARIF file was created
- guard the SARIF upload and artifact steps with the new output instead of hashFiles, avoiding invalid workflow evaluation

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68e40dd4b04c8321ba1958e408c4b0c0