### PR TITLE
Handle missing httpx dependency with stub fallback

### DIFF
--- a/model_builder_client.py
+++ b/model_builder_client.py
@@ -9,7 +9,16 @@ from ipaddress import ip_address
 from typing import Any, Iterable, List, Optional, Sequence, Tuple, cast
 from urllib.parse import urlparse
 
-import httpx
+try:
+    import httpx
+except ImportError:  # pragma: no cover - exercised in dedicated test
+    from services.stubs import create_httpx_stub, is_offline_env
+
+    httpx = create_httpx_stub()
+    if not is_offline_env():
+        logging.getLogger("TradingBot").warning(
+            "Модуль httpx не найден: используется оффлайн-стаб"
+        )
 
 from bot import config as bot_config
 from services.logging_utils import sanitize_log_value

--- a/tests/test_model_builder_client.py
+++ b/tests/test_model_builder_client.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import asyncio
+import importlib
+import builtins
+import sys
+
+
+def test_model_builder_client_uses_httpx_stub(monkeypatch):
+    original_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "httpx":
+            raise ImportError("httpx not installed for test")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    module_name = "model_builder_client"
+    original_module = sys.modules.pop(module_name, None)
+
+    try:
+        module = importlib.import_module(module_name)
+        assert getattr(module.httpx, "__offline_stub__", False) is True
+
+        client = module.httpx.Client()
+        response = client.post("https://example.test", json={"stub": True})
+        assert response.json() == {"stub": True}
+        assert response.status_code == 200
+
+        async def _exercise_async_client() -> None:
+            async with module.httpx.AsyncClient() as async_client:
+                async_response = await async_client.get(
+                    "https://example.test", json={"stub": "async"}
+                )
+                assert async_response.json() == {"stub": "async"}
+
+        asyncio.run(_exercise_async_client())
+    finally:
+        sys.modules.pop(module_name, None)
+        if original_module is not None:
+            sys.modules[module_name] = original_module


### PR DESCRIPTION
## Summary
- guard the httpx import in model_builder_client with a stub fallback when the package is unavailable
- log the fallback usage in non-offline environments while keeping the httpx symbol consistent
- add a regression test that simulates a missing httpx module and exercises the stubbed client

## Testing
- pytest tests/test_model_builder_client.py

------
https://chatgpt.com/codex/tasks/task_b_68e4272ba1348321beb4047cd07d1fa8