### PR TITLE
Fix Trivy workflow summary without jq

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -57,13 +57,15 @@ jobs:
             exit 0
           fi
           echo "sarif=true" >>"$GITHUB_OUTPUT"
-          if command -v jq >/dev/null 2>&1; then
-            count=$(jq -r '[.runs[]?.results[]?] | length' trivy-results.sarif)
-          else
-            sudo apt-get update >/dev/null 2>&1
-            sudo apt-get install -y jq >/dev/null 2>&1
-            count=$(jq -r '[.runs[]?.results[]?] | length' trivy-results.sarif)
-          fi
+          count=$(python - <<'PY'
+import json
+with open("trivy-results.sarif", "r", encoding="utf-8") as sarif_file:
+    sarif = json.load(sarif_file)
+runs = sarif.get("runs", [])
+total = sum(len(run.get("results", [])) for run in runs)
+print(total)
+PY
+          )
           printf '### Trivy scan summary\n\n* Найдено high/critical уязвимостей: `%s`\n' "$count" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload Trivy SARIF to GitHub Security tab


### PR DESCRIPTION
## Summary
- replace the jq-based Trivy summary with an inline Python script
- avoid apt-get usage so the job no longer fails when jq is unavailable

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_b_68e4274d6fdc8321bad52d6c3a8dde13