### PR TITLE
Fix docker publish workflow buildx race

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -134,6 +134,17 @@ jobs:
             sudo service docker start
           fi
 
+      - name: Wait for Docker daemon
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 30); do
+            if docker info >/dev/null 2>&1 || sudo docker info >/dev/null 2>&1; then
+              exit 0
+            fi
+            sleep 2
+          done
+          docker info
+
       - name: Set up Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435  # v3
         with:


### PR DESCRIPTION
## Summary
- ensure the GitHub Actions docker-publish workflow waits for the Docker daemon to become responsive before configuring Buildx, avoiding race conditions after restarting the service

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_b_68e4276750ec8321a90b6c032414404c