### PR TITLE
Fix redundant IS_TEST_MODE assignment to satisfy linting

### DIFF
--- a/bot/trade_manager/core.py
+++ b/bot/trade_manager/core.py
@@ -52,7 +52,6 @@ safe_api_call = _utils.safe_api_call
 TelegramLogger = _utils.TelegramLogger
 
 test_stubs.apply()
-IS_TEST_MODE = test_stubs.IS_TEST_MODE
 
 aiohttp: Any
 try:  # pragma: no cover - optional dependency


### PR DESCRIPTION
## Summary
- remove the duplicate IS_TEST_MODE assignment in the trade manager core module to resolve the Ruff redefinition warning

## Testing
- python -m ruff check bot tests
- python -m mypy bot

------
https://chatgpt.com/codex/tasks/task_b_68e427731e3c8321ac5c79ab5152e6f4