### PR TITLE
Fix BadRequest handling in trade manager service

### DIFF
--- a/services/trade_manager_service.py
+++ b/services/trade_manager_service.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any, Callable, Iterator, Mapping, TextIO, cast
 
 from flask import Flask, jsonify, request
+from werkzeug.exceptions import BadRequest
 try:  # optional dependency
     from flask.typing import ResponseReturnValue
 except Exception:  # pragma: no cover - fallback when flask.typing missing


### PR DESCRIPTION
## Summary
- import the werkzeug BadRequest exception so the close_position route handles invalid JSON inputs without NameError

## Testing
- flake8 .
- pytest -q --maxfail=1 --disable-warnings

------
https://chatgpt.com/codex/tasks/task_b_68e427994464832196f0ca3af42885e9