### PR TITLE
Guard GPT-OSS review workflow for unsupported events

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -132,7 +132,10 @@ jobs:
 
   review:
     needs: evaluate
-    if: ${{ needs.evaluate.outputs.run_review == 'true' && github.event_name != 'pull_request_target' }}
+    if: >-
+      ${{ fromJSON(needs.evaluate.outputs.run_review || 'false')
+          && (github.event_name == 'pull_request'
+              || github.event_name == 'issue_comment') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:
@@ -166,7 +169,11 @@ jobs:
           path: ${{ env.HELPERS_DIR }}
 
       - name: Проверка статуса PR
-        if: ${{ steps.validate_event.outputs.skip != 'true' }}
+        if: >-
+          ${{ steps.validate_event.outputs.skip != 'true'
+              && github.event_name != 'pull_request_target'
+              && (github.event_name == 'pull_request'
+                  || github.event_name == 'issue_comment') }}
         id: ensure_pr_ready
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/tests/test_gptoss_workflow_python3.py
+++ b/tests/test_gptoss_workflow_python3.py
@@ -50,14 +50,12 @@ def test_pr_status_step_skips_pull_request_target() -> None:
     assert notice_message in workflow_text
 
 
-def test_review_job_skips_target_events() -> None:
+def test_review_job_runs_only_for_supported_events() -> None:
     workflow_text = WORKFLOW_PATH.read_text(encoding='utf-8')
 
-    condition = (
-        "needs.evaluate.outputs.run_review == 'true' && github.event_name != 'pull_request_target'"
-    )
-
-    assert condition in workflow_text
+    assert "fromJSON(needs.evaluate.outputs.run_review || 'false')" in workflow_text
+    assert "github.event_name == 'pull_request'" in workflow_text
+    assert "github.event_name == 'issue_comment'" in workflow_text
 
 
 def test_skip_job_covers_target_events() -> None:
@@ -68,3 +66,12 @@ def test_skip_job_covers_target_events() -> None:
     )
 
     assert condition in workflow_text
+
+
+def test_pr_status_step_gates_supported_events() -> None:
+    workflow_text = WORKFLOW_PATH.read_text(encoding='utf-8')
+
+    assert "Проверка статуса PR" in workflow_text
+    assert "github.event_name != 'pull_request_target'" in workflow_text
+    assert "github.event_name == 'pull_request'" in workflow_text
+    assert "github.event_name == 'issue_comment'" in workflow_text


### PR DESCRIPTION
## Summary
- restrict the GPT-OSS review job to supported pull_request and issue_comment events using robust boolean parsing
- skip the PR status check when the workflow is triggered by unsupported events
- extend workflow unit tests to cover the new guards

## Testing
- pytest tests/test_gptoss_workflow_python3.py

------
https://chatgpt.com/codex/tasks/task_b_68e427884d6483218ef14f7dc81f2383