### PR TITLE
Handle missing Trivy SARIF results gracefully

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -59,11 +59,28 @@ jobs:
           echo "sarif=true" >>"$GITHUB_OUTPUT"
           count=$(python - <<'PY'
 import json
+from typing import Iterable
+
+def iter_results(runs: Iterable[dict]) -> int:
+    total = 0
+    for run in runs:
+        results = run.get("results")
+        if isinstance(results, list):
+            total += len(results)
+        elif results is None:
+            continue
+        else:
+            try:
+                total += len(list(results))
+            except TypeError:
+                continue
+    return total
+
 with open("trivy-results.sarif", "r", encoding="utf-8") as sarif_file:
     sarif = json.load(sarif_file)
+
 runs = sarif.get("runs", [])
-total = sum(len(run.get("results", [])) for run in runs)
-print(total)
+print(iter_results(runs))
 PY
           )
           printf '### Trivy scan summary\n\n* Найдено high/critical уязвимостей: `%s`\n' "$count" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- guard the Trivy summary step against SARIF runs that omit a results array
- keep the workflow from failing when Trivy reports no high/critical findings

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_b_68e4ca38f89c83218f0938572a3c6c62