### PR TITLE
Fix Buildx image tag in docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -151,9 +151,10 @@ jobs:
           driver: docker-container
           # Принудительно используем свежий BuildKit, который умеет работать
           # с OCI media types и не воспроизводит "unexpected media type" при
-          # чтении кэша, созданного с ``oci-mediatypes=true``. Образ
-          # ``moby/buildkit:v0.16.2`` поддерживает эту функциональность.
-          driver-opts: image=moby/buildkit:v0.16.2
+          # чтении кэша, созданного с ``oci-mediatypes=true``. Берём стабильный
+          # образ ``moby/buildkit:v0.24.0``, доступный на Docker Hub и уже
+          # содержащий необходимые исправления.
+          driver-opts: image=moby/buildkit:v0.24.0
 
       - name: Verify /mnt mount
         run: |


### PR DESCRIPTION
## Summary
- switch the Buildx driver image in the docker-publish workflow to the published moby/buildkit:v0.24.0 tag
- update the accompanying comment to reflect the new image choice

## Testing
- python scripts/health_check.py

------
https://chatgpt.com/codex/tasks/task_b_68e4ca5de94083219a2cb2f9acc896a5