### PR TITLE
Fix TradeManager shutdown and task error handling

### DIFF
--- a/bot/trade_manager/errors.py
+++ b/bot/trade_manager/errors.py
@@ -1,0 +1,6 @@
+"""Shared exception types for the trade manager package."""
+
+class TradeManagerTaskError(RuntimeError):
+    """Raised when one of the TradeManager background tasks fails."""
+
+__all__ = ["TradeManagerTaskError"]


### PR DESCRIPTION
## Summary
- ensure TradeManager checks the current test mode dynamically during task failure and shutdown handling
- extract TradeManagerTaskError into a shared module and keep package re-exports in sync after reloads

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68e4ca89c238832197bdc6bd4deb9f7c