### PR TITLE
Fix TradeManager test mode handling for Dependabot workflow

### DIFF
--- a/bot/trade_manager/errors.py
+++ b/bot/trade_manager/errors.py
@@ -1,0 +1,7 @@
+"""Error classes for the trade manager package."""
+
+class TradeManagerTaskError(RuntimeError):
+    """Raised when one of the TradeManager background tasks fails."""
+
+
+__all__ = ["TradeManagerTaskError"]


### PR DESCRIPTION
## Summary
- add a dedicated helper to detect test mode and reuse it across shutdown logic
- move TradeManagerTaskError into a reusable errors module to keep the class identity stable when the core module reloads

## Testing
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_b_68e4ca7dcbc483218de494c7109b655b