### PR TITLE
Ensure TradeManager test mode flag stays in sync

### DIFF
--- a/bot/trade_manager/errors.py
+++ b/bot/trade_manager/errors.py
@@ -1,0 +1,13 @@
+"""Shared exceptions used by the trade manager package."""
+
+from __future__ import annotations
+
+
+class TradeManagerTaskError(RuntimeError):
+    """Raised when one of the TradeManager background tasks fails."""
+
+    pass
+
+
+__all__ = ["TradeManagerTaskError"]
+


### PR DESCRIPTION
## Summary
- add a dynamic helper to keep the TradeManager test-mode flag in sync with the current environment
- reuse the shared TradeManagerTaskError definition so background task failures raise a stable exception type

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_b_68e4ca427f708321903b4e2f660f332b