### PR TITLE
Fix Trivy summary Python invocation

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -57,7 +57,7 @@ jobs:
             exit 0
           fi
           echo "sarif=true" >>"$GITHUB_OUTPUT"
-          count=$(python - <<'PY'
+          count=$(python3 - <<'PY'
 import json
 from typing import Iterable
 


### PR DESCRIPTION
## Summary
- update the Trivy workflow summary step to call python3 explicitly when parsing SARIF results

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e4f049b2148321811e36e9df6001b8