### PR TITLE
Handle workflow_run repository owner/name fallback for dependency snapshot

### DIFF
--- a/scripts/submit_dependency_snapshot.py
+++ b/scripts/submit_dependency_snapshot.py
@@ -155,6 +155,22 @@ def _extract_workflow_run_repository(payload: Mapping[str, object]) -> str:
                 normalised = _normalise_optional_string(value)
                 if normalised:
                     return normalised
+            name = mapping.get("name")
+            if isinstance(name, str):
+                owner = mapping.get("owner")
+                owner_login = ""
+                if isinstance(owner, str):
+                    owner_login = _normalise_optional_string(owner)
+                else:
+                    owner_mapping = _as_mapping(owner)
+                    if owner_mapping:
+                        login = owner_mapping.get("login")
+                        if isinstance(login, str):
+                            owner_login = _normalise_optional_string(login)
+                if owner_login:
+                    candidate = _normalise_optional_string(name)
+                    if candidate:
+                        return f"{owner_login}/{candidate}"
     return ""
 
 

--- a/tests/test_dependency_snapshot.py
+++ b/tests/test_dependency_snapshot.py
@@ -288,6 +288,77 @@ def test_submit_dependency_snapshot_uses_repository_dispatch_payload(
     assert submitted["ref"] == "refs/heads/auto"
 
 
+def test_submit_dependency_snapshot_recovers_repository_from_workflow_run_parts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload_path = tmp_path / "event.json"
+    payload_path.write_text(
+        json.dumps(
+            {
+                "workflow_run": {
+                    "head_sha": "feedface",
+                    "head_branch": "auto-main",
+                    "head_repository": {
+                        "name": "bot",
+                        "owner": {"login": "averinaleks"},
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("GITHUB_WORKSPACE", str(tmp_path))
+    monkeypatch.setenv("GITHUB_TOKEN", "dummy-token")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(payload_path))
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "dynamic")
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+    monkeypatch.delenv("GITHUB_SHA", raising=False)
+    monkeypatch.delenv("GITHUB_REF", raising=False)
+    monkeypatch.setenv("GITHUB_RUN_ID", "321")
+    monkeypatch.setenv("GITHUB_WORKFLOW", "dependency-graph")
+    monkeypatch.setenv("GITHUB_JOB", "submit")
+
+    manifest: snapshot.Manifest = {
+        "name": "requirements.txt",
+        "file": {"source_location": "requirements.txt"},
+        "resolved": {
+            "httpx": {
+                "package_url": HTTPX_PURL,
+                "relationship": "direct",
+                "scope": "runtime",
+                "dependencies": [],
+            }
+        },
+    }
+    monkeypatch.setattr(snapshot, "_build_manifests", lambda _: {"requirements.txt": manifest})
+
+    submitted: dict[str, object] = {}
+    submitted_url = ""
+
+    def capture_submission(url: str, body: bytes, headers: dict[str, str]) -> None:
+        del headers
+        nonlocal submitted_url
+        submitted_url = url
+        submitted.update(json.loads(body))
+
+    monkeypatch.setattr(snapshot, "_submit_with_headers", capture_submission)
+
+    snapshot.submit_dependency_snapshot()
+
+    captured = capsys.readouterr()
+    assert "Missing required environment variable" not in captured.err
+    assert "Using event payload" in captured.out
+
+    assert submitted_url.endswith(
+        "/repos/averinaleks/bot/dependency-graph/snapshots"
+    )
+    assert submitted["sha"] == "feedface"
+    assert submitted["ref"] == "refs/heads/auto-main"
+
+
 def test_submit_dependency_snapshot_supports_commit_oid_and_ref_name(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- allow the dependency snapshot submitter to derive repository names from workflow_run payloads that only expose owner/name pairs
- add a regression test covering the dynamic dependency submission payload structure

## Testing
- pytest tests/test_dependency_snapshot.py tests/test_dependency_snapshot_parser.py

------
https://chatgpt.com/codex/tasks/task_b_68e4f055db308321ab76e8cdb05c3dd4