### PR TITLE
Fix httpx stub handling for CI lint checks

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -10,6 +10,7 @@ if os.getenv("TEST_MODE") == "1" or "pytest" in sys.modules:
     import test_stubs as _test_stubs
 
     _test_stubs.apply()
+    test_stubs = _test_stubs
 
 # Allow loading submodules from project root
 __path__ = [

--- a/bot/trade_manager/core.py
+++ b/bot/trade_manager/core.py
@@ -32,7 +32,6 @@ import numpy as np
 from bot import test_stubs
 from bot.dotenv_utils import load_dotenv
 from bot.ray_compat import ray  # noqa: E402
-import httpx  # noqa: E402
 import inspect  # noqa: E402
 from bot.utils_loader import require_utils  # noqa: E402
 from bot.trade_manager import order_utils  # noqa: E402

--- a/bot/trade_manager/service.py
+++ b/bot/trade_manager/service.py
@@ -16,6 +16,8 @@ from typing import Any, Awaitable, Mapping, TypeVar, cast
 
 from services.stubs import create_httpx_stub
 
+httpx: Any
+
 try:  # pragma: no cover - exercised in environments without httpx
     import httpx as _httpx  # type: ignore
 except Exception:  # noqa: BLE001 - ensure service works without httpx installed


### PR DESCRIPTION
## Summary
- remove redundant httpx import in the trade manager core to avoid ruff redefinition errors
- expose test_stubs from the bot package and annotate the httpx stub for typing clarity

## Testing
- python -m ruff check bot tests
- python -m mypy bot
- pytest


------
https://chatgpt.com/codex/tasks/task_b_68e4f07e0b348321901244cf961e49f2