### PR TITLE
Fix utils reload helper for Dependabot workflow

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -312,7 +312,8 @@ def _reload_utils_with_blocked(monkeypatch, blocked_names):
         for mod_name in blocked_names:
             context.delitem(sys.modules, mod_name, raising=False)
         context.setattr(builtins, "__import__", fake_import)
-        return importlib.reload(sys.modules["bot.utils"])
+        module = sys.modules.get("bot.utils") or sys.modules.get("utils") or utils
+        return importlib.reload(module)
 
 
 def test_numba_warning_emitted_once(monkeypatch, caplog):


### PR DESCRIPTION
## Summary
- ensure `_reload_utils_with_blocked` reloads whichever `utils` module instance is available to support Dependabot tests

## Testing
- `pytest -m "not integration" -q`


------
https://chatgpt.com/codex/tasks/task_b_68e4f0929f188321bc6ac1f0ee487294