### PR TITLE
Handle null sentinels in dependency diff detection

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -90,7 +90,7 @@ jobs:
           from pathlib import Path
           from typing import Sequence
 
-          _NULL_STRINGS = {"null", "none", "undefined"}
+          _NULL_STRINGS = {"null", "none", "undefined", '""', "''"}
 
           def _normalise_value(raw: str | None) -> str:
               if not raw:

--- a/tests/test_dependency_graph_workflow.py
+++ b/tests/test_dependency_graph_workflow.py
@@ -61,7 +61,7 @@ def test_dependency_graph_detect_step_handles_nested_manifests() -> None:
 def test_dependency_graph_detect_step_normalises_null_strings() -> None:
     workflow = Path(".github/workflows/dependency-graph.yml").read_text(encoding="utf-8")
 
-    assert '_NULL_STRINGS = {"null", "none", "undefined"}' in workflow
+    assert """_NULL_STRINGS = {"null", "none", "undefined", '""', "''"}""" in workflow
     assert "def _normalise_value" in workflow
     assert "candidate.lower() in _NULL_STRINGS" in workflow
 


### PR DESCRIPTION
## Summary
- expand the dependency-graph workflow's diff detector to treat quoted empty strings as null values
- update the dependency graph workflow regression test to cover the new sentinels

## Testing
- pytest tests/test_dependency_graph_workflow.py
- pytest tests/test_dependency_snapshot.py

------
https://chatgpt.com/codex/tasks/task_b_68e4f0a8ff748321a51493ab5dca7c3e