### PR TITLE
Fix release drafter workflow hangs

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -27,12 +27,13 @@ jobs:
   update_release_draft:
     if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     concurrency:
-      group: release-drafter-${{ github.ref || github.run_id }}
+      group: release-drafter-${{ github.ref_name || github.event.repository.default_branch || github.run_id }}
       cancel-in-progress: false
     steps:
       - name: Update release draft
-        uses: release-drafter/release-drafter@v6.1.0 # Latest available release as of 2025-10-05
+        uses: release-drafter/release-drafter@v5.25.0 # v6.1.0 currently hangs while updating releases
         with:
           config-name: release-drafter.yml
         env:
@@ -50,7 +51,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Update pull request metadata
-        uses: release-drafter/release-drafter@v6.1.0 # Latest available release as of 2025-10-05
+        uses: release-drafter/release-drafter@v5.25.0 # v6.1.0 currently hangs while updating releases
         with:
           config-name: release-drafter.yml
           disable-releases: true


### PR DESCRIPTION
## Summary
- add a timeout and use ref_name in the Release Drafter concurrency key to avoid stale queued runs
- pin the Release Drafter action to v5.25.0 to work around hangs observed with v6.1.0

## Testing
- /root/.local/share/mise/installs/go/1.24.3/bin/actionlint .github/workflows/release-drafter.yml


------
https://chatgpt.com/codex/tasks/task_b_68e4f0c2f0f0832193bc93b6cac21fee