### PR TITLE
Skip Trivy cache on PR runs

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -26,6 +26,7 @@ jobs:
 
       - name: Cache Trivy vulnerability database
         id: cache-trivy
+        if: ${{ github.event_name != 'pull_request' }}
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         # v4.3.0
         with:


### PR DESCRIPTION
## Summary
- avoid running the Trivy database cache step for pull request events to prevent permission failures on forked contributions

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_b_68e5494c2fc08321abee766ef71c585d