### PR TITLE
Handle unknown arguments in component detection CLI fallback

### DIFF
--- a/component-detection
+++ b/component-detection
@@ -146,13 +146,25 @@ def main(argv: list[str] | None = None) -> int:
     list_parser = subparsers.add_parser("list-detectors")
     list_parser.set_defaults(func=lambda args: run_list_detectors())
 
-    args = parser.parse_args(argv)
+    args, unknown = parser.parse_known_args(argv)
 
-    if not args.command:
+    if unknown:
+        ignored = " ".join(unknown)
+        print(
+            f"Ignoring unsupported component-detection arguments: {ignored}",
+            file=sys.stderr,
+        )
+
+    if not getattr(args, "command", None):
         parser.print_help()
         return 1
 
-    return int(args.func(args))
+    func = getattr(args, "func", None)
+    if func is None:
+        parser.print_help()
+        return 1
+
+    return int(func(args))
 
 
 if __name__ == "__main__":

--- a/tests/test_component_detection.py
+++ b/tests/test_component_detection.py
@@ -38,3 +38,25 @@ def test_run_scan_uses_list_for_container_layer_ids(tmp_path: Path) -> None:
     assert components, "Expected at least one component in scan results"
     for component in components:
         assert component["containerLayerIds"] == []
+
+
+def test_main_ignores_unknown_arguments(tmp_path: Path, capsys) -> None:
+    module = _load_component_detection()
+    manifest = tmp_path / "requirements.txt"
+    manifest.write_text("requests==2.32.5\n", encoding="utf-8")
+
+    return_code = module.main(
+        [
+            "scan",
+            "--SourceDirectory",
+            str(tmp_path),
+            "--UnsupportedFlag",
+            "value",
+        ]
+    )
+
+    captured = capsys.readouterr()
+
+    assert return_code == 0
+    assert "Ignoring unsupported component-detection arguments" in captured.err
+    assert "--UnsupportedFlag value" in captured.err


### PR DESCRIPTION
## Summary
- ignore unsupported component-detection CLI arguments so the fallback script no longer aborts when GitHub passes extra flags
- add a regression test covering the new behaviour

## Testing
- pytest tests/test_component_detection.py

------
https://chatgpt.com/codex/tasks/task_b_68e54959850c8321b8603845882aac99