### PR TITLE
Bump ccxt to 4.5.8 for Dependabot workflow stability

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -22,7 +22,7 @@ werkzeug==3.1.3
 requests==2.32.5
 httpx==0.28.1
 cloudpickle==3.1.1
-ccxt==4.5.7
+ccxt==4.5.8
 # Newer scikit-learn releases pull in SciPy builds incompatible with our
 # pinned numpy; keep everything aligned with the Docker images.
 scikit-learn==1.7.2; python_version<'3.12'

--- a/requirements-core.in
+++ b/requirements-core.in
@@ -1,6 +1,6 @@
 numpy>=2.2.6  # core numeric library
 pandas>=2.2.2
-ccxt==4.5.7
+ccxt==4.5.8
 # ccxtpro is distributed under a commercial license and cannot be installed
 # automatically in CI. Install it manually in production environments if
 # real-time WebSocket support is required.

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -35,7 +35,7 @@ bcrypt==5.0.0
     # via -r requirements-core.in
 blinker==1.9.0
     # via flask
-ccxt==4.5.7
+ccxt==4.5.8
     # via -r requirements-core.in
 certifi==2025.8.3
     # via

--- a/requirements-healthcheck.txt
+++ b/requirements-healthcheck.txt
@@ -1,6 +1,6 @@
 gunicorn==23.0.0
 flask==3.1.2
-ccxt==4.5.7
+ccxt==4.5.8
 python-dotenv==1.1.1
 requests==2.32.5
 pandas==2.3.3

--- a/requirements.out
+++ b/requirements.out
@@ -47,7 +47,7 @@ blinker==1.9.0
     # via
     #   -r requirements.txt
     #   flask
-ccxt==4.5.7
+ccxt==4.5.8
     # via -r requirements.txt
 certifi==2025.8.3
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ bcrypt==5.0.0
     # via -r requirements-core.in
 blinker==1.9.0
     # via flask
-ccxt==4.5.7
+ccxt==4.5.8
     # via -r requirements-core.in
 certifi==2025.8.3
     # via


### PR DESCRIPTION
## Summary
- bump the pinned ccxt dependency to 4.5.8 across the requirement sets so Dependabot can complete cryptography-related updates

## Testing
- pytest -m "not integration" -q

------
https://chatgpt.com/codex/tasks/task_b_68e54f2c30d88321811d4f8f694f581c