### PR TITLE
Fix dependency graph workflow setup for dependency submissions

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -13,6 +13,8 @@ on:
       - "dependency-graph-auto-submission"
 
 permissions:
+  # Only the supported scopes for dependency snapshot submission; GitHub rejects
+  # the legacy "dependency-graph" permission.
   contents: write
   security-events: write
 
@@ -44,12 +46,6 @@ jobs:
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: '3.11'
-      - name: Install dependency snapshot dependencies
-        run: |
-          python -m pip install --upgrade pip \
-            || python -m pip install --upgrade pip --break-system-packages
-          python -m pip install requests \
-            || python -m pip install requests --break-system-packages
       - name: Detect dependency manifest changes
         id: detect
         env:


### PR DESCRIPTION
## Summary
- document the supported permission scopes in the dependency graph workflow to avoid the unsupported `dependency-graph` scope
- remove the unconditional pip installation so dependency snapshots only install packages when manifests change

## Testing
- pytest tests/test_dependency_graph_workflow.py

------
https://chatgpt.com/codex/tasks/task_b_68e54f3c7d608321a1d1ec3f621b76c9