### PR TITLE
Skip GPT-OSS review on pull_request_target events

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -133,7 +133,8 @@ jobs:
   review:
     needs: evaluate
     if: >-
-      ${{ fromJSON(needs.evaluate.outputs.run_review || 'false')
+      ${{ github.event_name != 'pull_request_target'
+          && fromJSON(needs.evaluate.outputs.run_review || 'false')
           && (github.event_name == 'pull_request'
               || github.event_name == 'issue_comment') }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- guard the GPT-OSS review job so it never runs for pull_request_target events

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e54f4c7c9c8321b6bc6a4160bd389e