### PR TITLE
Add synchronous byte iterator to HTTPX response stub

### DIFF
--- a/services/stubs.py
+++ b/services/stubs.py
@@ -100,6 +100,12 @@ def create_httpx_stub() -> SimpleNamespace:
                 return
             yield self._content
 
+        def iter_bytes(self):
+            if not self._content:
+                yield from ()
+                return
+            yield self._content
+
     def _build_response(method: str, url: str, **kwargs: Any) -> Response:
         json_payload = kwargs.get("json")
         data_payload = kwargs.get("data")


### PR DESCRIPTION
## Summary
- add a synchronous `iter_bytes` method to the HTTPX response stub so offline paths can iterate over response chunks without awaiting
- ensure empty content is handled without yielding data

## Testing
- pytest tests/test_gpt_client.py tests/test_gpt_client_stub.py tests/test_offline_mode_stubs.py

------
https://chatgpt.com/codex/tasks/task_b_68e55d1cead48321806a8d035437c3e5