### PR TITLE
Fix Trivy findings for python-slim runtime images

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -44,6 +44,17 @@ if (major, minor) != (3, 11):
     )
 PY
 
+# ``python:3.11-slim`` поставляется с устаревшим setuptools 65.5.1,
+# уязвимым к CVE-2024-6345 и CVE-2025-47273. Обновляем системные
+# packaging-инструменты до безопасных версий до того, как начнём собирать
+# виртуальное окружение, чтобы Trivy не находил high/critical уязвимости
+# прямо в базовом образе.
+RUN python -m pip install --no-cache-dir --upgrade \
+        'pip>=24.0' \
+        'setuptools>=80.9.0,<81' \
+        wheel \
+    && python -m pip cache purge
+
 # pip>=24.0 устраняет CVE-2023-32681, setuptools>=80.9.0 закрывает известные
 # уязвимости и совместимы с зависимостями проекта.
 RUN python -m venv "$VIRTUAL_ENV"
@@ -230,6 +241,14 @@ if (major, minor) != (3, 11):
         f"Runtime Python version mismatch: expected 3.11, got {major}.{minor}"
     )
 PY
+
+# Аналогично стадии сборки обновляем системный pip/setuptools, чтобы в
+# рантайме не оставалось уязвимых версий из базового образа.
+RUN python -m pip install --no-cache-dir --upgrade \
+        'pip>=24.0' \
+        'setuptools>=80.9.0,<81' \
+        wheel \
+    && python -m pip cache purge
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- upgrade system pip/setuptools inside the CPU Dockerfile build stage so the base python:3.11-slim image no longer bundles vulnerable setuptools 65.5.1
- repeat the upgrade in the runtime stage to ensure the final image also contains the patched packaging tools and Trivy stops flagging CVE-2024-6345/CVE-2025-47273

## Testing
- not run (docker build not executed in this environment)


------
https://chatgpt.com/codex/tasks/task_b_68e55c345dd88321b735b24511a98fdb