### PR TITLE
Fix cache purge curl command in docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -176,7 +176,11 @@ jobs:
           total=$(echo "${response}" | jq -r '.total_count // 0')
           if [ "${total}" -gt 0 ]; then
             echo "Found ${total} stale cache entr(ies) for scope ${CACHE_SCOPE}, deleting"
-            curl -fsS -X DELETE -H 'Accept: application/vnd.github+json' -H "Authorization: Bearer ${GITHUB_TOKEN}" "${api_url}" >/dev/null
+            curl -fsS -X DELETE \
+              -H 'Accept: application/vnd.github+json' \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              "${api_url}" \
+              >/dev/null
           else
             echo "No cache entries found for scope ${CACHE_SCOPE}"
           fi


### PR DESCRIPTION
## Summary
- fix the curl cache purge step to keep the redirection on the same command by splitting arguments across lines
- ensure the purge script no longer triggers a standalone `>/dev/null` command

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e563a5cfe48321a1cc18e965740341