### PR TITLE
Guard GPT-OSS workflow against non-PR issue comments

### DIFF
--- a/.github/workflows/gptoss_review.yml
+++ b/.github/workflows/gptoss_review.yml
@@ -47,6 +47,7 @@ jobs:
           PR_DRAFT: ${{ github.event.pull_request.draft || 'false' }}
           PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name || '' }}
           ISSUE_NUMBER: ${{ github.event.issue.number || '' }}
+          ISSUE_IS_PR: ${{ github.event.issue.pull_request != null }}
           COMMENT_AUTHOR: ${{ github.event.comment.user.login || '' }}
           COMMENT_AUTHOR_ASSOC: ${{ github.event.comment.author_association || '' }}
           COMMENT_BODY: ${{ github.event.comment.body || '' }}
@@ -80,7 +81,12 @@ jobs:
               fi
               ;;
             issue_comment)
-              pr_number="${ISSUE_NUMBER:-}"
+              issue_is_pr="${ISSUE_IS_PR:-false}"
+              if [ "$issue_is_pr" = "true" ]; then
+                pr_number="${ISSUE_NUMBER:-}"
+              else
+                pr_number=""
+              fi
               comment_author="${COMMENT_AUTHOR:-}"
               author_assoc="${COMMENT_AUTHOR_ASSOC:-}"
               comment_body="${COMMENT_BODY:-}"

--- a/tests/test_gptoss_workflow_python3.py
+++ b/tests/test_gptoss_workflow_python3.py
@@ -90,3 +90,11 @@ def test_pr_status_step_gates_supported_events() -> None:
     assert "github.event_name != 'pull_request_target'" in workflow_text
     assert "github.event_name == 'pull_request'" in workflow_text
     assert "github.event_name == 'issue_comment'" in workflow_text
+
+
+def test_issue_comment_requires_pull_request_reference() -> None:
+    workflow_text = WORKFLOW_PATH.read_text(encoding='utf-8')
+
+    assert 'ISSUE_IS_PR: ${{ github.event.issue.pull_request != null }}' in workflow_text
+    assert 'issue_is_pr="${ISSUE_IS_PR:-false}"' in workflow_text
+    assert 'Комментарий не относится к pull request' in workflow_text


### PR DESCRIPTION
## Summary
- ensure the GPT-OSS review workflow ignores issue comments that are not tied to a pull request
- extend the workflow regression tests to assert the new guard is present

## Testing
- pytest tests/test_gptoss_workflow_python3.py

------
https://chatgpt.com/codex/tasks/task_b_68e563e4eccc832198da74e376f2edf3