### PR TITLE
Add guidance for missing environment variables

### DIFF
--- a/config.py
+++ b/config.py
@@ -28,7 +28,16 @@ class MissingEnvError(Exception):
 
     def __init__(self, missing_keys: list[str]):
         self.missing_keys = tuple(missing_keys)
-        message = "Missing required environment variables: " + ", ".join(missing_keys)
+        hint = (
+            " Run 'python run_bot.py --offline' or create a .env file with the required"
+            " variables."
+        )
+        message = (
+            "Missing required environment variables: "
+            + ", ".join(missing_keys)
+            + "."
+            + hint
+        )
         super().__init__(message)
 
 
@@ -94,8 +103,9 @@ except MissingEnvError as exc:
         )
     else:
         logger.critical(
-            "Не заданы обязательные переменные окружения: %s",
-            missing,
+            "Не заданы обязательные переменные окружения: %s. "
+            "Запустите `python run_bot.py --offline` или создайте файл .env с обязательными переменными.",
+            sanitize_log_value(missing),
         )
         raise
 

--- a/tests/test_run_bot_factories.py
+++ b/tests/test_run_bot_factories.py
@@ -2,7 +2,7 @@ import pytest
 
 pytest.importorskip("pandas")
 
-from config import BotConfig
+from config import BotConfig, MissingEnvError
 
 import run_bot
 
@@ -23,3 +23,10 @@ def test_build_components_invalid_exchange_factory():
     message = "Failed to load service factory 'exchange' from 'bot:missing'"
     with pytest.raises(ValueError, match=message):
         run_bot._build_components(cfg, offline=False, symbols=None)
+
+
+def test_missing_env_error_message_contains_hint():
+    exc = MissingEnvError(["FOO", "BAR"])
+    message = str(exc)
+    assert "Run 'python run_bot.py --offline'" in message
+    assert "create a .env file with the required variables" in message


### PR DESCRIPTION
## Summary
- extend the MissingEnvError message with actionable guidance for offline mode or configuring a .env file
- include the same hints in the critical logger output when required variables are absent
- add a regression test ensuring the new error message includes the offline/.env instructions

## Testing
- pytest tests/test_run_bot_factories.py

------
https://chatgpt.com/codex/tasks/task_b_68e5644b8858832195e59ba9e78e2b1b