### PR TITLE
Ensure dependency graph checkout falls back to default branch

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -41,7 +41,12 @@ jobs:
               github.event.workflow_run.head_commit.sha ||
               github.event.workflow_run.head_ref ||
               github.event.workflow_run.head_branch ||
-              github.ref
+              github.ref ||
+              (
+                github.event.repository.default_branch &&
+                format('refs/heads/{0}', github.event.repository.default_branch)
+              ) ||
+              'refs/heads/main'
             }}
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:

--- a/tests/test_dependency_graph_workflow.py
+++ b/tests/test_dependency_graph_workflow.py
@@ -136,3 +136,5 @@ def test_dependency_graph_checkout_resolves_dispatch_ref() -> None:
     assert "github.event.workflow_run.head_commit.sha" in workflow
     assert "github.event.workflow_run.head_ref" in workflow
     assert "github.event.workflow_run.head_branch" in workflow
+    assert "github.event.repository.default_branch" in workflow
+    assert "format('refs/heads/{0}', github.event.repository.default_branch)" in workflow


### PR DESCRIPTION
## Summary
- add a final fallback in the dependency graph workflow so repository_dispatch events without a ref use the default branch
- extend the dependency graph workflow test to assert the new default-branch fallback is present

## Testing
- pytest tests/test_dependency_graph_workflow.py -q

------
https://chatgpt.com/codex/tasks/task_b_68e563d7eb4c8321b095c228e6bf12c4