### PR TITLE
Support dependency graph auto submission event

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
   workflow_dispatch:
+  dependency_graph:
+    types:
+      - auto-submission
   repository_dispatch:
     types:
       # Custom type used by auto-submission hooks. GitHub restricts repository
@@ -27,6 +30,11 @@ jobs:
           fetch-depth: 0
           ref: >-
             ${{
+              github.event.ref ||
+              github.event.ref_name ||
+              github.event.branch ||
+              github.event.head_ref ||
+              github.event.base_ref ||
               github.event.client_payload.sha ||
               github.event.client_payload.commit_sha ||
               github.event.client_payload.commit_oid ||
@@ -52,6 +60,8 @@ jobs:
           BEFORE: >-
             ${{
               github.event.before ||
+              github.event.base_sha ||
+              github.event.base_ref ||
               github.event.client_payload.before ||
               github.event.client_payload.base_sha ||
               github.event.client_payload.before_sha ||
@@ -65,6 +75,10 @@ jobs:
           AFTER: >-
             ${{
               github.sha ||
+              github.event.commit_oid ||
+              github.event.commit_sha ||
+              github.event.sha ||
+              github.event.ref ||
               github.event.client_payload.after ||
               github.event.client_payload.head_sha ||
               github.event.client_payload.commit_oid ||
@@ -200,7 +214,8 @@ jobs:
         if: >-
           steps.detect.outputs.changed == 'true' ||
           github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'repository_dispatch'
+          github.event_name == 'repository_dispatch' ||
+          github.event_name == 'dependency_graph'
         run: |
           python -m pip install --upgrade pip \
             || python -m pip install --upgrade pip --break-system-packages
@@ -210,7 +225,8 @@ jobs:
         if: >-
           steps.detect.outputs.changed == 'true' ||
           github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'repository_dispatch'
+          github.event_name == 'repository_dispatch' ||
+          github.event_name == 'dependency_graph'
         run: |
           python <<'PY'
           from __future__ import annotations
@@ -297,7 +313,8 @@ jobs:
         if: >-
           steps.detect.outputs.changed == 'true' ||
           github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'repository_dispatch'
+          github.event_name == 'repository_dispatch' ||
+          github.event_name == 'dependency_graph'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python scripts/submit_dependency_snapshot.py

--- a/scripts/submit_dependency_snapshot.py
+++ b/scripts/submit_dependency_snapshot.py
@@ -201,6 +201,7 @@ _EVENT_PAYLOAD_EVENTS = {
     "workflow_run",
     "workflow_call",
     "dynamic",
+    "dependency_graph",
 }
 _SHA_PATTERN = re.compile(r"^[0-9a-f]{40,64}$", re.IGNORECASE)
 

--- a/tests/test_dependency_graph_workflow.py
+++ b/tests/test_dependency_graph_workflow.py
@@ -69,6 +69,8 @@ def test_dependency_graph_detect_step_normalises_null_strings() -> None:
 def test_dependency_graph_detect_step_uses_dispatch_commit_fallbacks() -> None:
     workflow = Path(".github/workflows/dependency-graph.yml").read_text(encoding="utf-8")
 
+    assert "github.event.base_sha" in workflow
+    assert "github.event.base_ref" in workflow
     assert "github.event.client_payload.before" in workflow
     assert "github.event.client_payload.base_sha" in workflow
     assert "github.event.client_payload.before_sha" in workflow
@@ -80,6 +82,10 @@ def test_dependency_graph_detect_step_uses_dispatch_commit_fallbacks() -> None:
     assert "github.event.client_payload.commit_oid" in workflow
     assert "github.event.client_payload.commit_sha" in workflow
     assert "github.event.client_payload.sha" in workflow
+    assert "github.event.commit_oid" in workflow
+    assert "github.event.commit_sha" in workflow
+    assert "github.event.sha" in workflow
+    assert "github.event.ref" in workflow
     assert "github.event.workflow_run.head_sha" in workflow
     assert "github.event.workflow_run.head_commit.id" in workflow
     assert "github.event.workflow_run.head_commit.sha" in workflow
@@ -123,9 +129,22 @@ def test_dependency_graph_supports_repository_dispatch_auto_submission() -> None
     assert "github.event_name == 'repository_dispatch'" in workflow
 
 
+def test_dependency_graph_supports_dependency_graph_auto_submission() -> None:
+    workflow = Path(".github/workflows/dependency-graph.yml").read_text(encoding="utf-8")
+
+    assert "dependency_graph:" in workflow
+    assert "auto-submission" in workflow
+    assert "github.event_name == 'dependency_graph'" in workflow
+
+
 def test_dependency_graph_checkout_resolves_dispatch_ref() -> None:
     workflow = Path(".github/workflows/dependency-graph.yml").read_text(encoding="utf-8")
 
+    assert "github.event.ref" in workflow
+    assert "github.event.ref_name" in workflow
+    assert "github.event.branch" in workflow
+    assert "github.event.head_ref" in workflow
+    assert "github.event.base_ref" in workflow
     assert "github.event.client_payload.head_sha" in workflow
     assert "github.event.client_payload.commit_sha" in workflow
     assert "github.event.client_payload.ref_name" in workflow

--- a/tests/test_dependency_snapshot.py
+++ b/tests/test_dependency_snapshot.py
@@ -288,6 +288,67 @@ def test_submit_dependency_snapshot_uses_repository_dispatch_payload(
     assert submitted["ref"] == "refs/heads/auto"
 
 
+def test_submit_dependency_snapshot_uses_dependency_graph_payload(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload_path = tmp_path / "event.json"
+    payload_path.write_text(
+        json.dumps(
+            {
+                "action": "auto-submission",
+                "commit_oid": "0123456789abcdef",
+                "ref": "feature/auto",
+                "base_ref": "refs/heads/main",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("GITHUB_WORKSPACE", str(tmp_path))
+    monkeypatch.setenv("GITHUB_REPOSITORY", "averinaleks/bot")
+    monkeypatch.setenv("GITHUB_TOKEN", "dummy-token")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(payload_path))
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "dependency_graph")
+    monkeypatch.delenv("GITHUB_SHA", raising=False)
+    monkeypatch.delenv("GITHUB_REF", raising=False)
+    monkeypatch.setenv("GITHUB_RUN_ID", "654")
+    monkeypatch.setenv("GITHUB_WORKFLOW", "dependency-graph")
+    monkeypatch.setenv("GITHUB_JOB", "submit")
+
+    manifest: snapshot.Manifest = {
+        "name": "requirements.txt",
+        "file": {"source_location": "requirements.txt"},
+        "resolved": {
+            "httpx": {
+                "package_url": HTTPX_PURL,
+                "relationship": "direct",
+                "scope": "runtime",
+                "dependencies": [],
+            }
+        },
+    }
+    monkeypatch.setattr(snapshot, "_build_manifests", lambda _: {"requirements.txt": manifest})
+
+    submitted: dict[str, object] = {}
+
+    def capture_submission(url: str, body: bytes, headers: dict[str, str]) -> None:
+        del url, headers
+        submitted.update(json.loads(body))
+
+    monkeypatch.setattr(snapshot, "_submit_with_headers", capture_submission)
+
+    snapshot.submit_dependency_snapshot()
+
+    captured = capsys.readouterr()
+    assert "Missing required environment variable" not in captured.err
+    assert "Using event payload" in captured.out
+
+    assert submitted["sha"] == "0123456789abcdef"
+    assert submitted["ref"] == "refs/heads/feature/auto"
+
+
 def test_submit_dependency_snapshot_recovers_repository_from_workflow_run_parts(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- add the dependency_graph auto-submission trigger and fallbacks to the dependency snapshot workflow
- allow the submission script to use dependency_graph payload metadata and cover it with tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e563b2df0c83219aeffed8f1826134