### PR TITLE
Fix Trivy workflow summary script integration

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -17,12 +17,13 @@ jobs:
       contents: read
       security-events: write
       actions: write
-    env:
-      TRIVY_CACHE_DIR: ${{ runner.temp }}/trivy-cache
     steps:
       - name: Checkout repository
         uses: actions/checkout@2d1e4ee8c7c0e8a6c5a0f1f3af3c1b19aa9c9329
         # v4.2.2
+
+      - name: Define Trivy cache directory
+        run: echo "TRIVY_CACHE_DIR=$RUNNER_TEMP/trivy-cache" >> "$GITHUB_ENV"
 
       - name: Prepare Trivy cache directory
         run: mkdir -p "${{ env.TRIVY_CACHE_DIR }}"
@@ -60,32 +61,7 @@ jobs:
             exit 0
           fi
           echo "sarif=true" >>"$GITHUB_OUTPUT"
-          count=$(python3 - <<'PY'
-import json
-from typing import Iterable
-
-def iter_results(runs: Iterable[dict]) -> int:
-    total = 0
-    for run in runs:
-        results = run.get("results")
-        if isinstance(results, list):
-            total += len(results)
-        elif results is None:
-            continue
-        else:
-            try:
-                total += len(list(results))
-            except TypeError:
-                continue
-    return total
-
-with open("trivy-results.sarif", "r", encoding="utf-8") as sarif_file:
-    sarif = json.load(sarif_file)
-
-runs = sarif.get("runs", [])
-print(iter_results(runs))
-PY
-          )
+          count=$(python3 scripts/trivy_sarif_summary.py trivy-results.sarif)
           printf '### Trivy scan summary\n\n* Найдено high/critical уязвимостей: `%s`\n' "$count" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload Trivy SARIF to GitHub Security tab

--- a/scripts/trivy_sarif_summary.py
+++ b/scripts/trivy_sarif_summary.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Utilities for summarizing Trivy SARIF reports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Iterable, Iterator, Mapping, MutableMapping, Sequence
+from pathlib import Path
+
+RunMapping = Mapping[str, object]
+
+
+def _iter_results(runs: Iterable[RunMapping]) -> Iterator[object]:
+    """Yield each result entry across the provided SARIF runs."""
+
+    for run in runs:
+        if not isinstance(run, Mapping):
+            continue
+        results = run.get("results")
+        if isinstance(results, Sequence) and not isinstance(results, (str, bytes, bytearray)):
+            yield from results
+        elif results is None:
+            continue
+        elif isinstance(results, Iterable):
+            yield from results
+
+
+def count_results(runs: Iterable[RunMapping]) -> int:
+    """Return the number of results entries contained in ``runs``."""
+
+    return sum(1 for _ in _iter_results(runs))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Summarize Trivy SARIF output")
+    parser.add_argument("sarif", type=Path, help="Path to the SARIF report produced by Trivy")
+    args = parser.parse_args()
+
+    with args.sarif.open("r", encoding="utf-8") as sarif_file:
+        sarif = json.load(sarif_file)
+
+    runs = sarif.get("runs", []) if isinstance(sarif, MutableMapping) else []
+    print(count_results(runs))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- define the Trivy cache directory via GITHUB_ENV so the workflow parses correctly
- replace the inline heredoc with a reusable helper script to summarize SARIF results

## Testing
- ./actionlint .github/workflows/trivy.yml
- python3 scripts/trivy_sarif_summary.py /tmp/mock.sarif

------
https://chatgpt.com/codex/tasks/task_b_68e567e0b508832185de35ca418070fa