### PR TITLE
Handle unsupported dependency_graph trigger in workflow

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -5,9 +5,11 @@ on:
     branches:
       - main
   workflow_dispatch:
-  dependency_graph:
-    types:
-      - auto-submission
+  # NOTE: The dependency_graph event is not yet available for this repository.
+  #       The workflow still understands github.event_name == 'dependency_graph'
+  #       so that it can start handling the event once GitHub enables it, but we
+  #       cannot declare the trigger today because GitHub rejects the workflow
+  #       configuration when an unknown event is listed.
   repository_dispatch:
     types:
       # Custom type used by auto-submission hooks. GitHub restricts repository

--- a/tests/test_dependency_graph_workflow.py
+++ b/tests/test_dependency_graph_workflow.py
@@ -129,12 +129,11 @@ def test_dependency_graph_supports_repository_dispatch_auto_submission() -> None
     assert "github.event_name == 'repository_dispatch'" in workflow
 
 
-def test_dependency_graph_supports_dependency_graph_auto_submission() -> None:
+def test_dependency_graph_notes_dependency_graph_event_limitations() -> None:
     workflow = Path(".github/workflows/dependency-graph.yml").read_text(encoding="utf-8")
 
-    assert "dependency_graph:" in workflow
-    assert "auto-submission" in workflow
     assert "github.event_name == 'dependency_graph'" in workflow
+    assert "dependency_graph event is not yet available" in workflow
 
 
 def test_dependency_graph_checkout_resolves_dispatch_ref() -> None:


### PR DESCRIPTION
## Summary
- remove the unsupported dependency_graph trigger from the dependency snapshot workflow and document the limitation
- update the workflow test suite to look for the new documentation comment while keeping dependency_graph handling logic intact

## Testing
- pytest tests/test_dependency_graph_workflow.py -q

------
https://chatgpt.com/codex/tasks/task_b_68e567d5407c8321958fba2cefdfe56b